### PR TITLE
test(e2e): add overflow cluster affinities E2E tests

### DIFF
--- a/test/e2e/suites/base/clusteraffinities_test.go
+++ b/test/e2e/suites/base/clusteraffinities_test.go
@@ -24,11 +24,15 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/ptr"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/test/e2e/framework"
 	testhelper "github.com/karmada-io/karmada/test/helper"
 )
@@ -348,6 +352,151 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 		})
 	})
 
+	ginkgo.When("[OverflowAffinities] replica scheduling with overflow affinities", func() {
+		// overflowMaxReplicas caps each cluster via ResourceQuota.
+		// Each replica requests 10m CPU (test/helper/resource.go), so the quota per cluster
+		// is set to overflowMaxReplicas × 10m = 20m.
+		const overflowMaxReplicas int32 = 2
+		// totalOverflowReplicas exceeds the combined capacity of both clusters (2+2=4),
+		// so scheduling should fail when this count is requested.
+		const totalOverflowReplicas int32 = 5
+
+		var primaryClusterName, secondaryClusterName string
+		var overflowNamespace string
+		var overflowRQName, rqPolicyName string
+
+		ginkgo.BeforeEach(func() {
+			primaryClusterName = framework.ClusterNames()[0]
+			secondaryClusterName = framework.ClusterNames()[1]
+		})
+
+		ginkgo.BeforeEach(func() {
+			overflowNamespace = fmt.Sprintf("karmadatest-%s", rand.String(RandomStrLength))
+			err := setupTestNamespace(overflowNamespace, kubeClient)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveNamespace(kubeClient, overflowNamespace)
+			})
+		})
+
+		ginkgo.BeforeEach(func() {
+			// ResourceQuota caps each cluster at overflowMaxReplicas replicas.
+			overflowRQName = resourceQuotaPrefix + rand.String(RandomStrLength)
+			quotaCPU := resource.NewMilliQuantity(int64(overflowMaxReplicas)*10, resource.DecimalSI)
+			overflowRQ := &corev1.ResourceQuota{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ResourceQuota"},
+				ObjectMeta: metav1.ObjectMeta{Name: overflowRQName, Namespace: overflowNamespace},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: corev1.ResourceList{corev1.ResourceRequestsCPU: *quotaCPU},
+				},
+			}
+			framework.CreateResourceQuota(kubeClient, overflowRQ)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveResourceQuota(kubeClient, overflowNamespace, overflowRQName)
+			})
+
+			rqPolicyName = ppNamePrefix + rand.String(RandomStrLength)
+			rqPolicy := testhelper.NewPropagationPolicy(overflowNamespace, rqPolicyName,
+				[]policyv1alpha1.ResourceSelector{{APIVersion: "v1", Kind: "ResourceQuota", Name: overflowRQName}},
+				policyv1alpha1.Placement{
+					ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+						ClusterNames: []string{primaryClusterName, secondaryClusterName},
+					},
+				},
+			)
+			framework.CreatePropagationPolicy(karmadaClient, rqPolicy)
+			ginkgo.DeferCleanup(func() {
+				framework.RemovePropagationPolicy(karmadaClient, overflowNamespace, rqPolicyName)
+			})
+		})
+
+		ginkgo.BeforeEach(func() {
+			// Both cluster estimators must observe the quota before scheduling; otherwise
+			// calAvailableReplicas falls back to spec.Replicas and overflow never triggers.
+			framework.WaitResourceQuotaPresentOnCluster(primaryClusterName, overflowNamespace, overflowRQName)
+			framework.WaitResourceQuotaPresentOnCluster(secondaryClusterName, overflowNamespace, overflowRQName)
+		})
+
+		ginkgo.Context("scale-up and scale-down with overflow affinities", func() {
+			var deployment *appsv1.Deployment
+			var deployPolicyName string
+
+			ginkgo.BeforeEach(func() {
+				deployName := deploymentNamePrefix + rand.String(RandomStrLength)
+				deployment = testhelper.NewDeployment(overflowNamespace, deployName)
+				// Start at the primary cap so replicas land only on the primary cluster.
+				deployment.Spec.Replicas = ptr.To[int32](overflowMaxReplicas)
+
+				deployPolicyName = ppNamePrefix + rand.String(RandomStrLength)
+				deployPolicy := testhelper.NewPropagationPolicy(overflowNamespace, deployPolicyName,
+					[]policyv1alpha1.ResourceSelector{{
+						APIVersion: deployment.APIVersion,
+						Kind:       deployment.Kind,
+						Name:       deployment.Name,
+					}},
+					overflowAffinitiesPlacement(primaryClusterName, secondaryClusterName),
+				)
+				framework.CreatePropagationPolicy(karmadaClient, deployPolicy)
+				framework.CreateDeployment(kubeClient, deployment)
+				ginkgo.DeferCleanup(func() {
+					framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+					framework.RemovePropagationPolicy(karmadaClient, overflowNamespace, deployPolicyName)
+				})
+			})
+
+			ginkgo.It("should expand to secondary on scale-up and retract from secondary on scale-down", func() {
+				bindingName := names.GenerateBindingName(util.DeploymentKind, deployment.Name)
+
+				ginkgo.By("replicas are only propagated to the primary group if the primary group has sufficient resources", func() {
+					framework.AssertBindingScheduledClusters(karmadaClient, overflowNamespace, bindingName,
+						[][]string{{primaryClusterName}},
+					)
+				})
+
+				ginkgo.By("scale up: replicas overflow to the secondary group if the primary group has insufficient resources", func() {
+					// scaling up to 4 replicas: both clusters fill to their quota cap
+					framework.UpdateDeploymentReplicas(kubeClient, deployment, overflowMaxReplicas*2)
+
+					// verifying both clusters scheduled to capacity: primary=2, secondary=2
+					framework.WaitResourceBindingFitWith(karmadaClient, overflowNamespace, bindingName,
+						func(rb *workv1alpha2.ResourceBinding) bool {
+							if len(rb.Spec.Clusters) != 2 {
+								return false
+							}
+							m := clusterReplicaMap(rb)
+							return m[primaryClusterName] == overflowMaxReplicas &&
+								m[secondaryClusterName] == overflowMaxReplicas
+						},
+					)
+				})
+
+				ginkgo.By("schedule fails due to insufficient resources in primary group and overflow affinity groups", func() {
+					// scaling up to 5 replicas: exceeds combined quota, scheduling should fail
+					framework.UpdateDeploymentReplicas(kubeClient, deployment, totalOverflowReplicas)
+					framework.WaitResourceBindingFitWith(karmadaClient, overflowNamespace, bindingName,
+						func(rb *workv1alpha2.ResourceBinding) bool {
+							for _, cond := range rb.Status.Conditions {
+								if cond.Type == "Scheduled" && cond.Status == "False" {
+									return true
+								}
+							}
+							return false
+						},
+					)
+				})
+
+				ginkgo.By("scale down: replicas are reduced first from overflow affinity groups", func() {
+					// scaling back down to 2 replicas
+					framework.UpdateDeploymentReplicas(kubeClient, deployment, overflowMaxReplicas)
+					framework.AssertBindingScheduledClusters(karmadaClient, overflowNamespace, bindingName,
+						[][]string{{primaryClusterName}},
+					)
+					framework.WaitDeploymentDisappearOnCluster(secondaryClusterName, overflowNamespace, deployment.Name)
+				})
+			})
+		})
+	})
+
 	framework.SerialWhen("[Failover] member cluster become unReachable", func() {
 		var deployment *appsv1.Deployment
 		var policy *policyv1alpha1.PropagationPolicy
@@ -412,3 +561,38 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 		})
 	})
 })
+
+// overflowAffinitiesPlacement returns a Placement that schedules replicas to the primary cluster
+// first, spilling to the secondary overflow affinity only when the primary is at capacity. Uses
+// Aggregated division so the primary is filled before overflow triggers (Weighted would split
+// proportionally).
+func overflowAffinitiesPlacement(primary, secondary string) policyv1alpha1.Placement {
+	return policyv1alpha1.Placement{
+		ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{{
+			AffinityName: "primary",
+			ClusterAffinity: policyv1alpha1.ClusterAffinity{
+				ClusterNames: []string{primary},
+			},
+			OverflowAffinities: []policyv1alpha1.OverflowClusterAffinity{{
+				AffinityName: "secondary",
+				ClusterAffinity: policyv1alpha1.ClusterAffinity{
+					ClusterNames: []string{secondary},
+				},
+			}},
+		}},
+		ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+			ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+			ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceAggregated,
+		},
+	}
+}
+
+// clusterReplicaMap returns a name→replicas map from a ResourceBinding's cluster list.
+// Missing clusters return 0 (Go map zero value), so callers can compare directly.
+func clusterReplicaMap(rb *workv1alpha2.ResourceBinding) map[string]int32 {
+	m := make(map[string]int32, len(rb.Spec.Clusters))
+	for _, c := range rb.Spec.Clusters {
+		m[c.Name] = c.Replicas
+	}
+	return m
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

---

**What this PR does / why we need it**:

Adds E2E test coverage for Overflow Cluster Affinities. The tests verify that workloads correctly overflow to a secondary cluster when the primary cluster's `ResourceQuota` is exhausted, and that secondary replicas are reclaimed first on scale-down. Uses existing member clusters instead of freshly-joined ones, as discussed in #7390.

---

**Which issue(s) this PR fixes**:

Part of #7390

---

**Special notes for your reviewer**:

Per discussion on the issue, these tests use existing member clusters (framework.ClusterNames()[0] and [1]) rather than freshly-joined clusters. Newly-joined clusters via join.CommandJoinOption don't get a karmada-scheduler-estimator deployed — without it, calAvailableReplicas falls back to spec.Replicas, tier-0 absorbs all replicas, and overflow never triggers. Confirmed with @zhzhuang-zju .

---

**Does this PR introduce a user-facing change?**:

NONE