### PR TITLE
Change etcd to use /livez and /readyz endpoints

### DIFF
--- a/artifacts/deploy/karmada-etcd.yaml
+++ b/artifacts/deploy/karmada-etcd.yaml
@@ -39,22 +39,34 @@ spec:
           image: registry.k8s.io/etcd:3.6.6-0
           imagePullPolicy: IfNotPresent
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -ec
-                - 'etcdctl endpoint health --endpoints https://127.0.0.1:2379  --cacert /etc/karmada/pki/etcd-client/ca.crt --cert /etc/karmada/pki/etcd-client/tls.crt --key /etc/karmada/pki/etcd-client/tls.key'
-            failureThreshold: 3
-            initialDelaySeconds: 600
-            periodSeconds: 60
+            httpGet:
+              path: /livez
+              port: 2381
+              scheme: HTTP
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 2381
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 30
           ports:
             - containerPort: 2379
               name: client
               protocol: TCP
             - containerPort: 2380
               name: server
+              protocol: TCP
+            - containerPort: 2381
+              name: metrics
               protocol: TCP
           resources:
             requests:
@@ -68,6 +80,8 @@ spec:
             - http://0.0.0.0:2380
             - --listen-client-urls
             - https://0.0.0.0:2379
+            - --listen-metrics-urls
+            - http://0.0.0.0:2381
             - --advertise-client-urls
             - https://etcd-client.karmada-system.svc.cluster.local:2379
             - --initial-cluster

--- a/charts/karmada/templates/etcd.yaml
+++ b/charts/karmada/templates/etcd.yaml
@@ -48,16 +48,25 @@ spec:
           image: {{ template "karmada.internal.etcd.image" . }}
           imagePullPolicy: {{ .Values.etcd.internal.image.pullPolicy }}
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -ec
-                - 'etcdctl endpoint health --endpoints https://127.0.0.1:2379  --cacert /etc/kubernetes/pki/etcd/server-ca.crt --cert /etc/kubernetes/pki/etcd/karmada.crt --key /etc/kubernetes/pki/etcd/karmada.key'
-            failureThreshold: 3
-            initialDelaySeconds: 600
-            periodSeconds: 60
+            httpGet:
+              path: /livez
+              port: 2381
+              scheme: HTTP
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 2381
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 30
           env:
             - name: KARMADA_ETCD_NAME
               valueFrom:
@@ -69,6 +78,9 @@ spec:
               protocol: TCP
             - containerPort: 2380
               name: server
+              protocol: TCP
+            - containerPort: 2381
+              name: metrics
               protocol: TCP
           resources:
           {{- toYaml .Values.etcd.internal.resources | nindent 12 }}
@@ -86,6 +98,8 @@ spec:
             - http://0.0.0.0:2380
             - --listen-client-urls
             - https://0.0.0.0:2379
+            - --listen-metrics-urls
+            - http://0.0.0.0:2381
             - --advertise-client-urls
             - https://etcd-client.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}:2379
             - --initial-cluster

--- a/operator/pkg/controlplane/etcd/etcd.go
+++ b/operator/pkg/controlplane/etcd/etcd.go
@@ -67,10 +67,10 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 	}
 
 	etcdStatefulSetBytes, err := util.ParseTemplate(KarmadaEtcdStatefulSet, struct {
-		KarmadaInstanceName, StatefulSetName, Namespace, Image string
-		ImagePullPolicy, EtcdClientService, CertsSecretName    string
-		InitialCluster, EtcdDataVolumeName, EtcdCipherSuites   string
-		Replicas, EtcdListenClientPort, EtcdListenPeerPort     int32
+		KarmadaInstanceName, StatefulSetName, Namespace, Image              string
+		ImagePullPolicy, EtcdClientService, CertsSecretName                 string
+		InitialCluster, EtcdDataVolumeName, EtcdCipherSuites                string
+		Replicas, EtcdListenClientPort, EtcdListenPeerPort, EtcdMetricsPort int32
 	}{
 		KarmadaInstanceName:  name,
 		StatefulSetName:      util.KarmadaEtcdName(name),
@@ -85,6 +85,7 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 		Replicas:             *cfg.Replicas,
 		EtcdListenClientPort: constants.EtcdListenClientPort,
 		EtcdListenPeerPort:   constants.EtcdListenPeerPort,
+		EtcdMetricsPort:      constants.EtcdMetricsPort,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing Etcd statefuelset template: %w", err)

--- a/operator/pkg/controlplane/etcd/manifests.go
+++ b/operator/pkg/controlplane/etcd/manifests.go
@@ -52,6 +52,7 @@ spec:
         - --name=$(KARMADA_ETCD_NAME)
         - --listen-client-urls=https://0.0.0.0:{{ .EtcdListenClientPort }}
         - --listen-peer-urls=http://0.0.0.0:{{ .EtcdListenPeerPort }}
+        - --listen-metrics-urls=http://0.0.0.0:{{ .EtcdMetricsPort }}
         - --advertise-client-urls=https://{{ .EtcdClientService }}.{{ .Namespace }}.svc.cluster.local:{{ .EtcdListenClientPort }}
         - --initial-cluster={{ .InitialCluster }}
         - --initial-cluster-state=new
@@ -70,22 +71,34 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         livenessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -ec
-            - etcdctl endpoint health --endpoints https://127.0.0.1:{{ .EtcdListenClientPort }} --cacert=/etc/karmada/pki/etcd/etcd-ca.crt --cert=/etc/karmada/pki/etcd/etcd-server.crt --key=/etc/karmada/pki/etcd/etcd-server.key
-          failureThreshold: 3
-          initialDelaySeconds: 600
-          periodSeconds: 60
+          httpGet:
+            path: /livez
+            port: {{ .EtcdMetricsPort }}
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 10
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: {{ .EtcdMetricsPort }}
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 30
         ports:
         - containerPort: {{ .EtcdListenClientPort }}
           name: client
           protocol: TCP
         - containerPort: {{ .EtcdListenPeerPort }}
           name: server
+          protocol: TCP
+        - containerPort: {{ .EtcdMetricsPort }}
+          name: metrics
           protocol: TCP
         volumeMounts:
         - mountPath: /var/lib/etcd

--- a/pkg/karmadactl/cmdinit/kubernetes/command.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/command.go
@@ -38,6 +38,7 @@ func (i *CommandInitOption) defaultEtcdContainerCommand() []string {
 		fmt.Sprintf("--name=$(%s)", etcdEnvPodName),
 		fmt.Sprintf("--listen-peer-urls=http://$(%s):%v", etcdEnvPodIP, etcdContainerServerPort),
 		fmt.Sprintf("--listen-client-urls=https://$(%s):%v,http://127.0.0.1:%v", etcdEnvPodIP, etcdContainerClientPort, etcdContainerClientPort),
+		fmt.Sprintf("--listen-metrics-urls=http://$(%s):%v", etcdEnvPodIP, etcdContainerMetricsPort),
 		fmt.Sprintf("--advertise-client-urls=https://$(%s).%s.%s.svc.%s:%v", etcdEnvPodName, etcdStatefulSetAndServiceName, i.Namespace, i.HostClusterDomain, etcdContainerClientPort),
 		fmt.Sprintf("--initial-cluster=%s", strings.TrimRight(etcdClusterConfig.String(), ",")),
 		"--initial-cluster-state=new",

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
@@ -17,13 +17,13 @@ limitations under the License.
 package kubernetes
 
 import (
-	"fmt"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/component-base/cli/flag"
 	"k8s.io/utils/ptr"
 )
@@ -36,6 +36,8 @@ const (
 	etcdContainerClientPort            = 2379
 	etcdContainerServerPortName        = "server"
 	etcdContainerServerPort            = 2380
+	etcdContainerMetricsPortName       = "metrics"
+	etcdContainerMetricsPort           = 2381
 	etcdContainerDataVolumeMountName   = "etcd-data"
 	etcdContainerDataVolumeMountPath   = "/var/lib/karmada-etcd"
 	etcdContainerConfigVolumeMountName = "etcd-config"
@@ -142,34 +144,34 @@ func (i *CommandInitOption) makeETCDStatefulSet() *appsv1.StatefulSet {
 	}
 
 	// Probes
-	livenesProbe := &corev1.Probe{
+	livenessProbe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{
-					"/bin/sh",
-					"-ec",
-					fmt.Sprintf("etcdctl endpoint health --endpoints http://127.0.0.1:%v", etcdContainerClientPort),
-				},
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/livez",
+				Port:   intstr.FromInt(etcdContainerMetricsPort),
+				Scheme: corev1.URISchemeHTTP,
 			},
 		},
-		InitialDelaySeconds: 15,
-		FailureThreshold:    3,
-		PeriodSeconds:       60,
+		InitialDelaySeconds: 60,
 		TimeoutSeconds:      5,
+		PeriodSeconds:       10,
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
 	}
-	/*	readinesProbe := &corev1.Probe{
-		Handler: corev1.Handler{
-			TCPSocket: &corev1.TCPSocketAction{
-				Port: intstr.IntOrString{
-					IntVal: etcdContainerClientPort,
-				},
+	readinessProbe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/readyz",
+				Port:   intstr.FromInt(etcdContainerMetricsPort),
+				Scheme: corev1.URISchemeHTTP,
 			},
 		},
-		InitialDelaySeconds: 5,
-		FailureThreshold:    3,
-		PeriodSeconds:       30,
+		InitialDelaySeconds: 10,
 		TimeoutSeconds:      5,
-	}*/
+		PeriodSeconds:       5,
+		SuccessThreshold:    1,
+		FailureThreshold:    30,
+	}
 
 	// etcd Container
 	podSpec := corev1.PodSpec{
@@ -213,6 +215,11 @@ func (i *CommandInitOption) makeETCDStatefulSet() *appsv1.StatefulSet {
 						ContainerPort: etcdContainerServerPort,
 						Protocol:      corev1.ProtocolTCP,
 					},
+					{
+						Name:          etcdContainerMetricsPortName,
+						ContainerPort: etcdContainerMetricsPort,
+						Protocol:      corev1.ProtocolTCP,
+					},
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -231,8 +238,8 @@ func (i *CommandInitOption) makeETCDStatefulSet() *appsv1.StatefulSet {
 						MountPath: karmadaCertsVolumeMountPath,
 					},
 				},
-				LivenessProbe: livenesProbe,
-				//ReadinessProbe: readinesProbe,
+				LivenessProbe:  livenessProbe,
+				ReadinessProbe: readinessProbe,
 				Env: []corev1.EnvVar{
 					{
 						Name: etcdEnvPodName,


### PR DESCRIPTION
This PR backports #7381 to release-1.17, addressing the etcd health check failure caused by the removal of /bin/sh in newer etcd images.

Changes:
- Replace exec-based etcd liveness/readiness probes with HTTP /livez and /readyz endpoints
- Add metrics port 2381 declaration and --listen-metrics-urls flag
- Keep the same probe timing configuration as the original PR

Related issues:
- Fixes #7380
- Tracks #7490