### PR TITLE
Fix issue with installing Karmada operator CRDs via Helm

### DIFF
--- a/.github/workflows/installation-chart.yaml
+++ b/.github/workflows/installation-chart.yaml
@@ -41,7 +41,7 @@ jobs:
           large-packages: false
           docker-images: false
           swap-storage: false
-      
+
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -33,7 +33,6 @@ spec:
               APIVersion defines the versioned schema of this representation of an object.
               Servers should convert recognized schemas to the latest internal value, and
               may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
             description: |-
@@ -41,7 +40,6 @@ spec:
               Servers may infer this from the endpoint the client submits requests to.
               Cannot be updated.
               In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -71,9 +69,7 @@ spec:
                               SecretRef references a Kubernetes secret containing the etcd connection credentials.
                               The secret must contain the following data keys:
                               ca.crt: The Certificate Authority (CA) certificate data.
-                              tls.crt: The TLS certificate data used for verifying the etcd server's certificate.
-                              tls.key: The TLS private key.
-                              Required to configure the connection to an external etcd cluster.
+                              tls.
                             properties:
                               name:
                                 description: Name is the name of resource being referenced.
@@ -103,13 +99,7 @@ spec:
                                     description: |-
                                       The scheduler will prefer to schedule pods to nodes that satisfy
                                       the affinity expressions specified by this field, but it may choose
-                                      a node that violates one or more of the expressions. The node that is
-                                      most preferred is the one with the greatest sum of weights, i.e.
-                                      for each node that meets all of the scheduling requirements (resource
-                                      request, requiredDuringScheduling affinity expressions, etc.),
-                                      compute a sum by iterating through the elements of this field and adding
-                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                      node(s) with the highest sum are the most preferred.
+                                      a node that violates one or more of the expressions.
                                     items:
                                       description: |-
                                         An empty preferred scheduling term matches all objects with implicit weight 0
@@ -140,9 +130,7 @@ spec:
                                                     description: |-
                                                       An array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                                      array must have a single element, which will be interpreted as an integer.
-                                                      This array is replaced during a strategic merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -174,9 +162,7 @@ spec:
                                                     description: |-
                                                       An array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                                      array must have a single element, which will be interpreted as an integer.
-                                                      This array is replaced during a strategic merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -205,9 +191,6 @@ spec:
                                     description: |-
                                       If the affinity requirements specified by this field are not met at
                                       scheduling time, the pod will not be scheduled onto the node.
-                                      If the affinity requirements specified by this field cease to be met
-                                      at some point during pod execution (e.g. due to an update), the system
-                                      may or may not try to eventually evict the pod from its node.
                                     properties:
                                       nodeSelectorTerms:
                                         description: Required. A list of node selector
@@ -239,9 +222,7 @@ spec:
                                                     description: |-
                                                       An array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                                      array must have a single element, which will be interpreted as an integer.
-                                                      This array is replaced during a strategic merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -273,9 +254,7 @@ spec:
                                                     description: |-
                                                       An array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                                      array must have a single element, which will be interpreted as an integer.
-                                                      This array is replaced during a strategic merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -304,13 +283,7 @@ spec:
                                     description: |-
                                       The scheduler will prefer to schedule pods to nodes that satisfy
                                       the affinity expressions specified by this field, but it may choose
-                                      a node that violates one or more of the expressions. The node that is
-                                      most preferred is the one with the greatest sum of weights, i.e.
-                                      for each node that meets all of the scheduling requirements (resource
-                                      request, requiredDuringScheduling affinity expressions, etc.),
-                                      compute a sum by iterating through the elements of this field and adding
-                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                      node(s) with the highest sum are the most preferred.
+                                      a node that violates one or more of the expressions.
                                     items:
                                       description: The weights of all of the matched
                                         WeightedPodAffinityTerm fields are added per-node
@@ -348,8 +321,7 @@ spec:
                                                         description: |-
                                                           values is an array of string values. If the operator is In or NotIn,
                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
+                                                          the values array must be empty.
                                                         items:
                                                           type: string
                                                         type: array
@@ -363,23 +335,15 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
                                               description: |-
                                                 MatchLabelKeys is a set of pod label keys to select which pods will
-                                                be taken into consideration. The keys are used to lookup values from the
-                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                                to select the group of existing pods which pods will be taken into consideration
-                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default value is empty.
-                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
@@ -387,13 +351,7 @@ spec:
                                             mismatchLabelKeys:
                                               description: |-
                                                 MismatchLabelKeys is a set of pod label keys to select which pods will
-                                                be taken into consideration. The keys are used to lookup values from the
-                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                                to select the group of existing pods which pods will be taken into consideration
-                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default value is empty.
-                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
@@ -403,8 +361,6 @@ spec:
                                                 A label query over the set of namespaces that the term applies to.
                                                 The term is applied to the union of the namespaces selected by this field
                                                 and the ones listed in the namespaces field.
-                                                null selector and null or empty namespaces list means "this pod's namespace".
-                                                An empty selector ({}) matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -429,8 +385,7 @@ spec:
                                                         description: |-
                                                           values is an array of string values. If the operator is In or NotIn,
                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
+                                                          the values array must be empty.
                                                         items:
                                                           type: string
                                                         type: array
@@ -444,10 +399,8 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
@@ -456,7 +409,6 @@ spec:
                                                 namespaces specifies a static list of namespace names that the term applies to.
                                                 The term is applied to the union of the namespaces listed in this field
                                                 and the ones selected by namespaceSelector.
-                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
@@ -465,9 +417,7 @@ spec:
                                               description: |-
                                                 This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                                 the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                                selected pods is running.
-                                                Empty topologyKey is not allowed.
+                                                whose...
                                               type: string
                                           required:
                                           - topologyKey
@@ -488,19 +438,12 @@ spec:
                                     description: |-
                                       If the affinity requirements specified by this field are not met at
                                       scheduling time, the pod will not be scheduled onto the node.
-                                      If the affinity requirements specified by this field cease to be met
-                                      at some point during pod execution (e.g. due to a pod label update), the
-                                      system may or may not try to eventually evict the pod from its node.
-                                      When there are multiple elements, the lists of nodes corresponding to each
-                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                     items:
                                       description: |-
                                         Defines a set of pods (namely those matching the labelSelector
                                         relative to the given namespace(s)) that this pod should be
                                         co-located (affinity) or not co-located (anti-affinity) with,
-                                        where co-located is defined as running on a node whose value of
-                                        the label with key <topologyKey> matches that of any node on which
-                                        a pod of the set of pods is running
+                                        where...
                                       properties:
                                         labelSelector:
                                           description: |-
@@ -530,8 +473,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -545,23 +487,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -569,13 +503,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -585,8 +513,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -611,8 +537,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -626,10 +551,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -638,7 +561,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -647,9 +569,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -666,13 +586,7 @@ spec:
                                     description: |-
                                       The scheduler will prefer to schedule pods to nodes that satisfy
                                       the anti-affinity expressions specified by this field, but it may choose
-                                      a node that violates one or more of the expressions. The node that is
-                                      most preferred is the one with the greatest sum of weights, i.e.
-                                      for each node that meets all of the scheduling requirements (resource
-                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                      compute a sum by iterating through the elements of this field and subtracting
-                                      "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                      node(s) with the highest sum are the most preferred.
+                                      a node that violates one or more of the expressions.
                                     items:
                                       description: The weights of all of the matched
                                         WeightedPodAffinityTerm fields are added per-node
@@ -710,8 +624,7 @@ spec:
                                                         description: |-
                                                           values is an array of string values. If the operator is In or NotIn,
                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
+                                                          the values array must be empty.
                                                         items:
                                                           type: string
                                                         type: array
@@ -725,23 +638,15 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
                                               description: |-
                                                 MatchLabelKeys is a set of pod label keys to select which pods will
-                                                be taken into consideration. The keys are used to lookup values from the
-                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                                to select the group of existing pods which pods will be taken into consideration
-                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default value is empty.
-                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
@@ -749,13 +654,7 @@ spec:
                                             mismatchLabelKeys:
                                               description: |-
                                                 MismatchLabelKeys is a set of pod label keys to select which pods will
-                                                be taken into consideration. The keys are used to lookup values from the
-                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                                to select the group of existing pods which pods will be taken into consideration
-                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default value is empty.
-                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
@@ -765,8 +664,6 @@ spec:
                                                 A label query over the set of namespaces that the term applies to.
                                                 The term is applied to the union of the namespaces selected by this field
                                                 and the ones listed in the namespaces field.
-                                                null selector and null or empty namespaces list means "this pod's namespace".
-                                                An empty selector ({}) matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -791,8 +688,7 @@ spec:
                                                         description: |-
                                                           values is an array of string values. If the operator is In or NotIn,
                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
+                                                          the values array must be empty.
                                                         items:
                                                           type: string
                                                         type: array
@@ -806,10 +702,8 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
@@ -818,7 +712,6 @@ spec:
                                                 namespaces specifies a static list of namespace names that the term applies to.
                                                 The term is applied to the union of the namespaces listed in this field
                                                 and the ones selected by namespaceSelector.
-                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
@@ -827,9 +720,7 @@ spec:
                                               description: |-
                                                 This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                                 the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                                selected pods is running.
-                                                Empty topologyKey is not allowed.
+                                                whose...
                                               type: string
                                           required:
                                           - topologyKey
@@ -850,19 +741,12 @@ spec:
                                     description: |-
                                       If the anti-affinity requirements specified by this field are not met at
                                       scheduling time, the pod will not be scheduled onto the node.
-                                      If the anti-affinity requirements specified by this field cease to be met
-                                      at some point during pod execution (e.g. due to a pod label update), the
-                                      system may or may not try to eventually evict the pod from its node.
-                                      When there are multiple elements, the lists of nodes corresponding to each
-                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                     items:
                                       description: |-
                                         Defines a set of pods (namely those matching the labelSelector
                                         relative to the given namespace(s)) that this pod should be
                                         co-located (affinity) or not co-located (anti-affinity) with,
-                                        where co-located is defined as running on a node whose value of
-                                        the label with key <topologyKey> matches that of any node on which
-                                        a pod of the set of pods is running
+                                        where...
                                       properties:
                                         labelSelector:
                                           description: |-
@@ -892,8 +776,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -907,23 +790,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -931,13 +806,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -947,8 +816,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -973,8 +840,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -988,10 +854,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -1000,7 +864,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -1009,9 +872,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -1025,9 +886,7 @@ spec:
                               type: string
                             description: |-
                               Annotations is an unstructured key value map stored with a resource that may be
-                              set by external tools to store and retrieve arbitrary metadata. They are not
-                              queryable and should be preserved when modifying objects.
-                              More info: http://kubernetes.io/docs/user-guide/annotations
+                              set by external tools to store and retrieve arbitrary metadata.
                             type: object
                           imagePullPolicy:
                             description: |-
@@ -1052,7 +911,7 @@ spec:
                               Map of string keys and values that can be used to organize and categorize
                               (scope and select) objects. May match selectors of replication controllers
                               and services.
-                              More info: http://kubernetes.io/docs/user-guide/labels
+                              More info: http://kubernetes.
                             type: object
                           peerCertSANs:
                             description: PeerCertSANs sets extra Subject Alternative
@@ -1116,7 +975,7 @@ spec:
                                   This field depends on the
                                   DynamicResourceAllocation feature gate.
 
-                                  This field is immutable. It can only be set for containers.
+                                  This field is immutable.
                                 items:
                                   description: ResourceClaim references one entry
                                     in PodSpec.ResourceClaims.
@@ -1158,11 +1017,8 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           serverCertSANs:
@@ -1193,16 +1049,11 @@ spec:
                                   description: |-
                                     Operator represents a key's relationship to the value.
                                     Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                                    Exists is equivalent to wildcard for value, so that a pod can
-                                    tolerate all taints of a particular category.
-                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                   type: string
                                 tolerationSeconds:
                                   description: |-
                                     TolerationSeconds represents the period of time the toleration (which must be
-                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                    negative values will be treated as 0 (evict immediately) by the system.
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint.
                                   format: int64
                                   type: integer
                                 value:
@@ -1227,7 +1078,6 @@ spec:
                                       medium represents what type of storage medium should back this directory.
                                       The default is "" which means to use the node's default medium.
                                       Must be an empty string (default) or Memory.
-                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     type: string
                                   sizeLimit:
                                     anyOf:
@@ -1236,20 +1086,13 @@ spec:
                                     description: |-
                                       sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                       The size limit is also applicable for memory medium.
-                                      The maximum usage on memory medium EmptyDir would be the minimum value between
-                                      the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                      The default is nil which means that the limit is undefined.
-                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 type: object
                               hostPath:
                                 description: |-
                                   HostPath represents a pre-existing file or directory on the host
-                                  machine that is directly exposed to the container. This is generally
-                                  used for system agents or other privileged things that are allowed
-                                  to see the host machine. Most containers will NOT need this.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  machine that is directly exposed to the container.
                                 properties:
                                   path:
                                     description: |-
@@ -1270,8 +1113,7 @@ spec:
                                 description: |-
                                   The specification for the PersistentVolumeClaim. The entire content is
                                   copied unchanged into the PVC that gets created from this
-                                  template. The same fields as in a PersistentVolumeClaim
-                                  are also valid here.
+                                  template.
                                 properties:
                                   metadata:
                                     description: |-
@@ -1300,8 +1142,7 @@ spec:
                                     description: |-
                                       The specification for the PersistentVolumeClaim. The entire content is
                                       copied unchanged into the PVC that gets created from this
-                                      template. The same fields as in a PersistentVolumeClaim
-                                      are also valid here.
+                                      template.
                                     properties:
                                       accessModes:
                                         description: |-
@@ -1314,13 +1155,7 @@ spec:
                                       dataSource:
                                         description: |-
                                           dataSource field can be used to specify either:
-                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                          * An existing PVC (PersistentVolumeClaim)
-                                          If the provisioner or an external controller can support the specified data source,
-                                          it will create a new volume based on the contents of the specified data source.
-                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.
                                         properties:
                                           apiGroup:
                                             description: |-
@@ -1344,28 +1179,7 @@ spec:
                                       dataSourceRef:
                                         description: |-
                                           dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                          volume is desired. This may be any object from a non-empty API group (non
-                                          core object) or a PersistentVolumeClaim object.
-                                          When this field is specified, volume binding will only succeed if the type of
-                                          the specified object matches some installed volume populator or dynamic
-                                          provisioner.
-                                          This field will replace the functionality of the dataSource field and as such
-                                          if both fields are non-empty, they must have the same value. For backwards
-                                          compatibility, when namespace isn't specified in dataSourceRef,
-                                          both fields (dataSource and dataSourceRef) will be set to the same
-                                          value automatically if one of them is empty and the other is non-empty.
-                                          When namespace is specified in dataSourceRef,
-                                          dataSource isn't set to the same value and must be empty.
-                                          There are three important differences between dataSource and dataSourceRef:
-                                          * While dataSource only allows two specific types of objects, dataSourceRef
-                                            allows any non-core object, as well as PersistentVolumeClaim objects.
-                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                            preserves all values, and generates an error if a disallowed value is
-                                            specified.
-                                          * While dataSource only allows local objects, dataSourceRef allows objects
-                                            in any namespaces.
-                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          volume is desired.
                                         properties:
                                           apiGroup:
                                             description: |-
@@ -1384,20 +1198,15 @@ spec:
                                           namespace:
                                             description: |-
                                               Namespace is the namespace of resource being referenced
-                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                              Note that when a namespace is specified, a gateway.networking.k8s.
                                             type: string
                                         required:
                                         - kind
                                         - name
                                         type: object
                                       resources:
-                                        description: |-
-                                          resources represents the minimum resources the volume should have.
-                                          Users are allowed to specify resource requirements
-                                          that are lower than previous value but must still be higher than capacity recorded in the
-                                          status field of the claim.
-                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                        description: resources represents the minimum
+                                          resources the volume should have.
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -1417,11 +1226,8 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Requests describes the minimum amount of compute resources required.
-                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            description: Requests describes the minimum
+                                              amount of compute resources required.
                                             type: object
                                         type: object
                                       selector:
@@ -1450,8 +1256,7 @@ spec:
                                                   description: |-
                                                     values is an array of string values. If the operator is In or NotIn,
                                                     the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
+                                                    the values array must be empty.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1465,10 +1270,8 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -1478,17 +1281,9 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                         type: string
                                       volumeAttributesClassName:
-                                        description: |-
-                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                          If specified, the CSI driver will create or update the volume with the attributes defined
-                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                          it can be changed after the claim is created. An empty string or nil value indicates that no
-                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                          this field can be reset to its previous value (including nil) to cancel the modification.
-                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                          exists.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        description: volumeAttributesClassName may
+                                          be used to set the VolumeAttributesClass
+                                          used by this claim.
                                         type: string
                                       volumeMode:
                                         description: |-
@@ -1522,13 +1317,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: |-
                                     An empty preferred scheduling term matches all objects with implicit weight 0
@@ -1559,9 +1348,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1593,9 +1380,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1624,9 +1409,6 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to an update), the system
-                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
@@ -1658,9 +1440,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1692,9 +1472,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1723,13 +1501,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -1767,8 +1539,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1782,23 +1553,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -1806,13 +1569,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -1822,8 +1579,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -1848,8 +1603,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1863,10 +1617,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -1875,7 +1627,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -1884,9 +1635,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -1907,19 +1656,12 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -1948,8 +1690,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1963,23 +1704,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -1987,13 +1720,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -2003,8 +1730,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -2028,8 +1753,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2043,10 +1767,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -2055,7 +1777,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -2064,9 +1785,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -2083,13 +1802,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the anti-affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and subtracting
-                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -2127,8 +1840,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -2142,23 +1854,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -2166,13 +1870,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -2182,8 +1880,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -2208,8 +1904,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -2223,10 +1918,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -2235,7 +1928,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -2244,9 +1936,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -2267,19 +1957,12 @@ spec:
                                 description: |-
                                   If the anti-affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the anti-affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -2308,8 +1991,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2323,23 +2005,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -2347,13 +2021,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -2363,8 +2031,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -2388,8 +2054,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2403,10 +2068,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -2415,7 +2078,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -2424,9 +2086,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -2440,9 +2100,7 @@ spec:
                           type: string
                         description: |-
                           Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                          set by external tools to store and retrieve arbitrary metadata.
                         type: object
                       certSANs:
                         description: CertSANs sets extra Subject Alternative Names
@@ -2457,25 +2115,11 @@ spec:
                           ExtraArgs is an extra set of flags to pass to the kube-apiserver component or
                           override. A key in this map is the flag name as it appears on the command line except
                           without leading dash(es).
-
-                          Note: This is a temporary solution to allow for the configuration of the
-                          kube-apiserver component. In the future, we will provide a more structured way
-                          to configure the component. Once that is done, this field will be discouraged to be used.
-                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand the risks of this configuration.
-
-                          For supported flags, please see
-                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
-                          for details.
                         type: object
                       extraVolumeMounts:
                         description: |-
                           ExtraVolumeMounts specifies a list of extra volume mounts to be mounted into the API server's container
-                          To fulfil the base functionality required for a functioning control plane, when provisioning a new Karmada instance,
-                          the operator will automatically mount volumes into the API server container needed to configure things such as TLS,
-                          SA token issuance/signing and secured connection to etcd, amongst others. However, given the wealth of options for configurability,
-                          there are additional features (e.g., encryption at rest and custom AuthN webhook) that can be configured. ExtraVolumeMounts, in conjunction
-                          with ExtraArgs and ExtraVolumes can be used to fulfil those use cases.
+                          To fulfil the base functionality required for a functioning control plane, when provisioning a...
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
@@ -2491,8 +2135,6 @@ spec:
                                 to container and the other way around.
                                 When not set, MountPropagationNone is used.
                                 This field is beta in 1.10.
-                                When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
-                                (which defaults to None).
                               type: string
                             name:
                               description: This must match the Name of a Volume.
@@ -2508,18 +2150,6 @@ spec:
                                 recursively.
 
                                 If ReadOnly is false, this field has no meaning and must be unspecified.
-
-                                If ReadOnly is true, and this field is set to Disabled, the mount is not made
-                                recursively read-only.  If this field is set to IfPossible, the mount is made
-                                recursively read-only, if it is supported by the container runtime.  If this
-                                field is set to Enabled, the mount is made recursively read-only if it is
-                                supported by the container runtime, otherwise the pod will not be started and
-                                an error will be generated to indicate the reason.
-
-                                If this field is set to IfPossible or Enabled, MountPropagation must be set to
-                                None (or be unspecified, which defaults to None).
-
-                                If this field is not specified, it is treated as an equivalent of Disabled.
                               type: string
                             subPath:
                               description: |-
@@ -2527,11 +2157,8 @@ spec:
                                 Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
-                              description: |-
-                                Expanded path within the volume from which the container's volume should be mounted.
-                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root).
-                                SubPathExpr and SubPath are mutually exclusive.
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted.
                               type: string
                           required:
                           - mountPath
@@ -2542,10 +2169,7 @@ spec:
                         description: |-
                           ExtraVolumes specifies a list of extra volumes for the API server's pod
                           To fulfil the base functionality required for a functioning control plane, when provisioning a new Karmada instance,
-                          the operator will automatically attach volumes for the API server pod needed to configure things such as TLS,
-                          SA token issuance/signing and secured connection to etcd, amongst others. However, given the wealth of options for configurability,
-                          there are additional features (e.g., encryption at rest and custom AuthN webhook) that can be configured. ExtraVolumes, in conjunction
-                          with ExtraArgs and ExtraVolumeMounts can be used to fulfil those use cases.
+                          the...
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.
@@ -2554,23 +2178,19 @@ spec:
                               description: |-
                                 awsElasticBlockStore represents an AWS Disk resource that is attached to a
                                 kubelet's host machine and then exposed to the pod.
-                                Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
-                                awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                Deprecated: AWSElasticBlockStore is deprecated.
                               properties:
                                 fsType:
                                   description: |-
                                     fsType is the filesystem type of the volume that you want to mount.
                                     Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    Examples: "ext4", "xfs", "ntfs".
                                   type: string
                                 partition:
                                   description: |-
                                     partition is the partition in the volume that you want to mount.
                                     If omitted, the default is to mount by volume name.
                                     Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
@@ -2590,7 +2210,7 @@ spec:
                               description: |-
                                 azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                                 Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
-                                are redirected to the disk.csi.azure.com CSI driver.
+                                are redirected to the disk.csi.
                               properties:
                                 cachingMode:
                                   description: 'cachingMode is the Host Caching mode:
@@ -2616,7 +2236,7 @@ spec:
                                     blob disks per storage account  Dedicated: single
                                     blob disk per storage account  Managed: azure
                                     managed data disk (only in managed availability
-                                    set). defaults to shared'
+                                    set).'
                                   type: string
                                 readOnly:
                                   default: false
@@ -2632,7 +2252,7 @@ spec:
                               description: |-
                                 azureFile represents an Azure File Service mount on the host and bind mount to the pod.
                                 Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
-                                are redirected to the file.csi.azure.com CSI driver.
+                                are redirected to the file.
                               properties:
                                 readOnly:
                                   description: |-
@@ -2691,7 +2311,6 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -2707,15 +2326,13 @@ spec:
                               description: |-
                                 cinder represents a cinder volume attached and mounted on kubelets host machine.
                                 Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
-                                are redirected to the cinder.csi.openstack.org CSI driver.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                are redirected to the cinder.csi.
                               properties:
                                 fsType:
                                   description: |-
                                     fsType is the filesystem type to mount.
                                     Must be a filesystem type supported by the host operating system.
                                     Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
                                   description: |-
@@ -2735,7 +2352,6 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -2755,22 +2371,13 @@ spec:
                                   description: |-
                                     defaultMode is optional: mode bits used to set permissions on created files by default.
                                     Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
                                   description: |-
                                     items if unspecified, each key-value pair in the Data field of the referenced
                                     ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
+                                    key and content is the value.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -2782,10 +2389,6 @@ spec:
                                         description: |-
                                           mode is Optional: mode bits used to set permissions on this file.
                                           Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
@@ -2808,7 +2411,6 @@ spec:
                                     This field is effectively required, but due to backwards compatibility is
                                     allowed to be empty. Instances of this type with an empty value here are
                                     almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
                                   description: optional specify whether the ConfigMap
@@ -2837,8 +2439,6 @@ spec:
                                     nodePublishSecretRef is a reference to the secret object containing
                                     sensitive information to pass to the CSI driver to complete the CSI
                                     NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
                                       default: ""
@@ -2847,7 +2447,6 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -2874,12 +2473,6 @@ spec:
                                   description: |-
                                     Optional: mode bits to use on created files by default. Must be a
                                     Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
@@ -2912,10 +2505,6 @@ spec:
                                         description: |-
                                           Optional: mode bits used to set permissions on this file, must be an octal value
                                           between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
@@ -2966,7 +2555,6 @@ spec:
                                     medium represents what type of storage medium should back this directory.
                                     The default is "" which means to use the node's default medium.
                                     Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
@@ -2975,63 +2563,18 @@ spec:
                                   description: |-
                                     sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                     The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
+                              description: ephemeral represents a volume that is handled
+                                by a cluster storage driver.
                               properties:
                                 volumeClaimTemplate:
                                   description: |-
                                     Will be used to create a stand-alone PVC to provision the volume.
                                     The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-                                    Required, must not be nil.
+                                    owner of the PVC, i.e.
                                   properties:
                                     metadata:
                                       description: |-
@@ -3060,8 +2603,7 @@ spec:
                                       description: |-
                                         The specification for the PersistentVolumeClaim. The entire content is
                                         copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
+                                        template.
                                       properties:
                                         accessModes:
                                           description: |-
@@ -3074,13 +2616,7 @@ spec:
                                         dataSource:
                                           description: |-
                                             dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.
                                           properties:
                                             apiGroup:
                                               description: |-
@@ -3104,28 +2640,7 @@ spec:
                                         dataSourceRef:
                                           description: |-
                                             dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            volume is desired.
                                           properties:
                                             apiGroup:
                                               description: |-
@@ -3144,20 +2659,15 @@ spec:
                                             namespace:
                                               description: |-
                                                 Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                Note that when a namespace is specified, a gateway.networking.k8s.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            Users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                          description: resources represents the minimum
+                                            resources the volume should have.
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -3177,11 +2687,9 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                              description: Requests describes the
+                                                minimum amount of compute resources
+                                                required.
                                               type: object
                                           type: object
                                         selector:
@@ -3211,8 +2719,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3226,10 +2733,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -3239,17 +2744,9 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string or nil value indicates that no
-                                            VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                            this field can be reset to its previous value (including nil) to cancel the modification.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                          description: volumeAttributesClassName may
+                                            be used to set the VolumeAttributesClass
+                                            used by this claim.
                                           type: string
                                         volumeMode:
                                           description: |-
@@ -3332,9 +2829,7 @@ spec:
                                   description: |-
                                     secretRef is Optional: secretRef is reference to the secret object containing
                                     sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
+                                    empty if no secret object is specified.
                                   properties:
                                     name:
                                       default: ""
@@ -3343,7 +2838,6 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3351,9 +2845,9 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: |-
-                                flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
-                                Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                              description: flocker represents a Flocker volume attached
+                                to a kubelet's host machine. This depends on the Flocker
+                                control service being running.
                               properties:
                                 datasetName:
                                   description: |-
@@ -3369,24 +2863,19 @@ spec:
                               description: |-
                                 gcePersistentDisk represents a GCE Disk resource that is attached to a
                                 kubelet's host machine and then exposed to the pod.
-                                Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
-                                gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                Deprecated: GCEPersistentDisk is deprecated.
                               properties:
                                 fsType:
                                   description: |-
                                     fsType is filesystem type of the volume that you want to mount.
                                     Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    Examples: "ext4", "xfs", "ntfs".
                                   type: string
                                 partition:
                                   description: |-
                                     partition is the partition in the volume that you want to mount.
                                     If omitted, the default is to mount by volume name.
                                     Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
@@ -3406,16 +2895,13 @@ spec:
                             gitRepo:
                               description: |-
                                 gitRepo represents a git repository at a particular revision.
-                                Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
+                                Deprecated: GitRepo is deprecated.
                               properties:
                                 directory:
                                   description: |-
                                     directory is the target directory name.
                                     Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
+                                    git repository.
                                   type: string
                                 repository:
                                   description: repository is the URL
@@ -3454,10 +2940,7 @@ spec:
                             hostPath:
                               description: |-
                                 hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                machine that is directly exposed to the container.
                               properties:
                                 path:
                                   description: |-
@@ -3475,38 +2958,19 @@ spec:
                               - path
                               type: object
                             image:
-                              description: |-
-                                image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
-                                The volume is resolved at pod startup depending on which PullPolicy value is provided:
-
-                                - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
-                                - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
-                                - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
-
-                                The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
-                                A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
-                                The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
-                                The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                The volume will be mounted read-only (ro) and non-executable files (noexec).
-                                Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
-                                The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                              description: image represents an OCI object (a container
+                                image or artifact) pulled and mounted on the kubelet's
+                                host machine.
                               properties:
                                 pullPolicy:
                                   description: |-
                                     Policy for pulling OCI objects. Possible values are:
                                     Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
-                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
-                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
-                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
                                   type: string
                                 reference:
                                   description: |-
                                     Required: Image or artifact reference to be used.
                                     Behaves in the same way as pod.spec.containers[*].image.
-                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images
-                                    This field is optional to allow higher level config management to default or override
-                                    container images in workload controllers like Deployments and StatefulSets.
                                   type: string
                               type: object
                             iscsi:
@@ -3527,14 +2991,11 @@ spec:
                                   description: |-
                                     fsType is the filesystem type of the volume that you want to mount.
                                     Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    Examples: "ext4", "xfs", "ntfs".
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name.
                                   type: string
                                 iqn:
                                   description: iqn is the target iSCSI Qualified Name.
@@ -3573,7 +3034,6 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3622,7 +3082,7 @@ spec:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a
                                 PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                More info: https://kubernetes.
                               properties:
                                 claimName:
                                   description: |-
@@ -3638,9 +3098,9 @@ spec:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: |-
-                                photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
-                                Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                              description: photonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine.
                               properties:
                                 fsType:
                                   description: |-
@@ -3658,9 +3118,7 @@ spec:
                             portworxVolume:
                               description: |-
                                 portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
-                                Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                is on.
+                                Deprecated: PortworxVolume is deprecated.
                               properties:
                                 fsType:
                                   description: |-
@@ -3688,10 +3146,6 @@ spec:
                                   description: |-
                                     defaultMode are the mode bits used to set permissions on created files by default.
                                     Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
@@ -3709,22 +3163,12 @@ spec:
                                           of ClusterTrustBundle objects in an auto-updating file.
 
                                           Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
                                             description: |-
                                               Select all ClusterTrustBundles that match this label selector.  Only has
                                               effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
+                                              interpreted as "match nothing".
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -3749,8 +3193,7 @@ spec:
                                                       description: |-
                                                         values is an array of string values. If the operator is In or NotIn,
                                                         the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
+                                                        the values array must be empty.
                                                       items:
                                                         type: string
                                                       type: array
@@ -3764,10 +3207,8 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
@@ -3780,9 +3221,7 @@ spec:
                                             description: |-
                                               If true, don't block pod startup if the referenced ClusterTrustBundle(s)
                                               aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
+                                              allowed not to exist.
                                             type: boolean
                                           path:
                                             description: Relative path from the volume
@@ -3805,11 +3244,7 @@ spec:
                                             description: |-
                                               items if unspecified, each key-value pair in the Data field of the referenced
                                               ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
+                                              key and content is the value.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -3821,10 +3256,6 @@ spec:
                                                   description: |-
                                                     mode is Optional: mode bits used to set permissions on this file.
                                                     Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -3847,7 +3278,6 @@ spec:
                                               This field is effectively required, but due to backwards compatibility is
                                               allowed to be empty. Instances of this type with an empty value here are
                                               almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                           optional:
                                             description: optional specify whether
@@ -3891,10 +3321,6 @@ spec:
                                                   description: |-
                                                     Optional: mode bits used to set permissions on this file, must be an octal value
                                                     between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -3943,72 +3369,24 @@ spec:
                                         description: |-
                                           Projects an auto-rotating credential bundle (private key and certificate
                                           chain) that the pod can use either as a TLS client or server.
-
-                                          Kubelet generates a private key and uses it to send a
-                                          PodCertificateRequest to the named signer.  Once the signer approves the
-                                          request and issues a certificate chain, Kubelet writes the key and
-                                          certificate chain to the pod filesystem.  The pod does not start until
-                                          certificates have been issued for each podCertificate projected volume
-                                          source in its spec.
-
-                                          Kubelet will begin trying to rotate the certificate at the time indicated
-                                          by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                          timestamp.
-
-                                          Kubelet can write a single file, indicated by the credentialBundlePath
-                                          field, or separate files, indicated by the keyPath and
-                                          certificateChainPath fields.
-
-                                          The credential bundle is a single file in PEM format.  The first PEM
-                                          entry is the private key (in PKCS#8 format), and the remaining PEM
-                                          entries are the certificate chain issued by the signer (typically,
-                                          signers will return their certificate chain in leaf-to-root order).
-
-                                          Prefer using the credential bundle format, since your application code
-                                          can read it atomically.  If you use keyPath and certificateChainPath,
-                                          your application must make two separate file reads. If these coincide
-                                          with a certificate rotation, it is possible that the private key and leaf
-                                          certificate you read may not correspond to each other.  Your application
-                                          will need to check for this condition, and re-read until they are
-                                          consistent.
-
-                                          The named signer controls chooses the format of the certificate it
-                                          issues; consult the signer implementation's documentation to learn how to
-                                          use the certificates it issues.
                                         properties:
                                           certificateChainPath:
                                             description: |-
                                               Write the certificate chain at this path in the projected volume.
 
-                                              Most applications should use credentialBundlePath.  When using keyPath
-                                              and certificateChainPath, your application needs to check that the key
-                                              and leaf certificate are consistent, because it is possible to read the
-                                              files mid-rotation.
+                                              Most applications should use credentialBundlePath.
                                             type: string
                                           credentialBundlePath:
                                             description: |-
                                               Write the credential bundle at this path in the projected volume.
 
                                               The credential bundle is a single file that contains multiple PEM blocks.
-                                              The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                              key.
-
-                                              The remaining blocks are CERTIFICATE blocks, containing the issued
-                                              certificate chain from the signer (leaf and any intermediates).
-
-                                              Using credentialBundlePath lets your Pod's application code make a single
-                                              atomic read that retrieves a consistent key and certificate chain.  If you
-                                              project them to separate files, your application code will need to
-                                              additionally check that the leaf certificate was issued to the key.
                                             type: string
                                           keyPath:
                                             description: |-
                                               Write the key at this path in the projected volume.
 
-                                              Most applications should use credentialBundlePath.  When using keyPath
-                                              and certificateChainPath, your application needs to check that the key
-                                              and leaf certificate are consistent, because it is possible to read the
-                                              files mid-rotation.
+                                              Most applications should use credentialBundlePath.
                                             type: string
                                           keyType:
                                             description: |-
@@ -4024,16 +3402,6 @@ spec:
 
                                               Kubelet copies this value verbatim into the PodCertificateRequests it
                                               generates for this projection.
-
-                                              If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                              will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                              value is 7862400 (91 days).
-
-                                              The signer implementation is then free to issue a certificate with any
-                                              lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                              seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                              `kubernetes.io` signers will never issue certificates with a lifetime
-                                              longer than 24 hours.
                                             format: int32
                                             type: integer
                                           signerName:
@@ -4047,16 +3415,6 @@ spec:
                                               userAnnotations allow pod authors to pass additional information to
                                               the signer implementation.  Kubernetes does not restrict or validate this
                                               metadata in any way.
-
-                                              These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
-                                              the PodCertificateRequest objects that Kubelet creates.
-
-                                              Entries are subject to the same validation as object metadata annotations,
-                                              with the addition that all keys must be domain-prefixed. No restrictions
-                                              are placed on values, except an overall size limitation on the entire field.
-
-                                              Signers should document the keys and values they support. Signers should
-                                              deny requests that contain keys they do not recognize.
                                             type: object
                                         required:
                                         - keyType
@@ -4070,11 +3428,7 @@ spec:
                                             description: |-
                                               items if unspecified, each key-value pair in the Data field of the referenced
                                               Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
+                                              key and content is the value.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -4086,10 +3440,6 @@ spec:
                                                   description: |-
                                                     mode is Optional: mode bits used to set permissions on this file.
                                                     Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -4112,7 +3462,6 @@ spec:
                                               This field is effectively required, but due to backwards compatibility is
                                               allowed to be empty. Instances of this type with an empty value here are
                                               almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                           optional:
                                             description: optional field specify whether
@@ -4128,17 +3477,13 @@ spec:
                                             description: |-
                                               audience is the intended audience of the token. A recipient of a token
                                               must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
+                                              token, and otherwise should reject the token.
                                             type: string
                                           expirationSeconds:
                                             description: |-
                                               expirationSeconds is the requested duration of validity of the service
                                               account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
+                                              plugin will proactively rotate the service account token.
                                             format: int64
                                             type: integer
                                           path:
@@ -4201,8 +3546,7 @@ spec:
                                   description: |-
                                     fsType is the filesystem type of the volume that you want to mount.
                                     Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    Examples: "ext4", "xfs", "ntfs".
                                   type: string
                                 image:
                                   description: |-
@@ -4251,7 +3595,6 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -4304,7 +3647,6 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -4345,22 +3687,13 @@ spec:
                                   description: |-
                                     defaultMode is Optional: mode bits used to set permissions on created files by default.
                                     Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
                                   description: |-
                                     items If unspecified, each key-value pair in the Data field of the referenced
                                     Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
+                                    key and content is the value.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -4372,10 +3705,6 @@ spec:
                                         description: |-
                                           mode is Optional: mode bits used to set permissions on this file.
                                           Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
@@ -4429,7 +3758,6 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -4441,18 +3769,13 @@ spec:
                                 volumeNamespace:
                                   description: |-
                                     volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
+                                    namespace is specified then the Pod's namespace will be used.
                                   type: string
                               type: object
                             vsphereVolume:
                               description: |-
                                 vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
-                                Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
-                                are redirected to the csi.vsphere.vmware.com CSI driver.
+                                Deprecated: VsphereVolume is deprecated.
                               properties:
                                 fsType:
                                   description: |-
@@ -4510,18 +3833,12 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                          More info: http://kubernetes.
                         type: object
                       loadBalancerClass:
                         description: |-
                           LoadBalancerClass specifies the load balancer implementation class for the Karmada API server.
                           This field is applicable only when ServiceType is set to LoadBalancer.
-                          If specified, the service will be processed by the load balancer implementation that matches the specified class.
-                          By default, this is not set and the LoadBalancer type of Service uses the cloud provider's default load balancer
-                          implementation.
-                          Once set, it cannot be changed. The value must be a label-style identifier, with an optional prefix such as
-                          "internal-vip" or "example.com/internal-vip".
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
                         type: string
                       podDisruptionBudgetConfig:
                         description: |-
@@ -4577,7 +3894,7 @@ spec:
                               This field depends on the
                               DynamicResourceAllocation feature gate.
 
-                              This field is immutable. It can only be set for containers.
+                              This field is immutable.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -4618,11 +3935,8 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            description: Requests describes the minimum amount of
+                              compute resources required.
                             type: object
                         type: object
                       serviceAnnotations:
@@ -4651,7 +3965,6 @@ spec:
                         description: |-
                           SidecarContainers specifies a list of sidecar containers to be deployed
                           within the Karmada API server pod.
-                          This enables users to integrate auxiliary services such as KMS plugins for configuring encryption at rest.
                         items:
                           description: A single application container that you want
                             to run within a pod.
@@ -4660,12 +3973,7 @@ spec:
                               description: |-
                                 Arguments to the entrypoint.
                                 The container image's CMD is used if this is not provided.
-                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Cannot be updated.
-                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                Variable references $(VAR_NAME) are expanded using the container's environment.
                               items:
                                 type: string
                               type: array
@@ -4674,12 +3982,7 @@ spec:
                               description: |-
                                 Entrypoint array. Not executed within a shell.
                                 The container image's ENTRYPOINT is used if this is not provided.
-                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Cannot be updated.
-                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                Variable references $(VAR_NAME) are expanded using the container's environment.
                               items:
                                 type: string
                               type: array
@@ -4701,13 +4004,7 @@ spec:
                                     description: |-
                                       Variable references $(VAR_NAME) are expanded
                                       using the previously defined environment variables in the container and
-                                      any service environment variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless of whether the variable
-                                      exists or not.
-                                      Defaults to "".
+                                      any service environment variables.
                                     type: string
                                   valueFrom:
                                     description: Source for the environment variable's
@@ -4726,7 +4023,6 @@ spec:
                                               This field is effectively required, but due to backwards compatibility is
                                               allowed to be empty. Instances of this type with an empty value here are
                                               almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -4739,7 +4035,7 @@ spec:
                                       fieldRef:
                                         description: |-
                                           Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.
                                         properties:
                                           apiVersion:
                                             description: Version of the schema the
@@ -4763,18 +4059,12 @@ spec:
                                             description: |-
                                               The key within the env file. An invalid key will prevent the pod from starting.
                                               The keys defined within a source may consist of any printable ASCII characters except '='.
-                                              During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
                                             type: string
                                           optional:
                                             default: false
                                             description: |-
                                               Specify whether the file or its key must be defined. If the file or key
                                               does not exist, then the env var is not published.
-                                              If optional is set to true and the specified key does not exist,
-                                              the environment variable will not be set in the Pod's containers.
-
-                                              If optional is set to false and the specified key does not exist,
-                                              an error will be returned during Pod creation.
                                             type: boolean
                                           path:
                                             description: |-
@@ -4794,7 +4084,7 @@ spec:
                                       resourceFieldRef:
                                         description: |-
                                           Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -4832,7 +4122,6 @@ spec:
                                               This field is effectively required, but due to backwards compatibility is
                                               allowed to be empty. Instances of this type with an empty value here are
                                               almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -4854,10 +4143,6 @@ spec:
                               description: |-
                                 List of sources to populate environment variables in the container.
                                 The keys defined within a source may consist of any printable ASCII characters except '='.
-                                When a key exists in multiple
-                                sources, the value associated with the last source will take precedence.
-                                Values defined by an Env with a duplicate key will take precedence.
-                                Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
                                   a set of ConfigMaps or Secrets
@@ -4872,7 +4157,6 @@ spec:
                                           This field is effectively required, but due to backwards compatibility is
                                           allowed to be empty. Instances of this type with an empty value here are
                                           almost certainly wrong.
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -4895,7 +4179,6 @@ spec:
                                           This field is effectively required, but due to backwards compatibility is
                                           allowed to be empty. Instances of this type with an empty value here are
                                           almost certainly wrong.
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                       optional:
                                         description: Specify whether the Secret must
@@ -4909,9 +4192,7 @@ spec:
                             image:
                               description: |-
                                 Container image name.
-                                More info: https://kubernetes.io/docs/concepts/containers/images
-                                This field is optional to allow higher level config management to default or override
-                                container images in workload controllers like Deployments and StatefulSets.
+                                More info: https://kubernetes.
                               type: string
                             imagePullPolicy:
                               description: |-
@@ -4919,7 +4200,7 @@ spec:
                                 One of Always, Never, IfNotPresent.
                                 Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
                                 Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                More info: https://kubernetes.
                               type: string
                             lifecycle:
                               description: |-
@@ -4930,8 +4211,6 @@ spec:
                                   description: |-
                                     PostStart is called immediately after a container is created. If the handler fails,
                                     the container is terminated and restarted according to its restart policy.
-                                    Other management of the container blocks until the hook completes.
-                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies a command to execute
@@ -4940,10 +4219,7 @@ spec:
                                         command:
                                           description: |-
                                             Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            command  is root ('/') in the container's filesystem.
                                           items:
                                             type: string
                                           type: array
@@ -5039,13 +4315,7 @@ spec:
                                   description: |-
                                     PreStop is called immediately before a container is terminated due to an
                                     API request or management event such as liveness/startup probe failure,
-                                    preemption, resource contention, etc. The handler is not called if the
-                                    container crashes or exits. The Pod's termination grace period countdown begins before the
-                                    PreStop hook is executed. Regardless of the outcome of the handler, the
-                                    container will eventually terminate within the Pod's termination grace
-                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
-                                    or until the termination grace period is reached.
-                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                    preemption, resource contention, etc.
                                   properties:
                                     exec:
                                       description: Exec specifies a command to execute
@@ -5054,10 +4324,7 @@ spec:
                                         command:
                                           description: |-
                                             Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            command  is root ('/') in the container's filesystem.
                                           items:
                                             type: string
                                           type: array
@@ -5153,7 +4420,6 @@ spec:
                                   description: |-
                                     StopSignal defines which signal will be sent to a container when it is being stopped.
                                     If not specified, the default is defined by the container runtime in use.
-                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
                                   type: string
                               type: object
                             livenessProbe:
@@ -5170,10 +4436,7 @@ spec:
                                     command:
                                       description: |-
                                         Command is the command line to execute inside the container, the working directory for the
-                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                        a shell, you need to explicitly call out to that shell.
-                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        command  is root ('/') in the container's filesystem.
                                       items:
                                         type: string
                                       type: array
@@ -5198,8 +4461,6 @@ spec:
                                       description: |-
                                         Service is the name of the service to place in the gRPC HealthCheckRequest
                                         (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -5293,17 +4554,8 @@ spec:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: |-
-                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after the processes running in the pod are sent
-                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                    Set this value longer than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                    value overrides the value provided by the pod spec.
-                                    Value must be non-negative integer. The value zero indicates stop immediately via
-                                    the kill signal (no opportunity to shut down).
-                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
@@ -5324,11 +4576,7 @@ spec:
                               description: |-
                                 List of ports to expose from the container. Not specifying a port here
                                 DOES NOT prevent that port from being exposed. Any port which is
-                                listening on the default "0.0.0.0" address inside a container will be
-                                accessible from the network.
-                                Modifying this array with strategic merge patch may corrupt the data.
-                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                Cannot be updated.
+                                listening on the default "0.0.0.
                               items:
                                 description: ContainerPort represents a network port
                                   in a single container.
@@ -5376,7 +4624,7 @@ spec:
                                 Periodic probe of container service readiness.
                                 Container will be removed from service endpoints if the probe fails.
                                 Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                More info: https://kubernetes.
                               properties:
                                 exec:
                                   description: Exec specifies a command to execute
@@ -5385,10 +4633,7 @@ spec:
                                     command:
                                       description: |-
                                         Command is the command line to execute inside the container, the working directory for the
-                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                        a shell, you need to explicitly call out to that shell.
-                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        command  is root ('/') in the container's filesystem.
                                       items:
                                         type: string
                                       type: array
@@ -5413,8 +4658,6 @@ spec:
                                       description: |-
                                         Service is the name of the service to place in the gRPC HealthCheckRequest
                                         (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -5508,17 +4751,8 @@ spec:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: |-
-                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after the processes running in the pod are sent
-                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                    Set this value longer than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                    value overrides the value provided by the pod spec.
-                                    Value must be non-negative integer. The value zero indicates stop immediately via
-                                    the kill signal (no opportunity to shut down).
-                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
@@ -5567,7 +4801,7 @@ spec:
                                     This field depends on the
                                     DynamicResourceAllocation feature gate.
 
-                                    This field is immutable. It can only be set for containers.
+                                    This field is immutable.
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
@@ -5609,44 +4843,20 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: |-
-                                    Requests describes the minimum amount of compute resources required.
-                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  description: Requests describes the minimum amount
+                                    of compute resources required.
                                   type: object
                               type: object
                             restartPolicy:
                               description: |-
                                 RestartPolicy defines the restart behavior of individual containers in a pod.
-                                This overrides the pod-level restart policy. When this field is not specified,
-                                the restart behavior is defined by the Pod's restart policy and the container type.
-                                Additionally, setting the RestartPolicy as "Always" for the init container will
-                                have the following effect:
-                                this init container will be continually restarted on
-                                exit until all regular containers have terminated. Once all regular
-                                containers have completed, all init containers with restartPolicy "Always"
-                                will be shut down. This lifecycle differs from normal init containers and
-                                is often referred to as a "sidecar" container. Although this init
-                                container still starts in the init container sequence, it does not wait
-                                for the container to complete before proceeding to the next init
-                                container. Instead, the next init container starts immediately after this
-                                init container is started, or after any startupProbe has successfully
-                                completed.
+                                This overrides the pod-level restart policy.
                               type: string
                             restartPolicyRules:
                               description: |-
                                 Represents a list of rules to be checked to determine if the
                                 container should be restarted on exit. The rules are evaluated in
-                                order. Once a rule matches a container exit condition, the remaining
-                                rules are ignored. If no rule matches the container exit condition,
-                                the Container-level restart policy determines the whether the container
-                                is restarted or not. Constraints on the rules:
-                                - At most 20 rules are allowed.
-                                - Rules can have the same action.
-                                - Identical rules are not forbidden in validations.
-                                When rules are specified, container MUST set RestartPolicy explicitly
-                                even it if matches the Pod's RestartPolicy.
+                                order.
                               items:
                                 description: ContainerRestartRule describes how a
                                   container exit is handled.
@@ -5664,11 +4874,7 @@ spec:
                                       operator:
                                         description: |-
                                           Represents the relationship between the container exit code(s) and the
-                                          specified values. Possible values are:
-                                          - In: the requirement is satisfied if the container exit code is in the
-                                            set of specified values.
-                                          - NotIn: the requirement is satisfied if the container exit code is
-                                            not in the set of specified values.
+                                          specified values.
                                         type: string
                                       values:
                                         description: |-
@@ -5691,17 +4897,12 @@ spec:
                               description: |-
                                 SecurityContext defines the security options the container should be run with.
                                 If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                               properties:
                                 allowPrivilegeEscalation:
                                   description: |-
                                     AllowPrivilegeEscalation controls whether a process can gain more
                                     privileges than its parent process. This bool directly controls if
                                     the no_new_privs flag will be set on the container process.
-                                    AllowPrivilegeEscalation is true always when the container is:
-                                    1) run as Privileged
-                                    2) has CAP_SYS_ADMIN
-                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 appArmorProfile:
                                   description: |-
@@ -5714,7 +4915,6 @@ spec:
                                         localhostProfile indicates a profile loaded on the node that should be used.
                                         The profile must be preconfigured on the node to work.
                                         Must match the loaded name of the profile.
-                                        Must be set if and only if type is "Localhost".
                                       type: string
                                     type:
                                       description: |-
@@ -5722,7 +4922,6 @@ spec:
                                         Valid options are:
                                           Localhost - a profile pre-loaded on the node.
                                           RuntimeDefault - the container runtime's default profile.
-                                          Unconfined - no AppArmor enforcement.
                                       type: string
                                   required:
                                   - type
@@ -5762,8 +4961,6 @@ spec:
                                     procMount denotes the type of proc mount to use for the containers.
                                     The default value is Default which uses the container runtime defaults for
                                     readonly paths and masked paths.
-                                    This requires the ProcMountType feature flag to be enabled.
-                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
                                   description: |-
@@ -5775,36 +4972,25 @@ spec:
                                   description: |-
                                     The GID to run the entrypoint of the container process.
                                     Uses runtime default if unset.
-                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name is windows.
+                                    May also be set in PodSecurityContext.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: |-
-                                    Indicates that the container must run as a non-root user.
-                                    If true, the Kubelet will validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start the container if it does.
-                                    If unset or false, no such validation will be performed.
-                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  description: Indicates that the container must run
+                                    as a non-root user.
                                   type: boolean
                                 runAsUser:
                                   description: |-
                                     The UID to run the entrypoint of the container process.
                                     Defaults to user specified in image metadata if unspecified.
-                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name is windows.
+                                    May also be set in PodSecurityContext.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: |-
                                     The SELinux context to be applied to the container.
                                     If unspecified, the container runtime will allocate a random SELinux context for each
-                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name is windows.
+                                    container.  May also be set in PodSecurityContext.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5828,14 +5014,11 @@ spec:
                                     The seccomp options to use by this container. If seccomp options are
                                     provided at both the pod & container level, the container options
                                     override the pod options.
-                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
                                       description: |-
                                         localhostProfile indicates a profile defined in a file on the node should be used.
                                         The profile must be preconfigured on the node to work.
-                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
                                       description: |-
@@ -5843,8 +5026,6 @@ spec:
                                         Valid options are:
 
                                         Localhost - a profile defined in a file on the node should be used.
-                                        RuntimeDefault - the container runtime default profile should be used.
-                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
@@ -5853,8 +5034,6 @@ spec:
                                   description: |-
                                     The Windows specific settings applied to all containers.
                                     If unspecified, the options from the PodSecurityContext will be used.
-                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: |-
@@ -5867,18 +5046,14 @@ spec:
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: |-
-                                        HostProcess determines if a container should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same effective HostProcess value
-                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
                                       type: boolean
                                     runAsUserName:
                                       description: |-
                                         The UserName in Windows to run the entrypoint of the container process.
                                         Defaults to the user specified in image metadata if unspecified.
-                                        May also be set in PodSecurityContext. If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        May also be set in PodSecurityContext.
                                       type: string
                                   type: object
                               type: object
@@ -5886,11 +5061,6 @@ spec:
                               description: |-
                                 StartupProbe indicates that the Pod has successfully initialized.
                                 If specified, no other probes are executed until this completes successfully.
-                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
-                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
-                                when it might take a long time to load data or warm a cache, than during steady-state operation.
-                                This cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies a command to execute
@@ -5899,10 +5069,7 @@ spec:
                                     command:
                                       description: |-
                                         Command is the command line to execute inside the container, the working directory for the
-                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                        a shell, you need to explicitly call out to that shell.
-                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        command  is root ('/') in the container's filesystem.
                                       items:
                                         type: string
                                       type: array
@@ -5927,8 +5094,6 @@ spec:
                                       description: |-
                                         Service is the name of the service to place in the gRPC HealthCheckRequest
                                         (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -6022,17 +5187,8 @@ spec:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: |-
-                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after the processes running in the pod are sent
-                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                    Set this value longer than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                    value overrides the value provided by the pod spec.
-                                    Value must be non-negative integer. The value zero indicates stop immediately via
-                                    the kill signal (no opportunity to shut down).
-                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
@@ -6053,31 +5209,17 @@ spec:
                               description: |-
                                 Whether the container runtime should close the stdin channel after it has been opened by
                                 a single attach. When stdin is true the stdin stream will remain open across multiple attach
-                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
-                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
-                                at which time stdin is closed and remains closed until the container is restarted. If this
-                                flag is false, a container processes that reads from stdin will never receive an EOF.
-                                Default is false
+                                sessions.
                               type: boolean
                             terminationMessagePath:
                               description: |-
                                 Optional: Path at which the file to which the container's termination message
                                 will be written is mounted into the container's filesystem.
-                                Message written is intended to be brief final status, such as an assertion failure message.
-                                Will be truncated by the node if greater than 4096 bytes. The total message length across
-                                all containers will be limited to 12kb.
-                                Defaults to /dev/termination-log.
-                                Cannot be updated.
                               type: string
                             terminationMessagePolicy:
                               description: |-
                                 Indicate how the termination message should be populated. File will use the contents of
                                 terminationMessagePath to populate the container status message on both success and failure.
-                                FallbackToLogsOnError will use the last chunk of container log output if the termination
-                                message file is empty and the container exited with an error.
-                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
-                                Defaults to File.
-                                Cannot be updated.
                               type: string
                             tty:
                               description: |-
@@ -6127,8 +5269,6 @@ spec:
                                       to container and the other way around.
                                       When not set, MountPropagationNone is used.
                                       This field is beta in 1.10.
-                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
-                                      (which defaults to None).
                                     type: string
                                   name:
                                     description: This must match the Name of a Volume.
@@ -6144,18 +5284,6 @@ spec:
                                       recursively.
 
                                       If ReadOnly is false, this field has no meaning and must be unspecified.
-
-                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
-                                      recursively read-only.  If this field is set to IfPossible, the mount is made
-                                      recursively read-only, if it is supported by the container runtime.  If this
-                                      field is set to Enabled, the mount is made recursively read-only if it is
-                                      supported by the container runtime, otherwise the pod will not be started and
-                                      an error will be generated to indicate the reason.
-
-                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
-                                      None (or be unspecified, which defaults to None).
-
-                                      If this field is not specified, it is treated as an equivalent of Disabled.
                                     type: string
                                   subPath:
                                     description: |-
@@ -6163,11 +5291,8 @@ spec:
                                       Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: |-
-                                      Expanded path within the volume from which the container's volume should be mounted.
-                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                      Defaults to "" (volume's root).
-                                      SubPathExpr and SubPath are mutually exclusive.
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
                                     type: string
                                 required:
                                 - mountPath
@@ -6209,16 +5334,11 @@ spec:
                               description: |-
                                 Operator represents a key's relationship to the value.
                                 Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
-                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-
                                 TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint.
                               format: int64
                               type: integer
                             value:
@@ -6244,13 +5364,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: |-
                                     An empty preferred scheduling term matches all objects with implicit weight 0
@@ -6281,9 +5395,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6315,9 +5427,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6346,9 +5456,6 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to an update), the system
-                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
@@ -6380,9 +5487,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6414,9 +5519,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6445,13 +5548,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -6489,8 +5586,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -6504,23 +5600,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -6528,13 +5616,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -6544,8 +5626,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -6570,8 +5650,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -6585,10 +5664,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -6597,7 +5674,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -6606,9 +5682,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -6629,19 +5703,12 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -6670,8 +5737,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6685,23 +5751,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -6709,13 +5767,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -6725,8 +5777,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -6750,8 +5800,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6765,10 +5814,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -6777,7 +5824,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -6786,9 +5832,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -6805,13 +5849,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the anti-affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and subtracting
-                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -6849,8 +5887,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -6864,23 +5901,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -6888,13 +5917,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -6904,8 +5927,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -6930,8 +5951,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -6945,10 +5965,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -6957,7 +5975,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -6966,9 +5983,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -6989,19 +6004,12 @@ spec:
                                 description: |-
                                   If the anti-affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the anti-affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -7030,8 +6038,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7045,23 +6052,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -7069,13 +6068,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -7085,8 +6078,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -7110,8 +6101,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7125,10 +6115,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -7137,7 +6125,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -7146,9 +6133,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -7162,9 +6147,7 @@ spec:
                           type: string
                         description: |-
                           Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                          set by external tools to store and retrieve arbitrary metadata.
                         type: object
                       certSANs:
                         description: CertSANs sets extra Subject Alternative Names
@@ -7177,18 +6160,7 @@ spec:
                           type: string
                         description: |-
                           ExtraArgs is an extra set of flags to pass to the karmada-aggregated-apiserver component or
-                          override. A key in this map is the flag name as it appears on the command line except
-                          without leading dash(es).
-
-                          Note: This is a temporary solution to allow for the configuration of the
-                          karmada-aggregated-apiserver component. In the future, we will provide a more structured way
-                          to configure the component. Once that is done, this field will be discouraged to be used.
-                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand the risks of this configuration.
-
-                          For supported flags, please see
-                          https://karmada.io/docs/reference/components/karmada-aggregated-apiserver
-                          for details.
+                          override.
                         type: object
                       featureGates:
                         additionalProperties:
@@ -7196,7 +6168,7 @@ spec:
                         description: |-
                           FeatureGates enabled by the user.
                           - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
-                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go
+                          More info: https://github.
                         type: object
                       imagePullPolicy:
                         description: |-
@@ -7221,7 +6193,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                          More info: http://kubernetes.
                         type: object
                       podDisruptionBudgetConfig:
                         description: |-
@@ -7277,7 +6249,7 @@ spec:
                               This field depends on the
                               DynamicResourceAllocation feature gate.
 
-                              This field is immutable. It can only be set for containers.
+                              This field is immutable.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -7318,11 +6290,8 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            description: Requests describes the minimum amount of
+                              compute resources required.
                             type: object
                         type: object
                       tolerations:
@@ -7346,16 +6315,11 @@ spec:
                               description: |-
                                 Operator represents a key's relationship to the value.
                                 Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
-                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-
                                 TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint.
                               format: int64
                               type: integer
                             value:
@@ -7381,13 +6345,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: |-
                                     An empty preferred scheduling term matches all objects with implicit weight 0
@@ -7418,9 +6376,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7452,9 +6408,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7483,9 +6437,6 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to an update), the system
-                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
@@ -7517,9 +6468,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7551,9 +6500,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7582,13 +6529,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -7626,8 +6567,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -7641,23 +6581,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -7665,13 +6597,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -7681,8 +6607,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -7707,8 +6631,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -7722,10 +6645,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -7734,7 +6655,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -7743,9 +6663,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -7766,19 +6684,12 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -7807,8 +6718,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7822,23 +6732,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -7846,13 +6748,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -7862,8 +6758,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -7887,8 +6781,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7902,10 +6795,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -7914,7 +6805,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -7923,9 +6813,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -7942,13 +6830,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the anti-affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and subtracting
-                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -7986,8 +6868,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -8001,23 +6882,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -8025,13 +6898,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -8041,8 +6908,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -8067,8 +6932,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -8082,10 +6946,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -8094,7 +6956,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -8103,9 +6964,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -8126,19 +6985,12 @@ spec:
                                 description: |-
                                   If the anti-affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the anti-affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -8167,8 +7019,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -8182,23 +7033,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -8206,13 +7049,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -8222,8 +7059,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -8247,8 +7082,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -8262,10 +7096,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -8274,7 +7106,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -8283,9 +7114,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -8299,23 +7128,13 @@ spec:
                           type: string
                         description: |-
                           Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                          set by external tools to store and retrieve arbitrary metadata.
                         type: object
                       controllers:
                         description: |-
                           A list of controllers to enable. '*' enables all on-by-default controllers,
                           'foo' enables the controller named 'foo', '-foo' disables the controller named
                           'foo'.
-
-                          All controllers: binding, cluster, clusterStatus, endpointSlice, execution,
-                          federatedResourceQuotaStatus, federatedResourceQuotaSync, hpa, namespace,
-                          serviceExport, serviceImport, unifiedAuth, workStatus.
-                          Disabled-by-default controllers: hpa (default [*])
-                          Actual Supported controllers depend on the version of Karmada. See
-                          https://karmada.io/docs/administrator/configuration/configure-controllers#configure-karmada-controllers
-                          for details.
                         items:
                           type: string
                         type: array
@@ -8324,18 +7143,7 @@ spec:
                           type: string
                         description: |-
                           ExtraArgs is an extra set of flags to pass to the karmada-controller-manager component or
-                          override. A key in this map is the flag name as it appears on the command line except
-                          without leading dash(es).
-
-                          Note: This is a temporary solution to allow for the configuration of the
-                          karmada-controller-manager component. In the future, we will provide a more structured way
-                          to configure the component. Once that is done, this field will be discouraged to be used.
-                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand the risks of this configuration.
-
-                          For supported flags, please see
-                          https://karmada.io/docs/reference/components/karmada-controller-manager
-                          for details.
+                          override.
                         type: object
                       featureGates:
                         additionalProperties:
@@ -8343,10 +7151,7 @@ spec:
                         description: |-
                           FeatureGates enabled by the user.
                           - Failover: https://karmada.io/docs/userguide/failover/#failover
-                          - GracefulEviction: https://karmada.io/docs/userguide/failover/#graceful-eviction-feature
-                          - PropagateDeps: https://karmada.io/docs/userguide/scheduling/propagate-dependencies
-                          - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
-                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go
+                          - GracefulEviction: https://karmada.
                         type: object
                       imagePullPolicy:
                         description: |-
@@ -8371,7 +7176,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                          More info: http://kubernetes.
                         type: object
                       podDisruptionBudgetConfig:
                         description: |-
@@ -8427,7 +7232,7 @@ spec:
                               This field depends on the
                               DynamicResourceAllocation feature gate.
 
-                              This field is immutable. It can only be set for containers.
+                              This field is immutable.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -8468,11 +7273,8 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            description: Requests describes the minimum amount of
+                              compute resources required.
                             type: object
                         type: object
                       tolerations:
@@ -8496,16 +7298,11 @@ spec:
                               description: |-
                                 Operator represents a key's relationship to the value.
                                 Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
-                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-
                                 TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint.
                               format: int64
                               type: integer
                             value:
@@ -8531,13 +7328,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: |-
                                     An empty preferred scheduling term matches all objects with implicit weight 0
@@ -8568,9 +7359,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -8602,9 +7391,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -8633,9 +7420,6 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to an update), the system
-                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
@@ -8667,9 +7451,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -8701,9 +7483,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -8732,13 +7512,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -8776,8 +7550,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -8791,23 +7564,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -8815,13 +7580,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -8831,8 +7590,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -8857,8 +7614,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -8872,10 +7628,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -8884,7 +7638,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -8893,9 +7646,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -8916,19 +7667,12 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -8957,8 +7701,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -8972,23 +7715,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -8996,13 +7731,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -9012,8 +7741,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -9037,8 +7764,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -9052,10 +7778,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -9064,7 +7788,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -9073,9 +7796,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -9092,13 +7813,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the anti-affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and subtracting
-                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -9136,8 +7851,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -9151,23 +7865,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -9175,13 +7881,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -9191,8 +7891,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -9217,8 +7915,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -9232,10 +7929,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -9244,7 +7939,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -9253,9 +7947,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -9276,19 +7968,12 @@ spec:
                                 description: |-
                                   If the anti-affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the anti-affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -9317,8 +8002,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -9332,23 +8016,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -9356,13 +8032,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -9372,8 +8042,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -9397,8 +8065,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -9412,10 +8079,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -9424,7 +8089,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -9433,9 +8097,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -9449,9 +8111,7 @@ spec:
                           type: string
                         description: |-
                           Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                          set by external tools to store and retrieve arbitrary metadata.
                         type: object
                       extraArgs:
                         additionalProperties:
@@ -9460,16 +8120,6 @@ spec:
                           ExtraArgs is an extra set of flags to pass to the karmada-descheduler component or override.
                           A key in this map is the flag name as it appears on the command line except without
                           leading dash(es).
-
-                          Note: This is a temporary solution to allow for the configuration of the karmada-descheduler
-                          component. In the future, we will provide a more structured way to configure the component.
-                          Once that is done, this field will be discouraged to be used.
-                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand the risks of this configuration.
-
-                          For supported flags, please see
-                          https://karmada.io/docs/reference/components/karmada-descheduler
-                          for details.
                         type: object
                       imagePullPolicy:
                         description: |-
@@ -9494,7 +8144,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                          More info: http://kubernetes.
                         type: object
                       podDisruptionBudgetConfig:
                         description: |-
@@ -9550,7 +8200,7 @@ spec:
                               This field depends on the
                               DynamicResourceAllocation feature gate.
 
-                              This field is immutable. It can only be set for containers.
+                              This field is immutable.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -9591,11 +8241,8 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            description: Requests describes the minimum amount of
+                              compute resources required.
                             type: object
                         type: object
                       tolerations:
@@ -9619,16 +8266,11 @@ spec:
                               description: |-
                                 Operator represents a key's relationship to the value.
                                 Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
-                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-
                                 TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint.
                               format: int64
                               type: integer
                             value:
@@ -9654,13 +8296,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: |-
                                     An empty preferred scheduling term matches all objects with implicit weight 0
@@ -9691,9 +8327,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -9725,9 +8359,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -9756,9 +8388,6 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to an update), the system
-                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
@@ -9790,9 +8419,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -9824,9 +8451,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -9855,13 +8480,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -9899,8 +8518,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -9914,23 +8532,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -9938,13 +8548,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -9954,8 +8558,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -9980,8 +8582,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -9995,10 +8596,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -10007,7 +8606,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -10016,9 +8614,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -10039,19 +8635,12 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -10080,8 +8669,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -10095,23 +8683,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -10119,13 +8699,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -10135,8 +8709,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -10160,8 +8732,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -10175,10 +8746,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -10187,7 +8756,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -10196,9 +8764,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -10215,13 +8781,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the anti-affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and subtracting
-                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -10259,8 +8819,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -10274,23 +8833,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -10298,13 +8849,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -10314,8 +8859,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -10340,8 +8883,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -10355,10 +8897,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -10367,7 +8907,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -10376,9 +8915,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -10399,19 +8936,12 @@ spec:
                                 description: |-
                                   If the anti-affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the anti-affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -10440,8 +8970,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -10455,23 +8984,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -10479,13 +9000,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -10495,8 +9010,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -10520,8 +9033,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -10535,10 +9047,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -10547,7 +9057,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -10556,9 +9065,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -10572,9 +9079,7 @@ spec:
                           type: string
                         description: |-
                           Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                          set by external tools to store and retrieve arbitrary metadata.
                         type: object
                       extraArgs:
                         additionalProperties:
@@ -10583,16 +9088,6 @@ spec:
                           ExtraArgs is an extra set of flags to pass to the karmada-metrics-adapter component or override.
                           A key in this map is the flag name as it appears on the command line except without
                           leading dash(es).
-
-                          Note: This is a temporary solution to allow for the configuration of the karmada-metrics-adapter
-                          component. In the future, we will provide a more structured way to configure the component.
-                          Once that is done, this field will be discouraged to be used.
-                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand the risks of this configuration.
-
-                          For supported flags, please see
-                          https://karmada.io/docs/reference/components/karmada-metrics-adapter
-                          for details.
                         type: object
                       imagePullPolicy:
                         description: |-
@@ -10617,7 +9112,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                          More info: http://kubernetes.
                         type: object
                       podDisruptionBudgetConfig:
                         description: |-
@@ -10673,7 +9168,7 @@ spec:
                               This field depends on the
                               DynamicResourceAllocation feature gate.
 
-                              This field is immutable. It can only be set for containers.
+                              This field is immutable.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -10714,11 +9209,8 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            description: Requests describes the minimum amount of
+                              compute resources required.
                             type: object
                         type: object
                       tolerations:
@@ -10742,16 +9234,11 @@ spec:
                               description: |-
                                 Operator represents a key's relationship to the value.
                                 Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
-                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-
                                 TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint.
                               format: int64
                               type: integer
                             value:
@@ -10777,13 +9264,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: |-
                                     An empty preferred scheduling term matches all objects with implicit weight 0
@@ -10814,9 +9295,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -10848,9 +9327,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -10879,9 +9356,6 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to an update), the system
-                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
@@ -10913,9 +9387,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -10947,9 +9419,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -10978,13 +9448,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -11022,8 +9486,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -11037,23 +9500,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -11061,13 +9516,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -11077,8 +9526,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -11103,8 +9550,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -11118,10 +9564,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -11130,7 +9574,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -11139,9 +9582,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -11162,19 +9603,12 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -11203,8 +9637,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -11218,23 +9651,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -11242,13 +9667,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -11258,8 +9677,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -11283,8 +9700,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -11298,10 +9714,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -11310,7 +9724,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -11319,9 +9732,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -11338,13 +9749,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the anti-affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and subtracting
-                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -11382,8 +9787,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -11397,23 +9801,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -11421,13 +9817,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -11437,8 +9827,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -11463,8 +9851,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -11478,10 +9865,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -11490,7 +9875,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -11499,9 +9883,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -11522,19 +9904,12 @@ spec:
                                 description: |-
                                   If the anti-affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the anti-affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -11563,8 +9938,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -11578,23 +9952,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -11602,13 +9968,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -11618,8 +9978,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -11643,8 +10001,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -11658,10 +10015,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -11670,7 +10025,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -11679,9 +10033,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -11695,9 +10047,7 @@ spec:
                           type: string
                         description: |-
                           Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                          set by external tools to store and retrieve arbitrary metadata.
                         type: object
                       extraArgs:
                         additionalProperties:
@@ -11706,16 +10056,6 @@ spec:
                           ExtraArgs is an extra set of flags to pass to the karmada-scheduler component or override.
                           A key in this map is the flag name as it appears on the command line except without
                           leading dash(es).
-
-                          Note: This is a temporary solution to allow for the configuration of the karmada-scheduler
-                          component. In the future, we will provide a more structured way to configure the component.
-                          Once that is done, this field will be discouraged to be used.
-                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand the risks of this configuration.
-
-                          For supported flags, please see
-                          https://karmada.io/docs/reference/components/karmada-scheduler
-                          for details.
                         type: object
                       featureGates:
                         additionalProperties:
@@ -11723,7 +10063,7 @@ spec:
                         description: |-
                           FeatureGates enabled by the user.
                           - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
-                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go
+                          More info: https://github.
                         type: object
                       imagePullPolicy:
                         description: |-
@@ -11748,7 +10088,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                          More info: http://kubernetes.
                         type: object
                       podDisruptionBudgetConfig:
                         description: |-
@@ -11804,7 +10144,7 @@ spec:
                               This field depends on the
                               DynamicResourceAllocation feature gate.
 
-                              This field is immutable. It can only be set for containers.
+                              This field is immutable.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -11845,11 +10185,8 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            description: Requests describes the minimum amount of
+                              compute resources required.
                             type: object
                         type: object
                       tolerations:
@@ -11873,16 +10210,11 @@ spec:
                               description: |-
                                 Operator represents a key's relationship to the value.
                                 Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
-                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-
                                 TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint.
                               format: int64
                               type: integer
                             value:
@@ -11908,13 +10240,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: |-
                                     An empty preferred scheduling term matches all objects with implicit weight 0
@@ -11945,9 +10271,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -11979,9 +10303,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -12010,9 +10332,6 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to an update), the system
-                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
@@ -12044,9 +10363,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -12078,9 +10395,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -12109,13 +10424,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -12153,8 +10462,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -12168,23 +10476,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -12192,13 +10492,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -12208,8 +10502,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -12234,8 +10526,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -12249,10 +10540,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -12261,7 +10550,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -12270,9 +10558,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -12293,19 +10579,12 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -12334,8 +10613,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -12349,23 +10627,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -12373,13 +10643,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -12389,8 +10653,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -12414,8 +10676,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -12429,10 +10690,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -12441,7 +10700,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -12450,9 +10708,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -12469,13 +10725,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the anti-affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and subtracting
-                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -12513,8 +10763,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -12528,23 +10777,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -12552,13 +10793,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -12568,8 +10803,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -12594,8 +10827,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -12609,10 +10841,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -12621,7 +10851,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -12630,9 +10859,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -12653,19 +10880,12 @@ spec:
                                 description: |-
                                   If the anti-affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the anti-affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -12694,8 +10914,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -12709,23 +10928,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -12733,13 +10944,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -12749,8 +10954,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -12774,8 +10977,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -12789,10 +10991,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -12801,7 +11001,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -12810,9 +11009,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -12826,9 +11023,7 @@ spec:
                           type: string
                         description: |-
                           Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                          set by external tools to store and retrieve arbitrary metadata.
                         type: object
                       extraArgs:
                         additionalProperties:
@@ -12837,16 +11032,6 @@ spec:
                           ExtraArgs is an extra set of flags to pass to the karmada-search component or override.
                           A key in this map is the flag name as it appears on the command line except without
                           leading dash(es).
-
-                          Note: This is a temporary solution to allow for the configuration of the karmada-search
-                          component. In the future, we will provide a more structured way to configure the component.
-                          Once that is done, this field will be discouraged to be used.
-                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand the risks of this configuration.
-
-                          For supported flags, please see
-                          https://karmada.io/docs/reference/components/karmada-search
-                          for details.
                         type: object
                       imagePullPolicy:
                         description: |-
@@ -12871,7 +11056,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                          More info: http://kubernetes.
                         type: object
                       podDisruptionBudgetConfig:
                         description: |-
@@ -12927,7 +11112,7 @@ spec:
                               This field depends on the
                               DynamicResourceAllocation feature gate.
 
-                              This field is immutable. It can only be set for containers.
+                              This field is immutable.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -12968,11 +11153,8 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            description: Requests describes the minimum amount of
+                              compute resources required.
                             type: object
                         type: object
                       tolerations:
@@ -12996,16 +11178,11 @@ spec:
                               description: |-
                                 Operator represents a key's relationship to the value.
                                 Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
-                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-
                                 TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint.
                               format: int64
                               type: integer
                             value:
@@ -13031,13 +11208,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: |-
                                     An empty preferred scheduling term matches all objects with implicit weight 0
@@ -13068,9 +11239,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -13102,9 +11271,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -13133,9 +11300,6 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to an update), the system
-                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
@@ -13167,9 +11331,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -13201,9 +11363,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -13232,13 +11392,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -13276,8 +11430,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -13291,23 +11444,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -13315,13 +11460,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -13331,8 +11470,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -13357,8 +11494,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -13372,10 +11508,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -13384,7 +11518,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -13393,9 +11526,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -13416,19 +11547,12 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -13457,8 +11581,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -13472,23 +11595,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -13496,13 +11611,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -13512,8 +11621,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -13537,8 +11644,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -13552,10 +11658,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -13564,7 +11668,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -13573,9 +11676,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -13592,13 +11693,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the anti-affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and subtracting
-                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -13636,8 +11731,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -13651,23 +11745,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -13675,13 +11761,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -13691,8 +11771,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -13717,8 +11795,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -13732,10 +11809,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -13744,7 +11819,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -13753,9 +11827,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -13776,19 +11848,12 @@ spec:
                                 description: |-
                                   If the anti-affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the anti-affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -13817,8 +11882,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -13832,23 +11896,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -13856,13 +11912,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -13872,8 +11922,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -13897,8 +11945,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -13912,10 +11959,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -13924,7 +11969,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -13933,9 +11977,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -13949,9 +11991,7 @@ spec:
                           type: string
                         description: |-
                           Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                          set by external tools to store and retrieve arbitrary metadata.
                         type: object
                       extraArgs:
                         additionalProperties:
@@ -13960,16 +12000,6 @@ spec:
                           ExtraArgs is an extra set of flags to pass to the karmada-webhook component or
                           override. A key in this map is the flag name as it appears on the command line except
                           without leading dash(es).
-
-                          Note: This is a temporary solution to allow for the configuration of the
-                          karmada-webhook component. In the future, we will provide a more structured way
-                          to configure the component. Once that is done, this field will be discouraged to be used.
-                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand the risks of this configuration.
-
-                          For supported flags, please see
-                          https://karmada.io/docs/reference/components/karmada-webhook
-                          for details.
                         type: object
                       imagePullPolicy:
                         description: |-
@@ -13994,7 +12024,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                          More info: http://kubernetes.
                         type: object
                       podDisruptionBudgetConfig:
                         description: |-
@@ -14050,7 +12080,7 @@ spec:
                               This field depends on the
                               DynamicResourceAllocation feature gate.
 
-                              This field is immutable. It can only be set for containers.
+                              This field is immutable.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -14091,11 +12121,8 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            description: Requests describes the minimum amount of
+                              compute resources required.
                             type: object
                         type: object
                       tolerations:
@@ -14119,16 +12146,11 @@ spec:
                               description: |-
                                 Operator represents a key's relationship to the value.
                                 Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
-                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-
                                 TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint.
                               format: int64
                               type: integer
                             value:
@@ -14154,13 +12176,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: |-
                                     An empty preferred scheduling term matches all objects with implicit weight 0
@@ -14191,9 +12207,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -14225,9 +12239,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -14256,9 +12268,6 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to an update), the system
-                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
@@ -14290,9 +12299,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -14324,9 +12331,7 @@ spec:
                                                 description: |-
                                                   An array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                                  array must have a single element, which will be interpreted as an integer.
-                                                  This array is replaced during a strategic merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -14355,13 +12360,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and adding
-                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -14399,8 +12398,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -14414,23 +12412,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -14438,13 +12428,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -14454,8 +12438,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -14480,8 +12462,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -14495,10 +12476,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -14507,7 +12486,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -14516,9 +12494,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -14539,19 +12515,12 @@ spec:
                                 description: |-
                                   If the affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -14580,8 +12549,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -14595,23 +12563,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -14619,13 +12579,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -14635,8 +12589,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -14660,8 +12612,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -14675,10 +12626,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -14687,7 +12636,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -14696,9 +12644,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -14715,13 +12661,7 @@ spec:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
                                   the anti-affinity expressions specified by this field, but it may choose
-                                  a node that violates one or more of the expressions. The node that is
-                                  most preferred is the one with the greatest sum of weights, i.e.
-                                  for each node that meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                  compute a sum by iterating through the elements of this field and subtracting
-                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                  node(s) with the highest sum are the most preferred.
+                                  a node that violates one or more of the expressions.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -14759,8 +12699,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -14774,23 +12713,15 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
                                           description: |-
                                             MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -14798,13 +12729,7 @@ spec:
                                         mismatchLabelKeys:
                                           description: |-
                                             MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            be taken into consideration.
                                           items:
                                             type: string
                                           type: array
@@ -14814,8 +12739,6 @@ spec:
                                             A label query over the set of namespaces that the term applies to.
                                             The term is applied to the union of the namespaces selected by this field
                                             and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -14840,8 +12763,7 @@ spec:
                                                     description: |-
                                                       values is an array of string values. If the operator is In or NotIn,
                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
+                                                      the values array must be empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -14855,10 +12777,8 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -14867,7 +12787,6 @@ spec:
                                             namespaces specifies a static list of namespace names that the term applies to.
                                             The term is applied to the union of the namespaces listed in this field
                                             and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -14876,9 +12795,7 @@ spec:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                             the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
+                                            whose...
                                           type: string
                                       required:
                                       - topologyKey
@@ -14899,19 +12816,12 @@ spec:
                                 description: |-
                                   If the anti-affinity requirements specified by this field are not met at
                                   scheduling time, the pod will not be scheduled onto the node.
-                                  If the anti-affinity requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to a pod label update), the
-                                  system may or may not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes corresponding to each
-                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: |-
                                     Defines a set of pods (namely those matching the labelSelector
                                     relative to the given namespace(s)) that this pod should be
                                     co-located (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node whose value of
-                                    the label with key <topologyKey> matches that of any node on which
-                                    a pod of the set of pods is running
+                                    where...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -14940,8 +12850,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -14955,23 +12864,15 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
                                       description: |-
                                         MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -14979,13 +12880,7 @@ spec:
                                     mismatchLabelKeys:
                                       description: |-
                                         MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
@@ -14995,8 +12890,6 @@ spec:
                                         A label query over the set of namespaces that the term applies to.
                                         The term is applied to the union of the namespaces selected by this field
                                         and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -15020,8 +12913,7 @@ spec:
                                                 description: |-
                                                   values is an array of string values. If the operator is In or NotIn,
                                                   the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
+                                                  the values array must be empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -15035,10 +12927,8 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -15047,7 +12937,6 @@ spec:
                                         namespaces specifies a static list of namespace names that the term applies to.
                                         The term is applied to the union of the namespaces listed in this field
                                         and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -15056,9 +12945,7 @@ spec:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
                                         the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
+                                        whose...
                                       type: string
                                   required:
                                   - topologyKey
@@ -15072,46 +12959,13 @@ spec:
                           type: string
                         description: |-
                           Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                          set by external tools to store and retrieve arbitrary metadata.
                         type: object
                       controllers:
                         description: |-
                           A list of controllers to enable. '*' enables all on-by-default controllers,
                           'foo' enables the controller named 'foo', '-foo' disables the controller named
                           'foo'.
-
-                          All controllers: attachdetach, bootstrapsigner, cloud-node-lifecycle,
-                          clusterrole-aggregation, cronjob, csrapproving, csrcleaner, csrsigning,
-                          daemonset, deployment, disruption, endpoint, endpointslice,
-                          endpointslicemirroring, ephemeral-volume, garbagecollector,
-                          horizontalpodautoscaling, job, namespace, nodeipam, nodelifecycle,
-                          persistentvolume-binder, persistentvolume-expander, podgc, pv-protection,
-                          pvc-protection, replicaset, replicationcontroller, resourcequota,
-                          root-ca-cert-publisher, route, service, serviceaccount, serviceaccount-token,
-                          statefulset, tokencleaner, ttl, ttl-after-finished
-                          Disabled-by-default controllers: bootstrapsigner, tokencleaner (default [*])
-                          Actual Supported controllers depend on the version of Kubernetes. See
-                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
-                          for details.
-
-                          However, Karmada uses Kubernetes Native API definitions for federated resource template,
-                          so it doesn't need enable some resource related controllers like daemonset, deployment etc.
-                          On the other hand, Karmada leverages the capabilities of the Kubernetes controller to
-                          manage the lifecycle of the federated resource, so it needs to enable some controllers.
-                          For example, the `namespace` controller is used to manage the lifecycle of the namespace
-                          and the `garbagecollector` controller handles automatic clean-up of redundant items in
-                          your karmada.
-
-                          According to the user feedback and karmada requirements, the following controllers are
-                          enabled by default: namespace, garbagecollector, serviceaccount-token, ttl-after-finished,
-                          bootstrapsigner,csrapproving,csrcleaner,csrsigning. See
-                          https://karmada.io/docs/administrator/configuration/configure-controllers#kubernetes-controllers
-
-                          Others are disabled by default. If you want to enable or disable other controllers, you
-                          have to explicitly specify all the controllers that kube-controller-manager should enable
-                          at startup phase.
                         items:
                           type: string
                         type: array
@@ -15122,16 +12976,6 @@ spec:
                           ExtraArgs is an extra set of flags to pass to the kube-controller-manager component or
                           override. A key in this map is the flag name as it appears on the command line except
                           without leading dash(es).
-
-                          Note: This is a temporary solution to allow for the configuration of the
-                          kube-controller-manager component. In the future, we will provide a more structured way
-                          to configure the component. Once that is done, this field will be discouraged to be used.
-                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand the risks of this configuration.
-
-                          For supported flags, please see
-                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
-                          for details.
                         type: object
                       featureGates:
                         additionalProperties:
@@ -15163,7 +13007,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                          More info: http://kubernetes.
                         type: object
                       podDisruptionBudgetConfig:
                         description: |-
@@ -15219,7 +13063,7 @@ spec:
                               This field depends on the
                               DynamicResourceAllocation feature gate.
 
-                              This field is immutable. It can only be set for containers.
+                              This field is immutable.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -15260,11 +13104,8 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            description: Requests describes the minimum amount of
+                              compute resources required.
                             type: object
                         type: object
                       tolerations:
@@ -15288,16 +13129,11 @@ spec:
                               description: |-
                                 Operator represents a key's relationship to the value.
                                 Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                                Exists is equivalent to wildcard for value, so that a pod can
-                                tolerate all taints of a particular category.
-                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-
                                 TolerationSeconds represents the period of time the toleration (which must be
-                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                negative values will be treated as 0 (evict immediately) by the system.
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint.
                               format: int64
                               type: integer
                             value:
@@ -15312,13 +13148,9 @@ spec:
                 - etcd
                 type: object
               crdTarball:
-                description: |-
-                  CRDTarball specifies the source from which the Karmada CRD tarball should be downloaded, along with the download policy to use.
-                  If not set, the operator will download the tarball from a GitHub release.
-                  By default, it will download the tarball of the same version as the operator itself.
-                  For instance, if the operator's version is v1.10.0, the tarball will be downloaded from the following location:
-                  https://github.com/karmada-io/karmada/releases/download/v1.10.0/crds.tar.gz
-                  By default, the operator will only attempt to download the tarball if it's not yet present in the local cache.
+                description: CRDTarball specifies the source from which the Karmada
+                  CRD tarball should be downloaded, along with the download policy
+                  to use.
                 properties:
                   crdDownloadPolicy:
                     default: IfNotPresent
@@ -15335,17 +13167,12 @@ spec:
                       via either HTTP or HTTPS protocol.
                     properties:
                       proxy:
-                        description: |-
-                          Proxy specifies the configuration of a proxy server to use when downloading the CRD tarball.
-                          When set, the operator will use the configuration to determine how to establish a connection to the proxy to fetch the tarball from the URL specified above.
-                          This is useful in environments where direct access to the server hosting the CRD tarball is restricted and a proxy must be used to reach that server.
-                          If a proxy configuration is not set, the operator will attempt to download the tarball directly from the URL specified above without using a proxy.
+                        description: Proxy specifies the configuration of a proxy
+                          server to use when downloading the CRD tarball.
                         properties:
                           proxyURL:
-                            description: |-
-                              ProxyURL specifies the HTTP/HTTPS proxy server URL to use when downloading the CRD tarball.
-                              This is useful in environments where direct access to the server hosting the CRD tarball is restricted and a proxy must be used to reach that server.
-                              The format should be a valid URL, e.g., "http://proxy.example.com:8080".
+                            description: ProxyURL specifies the HTTP/HTTPS proxy server
+                              URL to use when downloading the CRD tarball.
                             type: string
                         required:
                         - proxyURL
@@ -15362,7 +13189,6 @@ spec:
                   CustomCertificate specifies the configuration to customize the certificates
                   for Karmada components or control the certificate generation process, such as
                   the algorithm, validity period, etc.
-                  Currently, it only supports customizing the CA certificate for limited components.
                 properties:
                   apiServerCACert:
                     description: |-
@@ -15370,9 +13196,7 @@ spec:
                       for component karmada-apiserver.
                       The secret must contain the following data keys:
                       - tls.crt: The TLS certificate.
-                      - tls.key: The TLS private key.
-                      If specified, this CA will be used to issue client certificates for
-                      all components that access the APIServer as clients.
+                      - tls.
                     properties:
                       name:
                         description: Name is the name of resource being referenced.
@@ -15396,10 +13220,7 @@ spec:
                 description: |-
                   FeatureGates enabled by the user.
                   - Failover: https://karmada.io/docs/userguide/failover/#failover
-                  - GracefulEviction: https://karmada.io/docs/userguide/failover/#graceful-eviction-feature
-                  - PropagateDeps: https://karmada.io/docs/userguide/scheduling/propagate-dependencies
-                  - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
-                  More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go
+                  - GracefulEviction: https://karmada.
                 type: object
               hostCluster:
                 description: |-
@@ -15444,7 +13265,6 @@ spec:
                   PrivateRegistry is the global image registry.
                   If set, the operator will pull all required images from it, no matter
                   the image is maintained by Karmada or Kubernetes.
-                  It will be useful for offline installation to specify an accessible registry.
                 properties:
                   registry:
                     description: |-
@@ -15459,7 +13279,6 @@ spec:
                 description: |-
                   Suspend indicates that the operator should suspend reconciliation
                   for this Karmada control plane and all its managed resources.
-                  Karmada instances for which this field is not explicitly set to `true` will continue to be reconciled as usual.
                 type: boolean
             type: object
           status:
@@ -15469,7 +13288,6 @@ spec:
                 description: |-
                   APIServerService reports the location of the Karmada API server service which
                   can be used by third-party applications to discover the Karmada Service, e.g.
-                  expose the service outside the cluster by Ingress.
                 properties:
                   name:
                     description: Name represents the name of the Karmada API Server
@@ -15488,7 +13306,7 @@ spec:
                     lastTransitionTime:
                       description: |-
                         lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        This should be when the underlying condition changed.
                       format: date-time
                       type: string
                     message:
@@ -15500,18 +13318,13 @@ spec:
                     observedGeneration:
                       description: |-
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$

--- a/charts/karmada-operator/templates/post-hook-job.yaml
+++ b/charts/karmada-operator/templates/post-hook-job.yaml
@@ -30,6 +30,10 @@ spec:
           bash <<'EOF'
           set -ex
           kubectl apply --server-side -f /crds --force-conflicts
+          kubectl label crd karmadas.operator.karmada.io app.kubernetes.io/managed-by=Helm --overwrite
+          kubectl annotate crd karmadas.operator.karmada.io meta.helm.sh/release-name={{ .Release.Name }} --overwrite
+          kubectl annotate crd karmadas.operator.karmada.io meta.helm.sh/release-namespace={{ .Release.Namespace }} --overwrite
+          kubectl annotate crd karmadas.operator.karmada.io helm.sh/resource-policy=keep --overwrite
           EOF
         volumeMounts:
         - name: crds

--- a/hack/update-crdgen.sh
+++ b/hack/update-crdgen.sh
@@ -35,5 +35,5 @@ controller-gen crd paths=./pkg/apis/remedy/... output:crd:dir=./charts/karmada/_
 controller-gen crd paths=./pkg/apis/work/... output:crd:dir=./charts/karmada/_crds/bases/work
 controller-gen crd paths=./pkg/apis/apps/... output:crd:dir=./charts/karmada/_crds/bases/apps
 controller-gen crd:generateEmbeddedObjectMeta=true paths=./examples/customresourceinterpreter/apis/... output:crd:dir=./examples/customresourceinterpreter/apis/
-controller-gen crd:generateEmbeddedObjectMeta=true paths=./operator/pkg/apis/operator/... output:crd:dir=./charts/karmada-operator/crds
+controller-gen crd:generateEmbeddedObjectMeta=true,maxDescLen=200 paths=./operator/pkg/apis/operator/... output:crd:dir=./charts/karmada-operator/crds
 controller-gen crd:generateEmbeddedObjectMeta=true paths=./operator/pkg/apis/operator/... output:crd:dir=./operator/config/crds


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

**What this PR does / why we need it**:

The operator CRD is ~1.1MB, which exceeds the 1MB ConfigMap limit. The post-hook mechanism embeds the CRD into a ConfigMap to work around Helm not upgrading CRDs from `crds/`, but that hits a hard ceiling. To temporarily get around that limit, we limit the length of description fields in the generated OpenAPI schema of the CRD.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7371

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-operator-chart`: Fixed issue with embedding the `Karmada` CRD, which has exceeded the config map size limit, into a config map used by the chart CRD installation/upgrade job, that prevented users from upgrading the chart. 
```

