### PR TITLE
Performing Cluster-level assumption deduction in GeneralEstimator

### DIFF
--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -107,26 +107,33 @@ func (ge *GeneralEstimator) maxAvailableReplicas(cluster *clusterv1alpha1.Cluste
 func (ge *GeneralEstimator) MaxAvailableComponentSets(_ context.Context, req ComponentSetEstimationRequest) ([]ComponentSetEstimationResponse, error) {
 	responses := make([]ComponentSetEstimationResponse, len(req.Clusters))
 	for i, cluster := range req.Clusters {
-		maxComponentSets := ge.maxAvailableComponentSets(cluster, req.Components)
+		maxComponentSets := ge.maxAvailableComponentSets(cluster, req.Components, req.AssumedWorkloads[cluster.Name])
 		responses[i] = ComponentSetEstimationResponse{Name: cluster.Name, Sets: maxComponentSets}
 	}
 	return responses, nil
 }
 
-func (ge *GeneralEstimator) maxAvailableComponentSets(cluster *clusterv1alpha1.Cluster, components []workv1alpha2.Component) int32 {
+func (ge *GeneralEstimator) maxAvailableComponentSets(cluster *clusterv1alpha1.Cluster, components []workv1alpha2.Component, assumedWorkloads []AssumedWorkload) int32 {
 	resourceSummary := cluster.Status.ResourceSummary.DeepCopy()
 	if resourceSummary == nil {
 		return 0
 	}
 
-	// Aggregate per-set resource requirements
-	perSet := perSetRequirement(components)
-
-	// Check pod constraint
 	available := availableResourceMap(resourceSummary)
 	allowedPods := getAllowedPodNumber(resourceSummary)
 	if allowedPods <= 0 {
 		return 0
+	}
+
+	// Deduct assumed workloads from cluster-wide available resources.
+	// GeneralEstimator has no per-node view, so cluster-level aggregate deduction is used as a
+	// fallback: accumulate each assumed component's Replicas × ResourceRequest, subtract from the
+	// available resource map, and also reduce the allowed pod budget.
+	if len(assumedWorkloads) > 0 {
+		allowedPods, available = deductAssumedWorkloads(allowedPods, available, assumedWorkloads)
+		if allowedPods <= 0 {
+			return 0
+		}
 	}
 
 	podsPerSet := podsInSet(components)
@@ -136,36 +143,66 @@ func (ge *GeneralEstimator) maxAvailableComponentSets(cluster *clusterv1alpha1.C
 	}
 
 	podBound := int32(allowedPods / podsPerSet) // #nosec G115: integer overflow conversion int64 -> int32
-	if len(perSet) == 0 || allZero(perSet) {
-		return podBound
+
+	perSet := perSetRequirement(components)
+	maxSets, ok := resourceBoundedSets(podBound, perSet, available)
+	if !ok {
+		return 0
 	}
 
-	// Find limiting resource requirement, which will bound maxSet calculation
+	return applyResourceModelBound(cluster, components, maxSets)
+}
+
+// deductAssumedWorkloads subtracts the resource demands of assumed workloads from the
+// pod budget and available resource map, returning the updated values.
+func deductAssumedWorkloads(allowedPods int64, available map[corev1.ResourceName]int64, assumedWorkloads []AssumedWorkload) (int64, map[corev1.ResourceName]int64) {
+	assumedPods, assumedResources := sumAssumedWorkloadDemands(assumedWorkloads)
+	allowedPods -= assumedPods
+	for resName, qty := range assumedResources {
+		available[resName] -= qty
+	}
+	return allowedPods, available
+}
+
+// resourceBoundedSets returns the maximum number of component sets that fit within the
+// available resource map, starting from podBound as the upper limit.
+// Returns (maxSets, true) on success, or (0, false) when any resource is exhausted.
+func resourceBoundedSets(podBound int32, perSet map[corev1.ResourceName]int64, available map[corev1.ResourceName]int64) (int32, bool) {
+	if len(perSet) == 0 || allZero(perSet) {
+		return podBound, true
+	}
 	maxSets := podBound
 	for resName, req := range perSet {
 		if req <= 0 {
 			continue
 		}
-
-		resAvail := available[resName]
-		if resAvail <= 0 {
-			return 0 // no capacity for this resource
+		if available[resName] <= 0 {
+			return 0, false
 		}
 
-		resBound := int32(resAvail / req) // #nosec G115: integer overflow conversion int64 -> int32
+		resBound := int32(available[resName] / req) // #nosec G115: integer overflow conversion int64 -> int32
 		if resBound < maxSets {
 			maxSets = resBound
 		}
 	}
+	return maxSets, true
+}
 
-	if features.FeatureGate.Enabled(features.CustomizedClusterResourceModeling) && len(cluster.Status.ResourceSummary.AllocatableModelings) > 0 {
-		if num, err := getMaximumSetsBasedOnResourceModels(cluster, components, maxSets); err != nil {
-			klog.Warningf("Failed to get maximum sets based on resource models, skipping: %v", err)
-		} else if num < maxSets {
-			maxSets = num
-		}
+// applyResourceModelBound refines maxSets using cluster ResourceModels when the feature is
+// enabled and model data is available.  Returns the original maxSets if the feature is off
+// or the model-based calculation fails.
+func applyResourceModelBound(cluster *clusterv1alpha1.Cluster, components []workv1alpha2.Component, maxSets int32) int32 {
+	if !features.FeatureGate.Enabled(features.CustomizedClusterResourceModeling) || len(cluster.Status.ResourceSummary.AllocatableModelings) == 0 {
+		return maxSets
 	}
-
+	num, err := getMaximumSetsBasedOnResourceModels(cluster, components, maxSets)
+	if err != nil {
+		klog.Warningf("Failed to get maximum sets based on resource models, skipping: %v", err)
+		return maxSets
+	}
+	if num < maxSets {
+		return num
+	}
 	return maxSets
 }
 
@@ -271,6 +308,26 @@ func podsInSet(components []workv1alpha2.Component) int64 {
 		sum += int64(c.Replicas)
 	}
 	return sum
+}
+
+// sumAssumedWorkloadDemands computes the total pod count and aggregate per-resource demand
+// across all assumed workloads. GeneralEstimator uses this to deduct reserved capacity from
+// the cluster-wide available budget before estimating the remaining component-set count.
+func sumAssumedWorkloadDemands(assumedWorkloads []AssumedWorkload) (pods int64, resources map[corev1.ResourceName]int64) {
+	resources = make(map[corev1.ResourceName]int64)
+	for _, aw := range assumedWorkloads {
+		for _, c := range aw.Components {
+			replicas := int64(c.Replicas)
+			pods += replicas
+			if c.ReplicaRequirements == nil {
+				continue
+			}
+			for resName, qty := range c.ReplicaRequirements.ResourceRequest {
+				resources[resName] += quantityAsInt64(qty) * replicas
+			}
+		}
+	}
+	return pods, resources
 }
 
 // perSetRequirement computes the aggregate resource(such as CPU, Memory, GPU, etc) demand of one set of components.

--- a/pkg/estimator/client/general_test.go
+++ b/pkg/estimator/client/general_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
@@ -1330,8 +1331,272 @@ func TestGetMaxAvailableComponentSetsGeneral(t *testing.T) {
 	estimator := NewGeneralEstimator()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := estimator.maxAvailableComponentSets(tt.cluster, tt.components)
+			result := estimator.maxAvailableComponentSets(tt.cluster, tt.components, nil)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestMaxAvailableComponentSets_AssumedWorkloadDeduction(t *testing.T) {
+	// Base cluster: 100 pods, 10 CPU, 8Gi memory available.
+	baseCluster := func(cpuAlloc, memAllocGi string) *clusterv1alpha1.Cluster {
+		return &clusterv1alpha1.Cluster{
+			Status: clusterv1alpha1.ClusterStatus{
+				ResourceSummary: &clusterv1alpha1.ResourceSummary{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourcePods:   resource.MustParse("100"),
+						corev1.ResourceCPU:    resource.MustParse(cpuAlloc),
+						corev1.ResourceMemory: resource.MustParse(memAllocGi),
+					},
+				},
+			},
+		}
+	}
+
+	// Component set: 1 jobmanager (1 CPU) + 2 taskmanagers (1.5 CPU each) = 4 CPU per set
+	finkComponents := []workv1alpha2.Component{
+		{
+			Name:     "jobmanager",
+			Replicas: 1,
+			ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+				ResourceRequest: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+		},
+		{
+			Name:     "taskmanager",
+			Replicas: 2,
+			ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+				ResourceRequest: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1500m"),
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		cluster          *clusterv1alpha1.Cluster
+		components       []workv1alpha2.Component
+		assumedWorkloads []AssumedWorkload
+		expected         int32
+	}{
+		{
+			name:       "no assumed workloads — baseline unchanged",
+			cluster:    baseCluster("10", "8Gi"),
+			components: finkComponents,
+			// 10 CPU / 4 CPU-per-set = 2 sets
+			expected: 2,
+		},
+		{
+			name:       "assumed workload deducts CPU, reduces set count",
+			cluster:    baseCluster("10", "8Gi"),
+			components: finkComponents,
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Namespace: "ns",
+					Components: []workv1alpha2.Component{
+						{
+							Name:     "jobmanager",
+							Replicas: 1,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name:     "taskmanager",
+							Replicas: 2,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("1500m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			// Assumed uses 4 CPU → remaining 6 CPU / 4 per-set = 1 set
+			expected: 1,
+		},
+		{
+			name:       "assumed workload exhausts all CPU → 0 sets",
+			cluster:    baseCluster("8", "8Gi"),
+			components: finkComponents,
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Namespace: "ns",
+					Components: []workv1alpha2.Component{
+						{
+							Name:     "taskmanager",
+							Replicas: 4,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			// Assumed uses 8 CPU → 0 remaining → 0 sets
+			expected: 0,
+		},
+		{
+			name: "assumed workload exhausts pod budget → 0 sets",
+			cluster: &clusterv1alpha1.Cluster{
+				Status: clusterv1alpha1.ClusterStatus{
+					ResourceSummary: &clusterv1alpha1.ResourceSummary{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourcePods: resource.MustParse("3"),
+							corev1.ResourceCPU:  resource.MustParse("100"),
+						},
+					},
+				},
+			},
+			components: finkComponents, // 3 pods per set
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Components: []workv1alpha2.Component{
+						{Name: "worker", Replicas: 3},
+					},
+				},
+			},
+			// 3 pods assumed, 0 remaining → 0 sets
+			expected: 0,
+		},
+		{
+			name:       "multiple assumed workloads — cumulative deduction",
+			cluster:    baseCluster("12", "8Gi"),
+			components: finkComponents,
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Namespace: "ns-a",
+					Components: []workv1alpha2.Component{
+						{
+							Name:     "jobmanager",
+							Replicas: 1,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+				{
+					Namespace: "ns-b",
+					Components: []workv1alpha2.Component{
+						{
+							Name:     "taskmanager",
+							Replicas: 2,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("1500m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			// Assumed total: 1 CPU + 3 CPU = 4 CPU → remaining 8 CPU / 4 per-set = 2 sets
+			expected: 2,
+		},
+		{
+			name:       "assumed workload with no resource requirements — only pod deduction",
+			cluster:    baseCluster("10", "8Gi"),
+			components: finkComponents,
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Components: []workv1alpha2.Component{
+						{Name: "no-req-worker", Replicas: 3},
+					},
+				},
+			},
+			// Pods: 100 - 3 = 97; 97/3 = 32 pod-bound sets; CPU: 10/4 = 2 sets → min = 2
+			expected: 2,
+		},
+	}
+
+	ge := NewGeneralEstimator()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ge.maxAvailableComponentSets(tt.cluster, tt.components, tt.assumedWorkloads)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestMaxAvailableComponentSets_PerClusterRouting verifies that AssumedWorkloads are routed
+// per-cluster: each cluster only sees its own assumed workloads, not those of other clusters.
+func TestMaxAvailableComponentSets_PerClusterRouting(t *testing.T) {
+	// Both clusters have identical capacity: 100 pods, 8 CPU.
+	makeCluster := func(name string) *clusterv1alpha1.Cluster {
+		return &clusterv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status: clusterv1alpha1.ClusterStatus{
+				ResourceSummary: &clusterv1alpha1.ResourceSummary{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourcePods: resource.MustParse("100"),
+						corev1.ResourceCPU:  resource.MustParse("8"),
+					},
+				},
+			},
+		}
+	}
+
+	// 1 set = 4 CPU; 8 CPU → 2 sets without any assumed workloads.
+	components := []workv1alpha2.Component{
+		{
+			Name:     "worker",
+			Replicas: 2,
+			ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+				ResourceRequest: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+		},
+	}
+
+	// Only cluster-a has 4 CPU assumed; cluster-b has none.
+	assumed4CPU := []AssumedWorkload{
+		{
+			Components: []workv1alpha2.Component{
+				{
+					Name:     "assumed-worker",
+					Replicas: 2,
+					ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	req := ComponentSetEstimationRequest{
+		Clusters:   []*clusterv1alpha1.Cluster{makeCluster("cluster-a"), makeCluster("cluster-b")},
+		Components: components,
+		AssumedWorkloads: map[string][]AssumedWorkload{
+			"cluster-a": assumed4CPU,
+			// cluster-b intentionally absent
+		},
+	}
+
+	ge := NewGeneralEstimator()
+	resp, err := ge.MaxAvailableComponentSets(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Len(t, resp, 2)
+
+	byName := map[string]int32{}
+	for _, r := range resp {
+		byName[r.Name] = r.Sets
+	}
+	// cluster-a: 8 CPU - 4 assumed = 4 remaining → 4/4 = 1 set
+	assert.Equal(t, int32(1), byName["cluster-a"], "cluster-a should have 1 set after deduction")
+	// cluster-b: no assumptions → 8/4 = 2 sets
+	assert.Equal(t, int32(2), byName["cluster-b"], "cluster-b should have 2 sets (unaffected)")
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Performing Cluster-level assumption deduction in `GeneralEstimator`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7481 

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

