### PR TITLE
Add assumedWorkloads to estimator server framework

### DIFF
--- a/pkg/estimator/server/estimate.go
+++ b/pkg/estimator/server/estimate.go
@@ -24,6 +24,7 @@ import (
 	utiltrace "k8s.io/utils/trace"
 
 	"github.com/karmada-io/karmada/pkg/estimator/pb"
+	"github.com/karmada-io/karmada/pkg/estimator/server/framework"
 	schedcache "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/cache"
 )
 
@@ -81,7 +82,12 @@ func (es *AccurateSchedulerEstimatorServer) EstimateComponents(ctx context.Conte
 		return 0, nil
 	}
 
-	maxAvailableComponentSets, err := es.estimateComponents(ctx, snapShot, request.Components, request.Namespace)
+	maxAvailableComponentSets, err := es.estimateComponents(ctx, framework.ComponentEstimationContext{
+		Snapshot:         snapShot,
+		Components:       request.Components,
+		Namespace:        request.Namespace,
+		AssumedWorkloads: request.GetAssumedWorkloads(),
+	})
 	if err != nil {
 		return 0, err
 	}
@@ -90,8 +96,8 @@ func (es *AccurateSchedulerEstimatorServer) EstimateComponents(ctx context.Conte
 	return maxAvailableComponentSets, nil
 }
 
-func (es *AccurateSchedulerEstimatorServer) estimateComponents(ctx context.Context, snapshot *schedcache.Snapshot, components []*pb.Component, namespace string) (int32, error) {
-	maxSets, ret := es.estimateFramework.RunEstimateComponentsPlugins(ctx, snapshot, components, namespace)
+func (es *AccurateSchedulerEstimatorServer) estimateComponents(ctx context.Context, estCtx framework.ComponentEstimationContext) (int32, error) {
+	maxSets, ret := es.estimateFramework.RunEstimateComponentsPlugins(ctx, estCtx)
 
 	// No replicas can be scheduled on the cluster, skip further checks and return 0
 	if ret.IsUnschedulable() {

--- a/pkg/estimator/server/framework/interface.go
+++ b/pkg/estimator/server/framework/interface.go
@@ -39,12 +39,12 @@ type Framework interface {
 	// It is merged from all plugins' returned result codes.
 	RunEstimateReplicasPlugins(ctx context.Context, snapshot *schedcache.Snapshot, replicaRequirements *pb.ReplicaRequirements) (int32, *Result)
 	// RunEstimateComponentsPlugins runs the set of configured EstimateComponentsPlugins
-	// for estimating the maximum number of complete component sets based on the given components.
+	// for estimating the maximum number of complete component sets based on the given estCtx.
 	// It returns an integer and a Result.
 	// The integer represents the minimum calculated value of estimated component sets from each EstimateComponentsPlugin.
 	// The Result contains code, reasons and error.
 	// It is merged from all plugins' returned result codes.
-	RunEstimateComponentsPlugins(ctx context.Context, snapshot *schedcache.Snapshot, components []*pb.Component, namespace string) (int32, *Result)
+	RunEstimateComponentsPlugins(ctx context.Context, estCtx ComponentEstimationContext) (int32, *Result)
 	// TODO(wengyao04): we can add filter and score plugin extension points if needed in the future
 }
 
@@ -75,7 +75,20 @@ type EstimateComponentsPlugin interface {
 	// The integer represents the estimated number of complete component sets that can be scheduled.
 	// The Result contains code, reasons and error.
 	// It is merged from all plugins' returned result codes.
-	EstimateComponents(ctx context.Context, snapshot *schedcache.Snapshot, components []*pb.Component, namespace string) (int32, *Result)
+	EstimateComponents(ctx context.Context, estCtx ComponentEstimationContext) (int32, *Result)
+}
+
+// ComponentEstimationContext contains the business context required by component-set estimators.
+// It intentionally keeps framework/plugin interfaces decoupled from transport-level request objects.
+type ComponentEstimationContext struct {
+	// Snapshot is the scheduler cache snapshot used for estimation.
+	Snapshot *schedcache.Snapshot
+	// Components is the workload component template of one complete set.
+	Components []*pb.Component
+	// Namespace is the workload namespace (used by quota-aware plugins).
+	Namespace string
+	// AssumedWorkloads are in-flight workloads already assigned to this target cluster.
+	AssumedWorkloads []*pb.AssumedWorkload
 }
 
 // Handle provides data and some tools that plugins can use. It is

--- a/pkg/estimator/server/framework/plugins/noderesource/noderesource.go
+++ b/pkg/estimator/server/framework/plugins/noderesource/noderesource.go
@@ -127,17 +127,18 @@ func getNodeAvailableResource(node *schedulerframework.NodeInfo) *util.Resource 
 
 // EstimateComponents estimates the maximum number of complete component sets that can be scheduled.
 // It returns the number of sets that can fit on the available node resources.
-func (pl *nodeResourceEstimator) EstimateComponents(_ context.Context, snapshot *schedcache.Snapshot, components []*pb.Component, _ string) (int32, *framework.Result) {
+func (pl *nodeResourceEstimator) EstimateComponents(_ context.Context, estCtx framework.ComponentEstimationContext) (int32, *framework.Result) {
 	if !pl.enabled {
 		return pl.disabledResult()
 	}
 
+	components := estCtx.Components
 	if len(components) == 0 {
 		klog.V(5).Infof("%s: received empty components list", pl.Name())
 		return noNodeConstraint, framework.NewResult(framework.Noopperation, fmt.Sprintf("%s received empty components list", pl.Name()))
 	}
 
-	nodes, err := getNodesAvailableResources(snapshot)
+	nodes, err := getNodesAvailableResources(estCtx.Snapshot)
 	if err != nil {
 		return 0, framework.AsResult(err)
 	}

--- a/pkg/estimator/server/framework/plugins/noderesource/noderesource_test.go
+++ b/pkg/estimator/server/framework/plugins/noderesource/noderesource_test.go
@@ -327,7 +327,10 @@ func TestNodeResourceEstimator_EstimateComponents(t *testing.T) {
 			}
 
 			// Execute test
-			result, status := pl.EstimateComponents(context.Background(), snapshot, tt.components, "")
+			result, status := pl.EstimateComponents(context.Background(), framework.ComponentEstimationContext{
+				Snapshot:   snapshot,
+				Components: tt.components,
+			})
 
 			// Verify results
 			if result != tt.expected {

--- a/pkg/estimator/server/framework/plugins/resourcequota/resourcequota.go
+++ b/pkg/estimator/server/framework/plugins/resourcequota/resourcequota.go
@@ -143,17 +143,19 @@ func (pl *resourceQuotaEstimator) Estimate(_ context.Context, _ *schedcache.Snap
 // selectors (e.g., priorityClassName), aggregates their resource requirements, and calculates how
 // many complete component sets can fit within the quota. The function returns the minimum allowed
 // sets across all ResourceQuotas to ensure all quota constraints are satisfied.
-func (pl *resourceQuotaEstimator) EstimateComponents(_ context.Context, _ *schedcache.Snapshot, components []*pb.Component, namespace string) (int32, *framework.Result) {
+func (pl *resourceQuotaEstimator) EstimateComponents(_ context.Context, estCtx framework.ComponentEstimationContext) (int32, *framework.Result) {
 	if !pl.enabled {
 		klog.V(5).Info("Estimator Plugin", "name", Name, "enabled", pl.enabled)
 		return noQuotaConstraint, framework.NewResult(framework.Noopperation, fmt.Sprintf("%s is disabled", pl.Name()))
 	}
 
+	components := estCtx.Components
 	if len(components) == 0 {
 		klog.V(5).Infof("%s: components list is empty, skipping resource quota check", pl.Name())
 		return noQuotaConstraint, framework.NewResult(framework.Success, fmt.Sprintf("%s received empty components list", pl.Name()))
 	}
 
+	namespace := estCtx.Namespace
 	if namespace == "" {
 		klog.V(5).Infof("%s: namespace is empty, skipping resource quota check", pl.Name())
 		return noQuotaConstraint, framework.NewResult(framework.Success)

--- a/pkg/estimator/server/framework/plugins/resourcequota/resourcequota_test.go
+++ b/pkg/estimator/server/framework/plugins/resourcequota/resourcequota_test.go
@@ -1058,7 +1058,10 @@ func TestResourceQuotaEstimator_EstimateComponents(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			testCtx := setup(t, tt.resourceQuotaList, tt.enabled)
-			sets, ret := testCtx.p.EstimateComponents(testCtx.ctx, nil, tt.components, tt.namespace)
+			sets, ret := testCtx.p.EstimateComponents(testCtx.ctx, framework.ComponentEstimationContext{
+				Components: tt.components,
+				Namespace:  tt.namespace,
+			})
 
 			require.Equal(t, tt.expect.ret.Code(), ret.Code())
 			assert.ElementsMatch(t, tt.expect.ret.Reasons(), ret.Reasons())

--- a/pkg/estimator/server/framework/runtime/framework.go
+++ b/pkg/estimator/server/framework/runtime/framework.go
@@ -178,10 +178,11 @@ func (frw *frameworkImpl) runEstimateReplicasPlugins(
 }
 
 // RunEstimateComponentsPlugins runs the set of configured EstimateComponentsPlugins
-// for estimating the maximum number of complete component sets based on the given components.
+// for estimating the maximum number of complete component sets based on the given
+// components estimation request, including its components, namespace, and assumptions.
 // It returns an integer and a Result.
 // The integer represents the minimum calculated value of estimated component sets from each EstimateComponentsPlugin.
-func (frw *frameworkImpl) RunEstimateComponentsPlugins(ctx context.Context, snapshot *schedcache.Snapshot, components []*pb.Component, namespace string) (int32, *framework.Result) {
+func (frw *frameworkImpl) RunEstimateComponentsPlugins(ctx context.Context, estCtx framework.ComponentEstimationContext) (int32, *framework.Result) {
 	startTime := time.Now()
 	defer func() {
 		metrics.FrameworkExtensionPointDuration.WithLabelValues(estimateComponentsExtension).Observe(utilmetrics.DurationInSeconds(startTime))
@@ -189,7 +190,7 @@ func (frw *frameworkImpl) RunEstimateComponentsPlugins(ctx context.Context, snap
 	var sets int32 = math.MaxInt32
 	results := make(framework.PluginToResult)
 	for _, pl := range frw.estimateComponentsPlugins {
-		plSets, ret := frw.runEstimateComponentsPlugins(ctx, pl, snapshot, components, namespace)
+		plSets, ret := frw.runEstimateComponentsPlugins(ctx, pl, estCtx)
 		if (ret.IsSuccess() || ret.IsUnschedulable()) && plSets < sets {
 			sets = plSets
 		}
@@ -198,9 +199,9 @@ func (frw *frameworkImpl) RunEstimateComponentsPlugins(ctx context.Context, snap
 	return sets, results.Merge()
 }
 
-func (frw *frameworkImpl) runEstimateComponentsPlugins(ctx context.Context, pl framework.EstimateComponentsPlugin, snapshot *schedcache.Snapshot, components []*pb.Component, namespace string) (int32, *framework.Result) {
+func (frw *frameworkImpl) runEstimateComponentsPlugins(ctx context.Context, pl framework.EstimateComponentsPlugin, estCtx framework.ComponentEstimationContext) (int32, *framework.Result) {
 	startTime := time.Now()
-	sets, ret := pl.EstimateComponents(ctx, snapshot, components, namespace)
+	sets, ret := pl.EstimateComponents(ctx, estCtx)
 	metrics.PluginExecutionDuration.WithLabelValues(pl.Name(), estimateComponentsExtension).Observe(utilmetrics.DurationInSeconds(startTime))
 	return sets, ret
 }

--- a/pkg/estimator/server/framework/runtime/framework_test.go
+++ b/pkg/estimator/server/framework/runtime/framework_test.go
@@ -59,7 +59,7 @@ func (pl *TestPlugin) Estimate(_ context.Context, _ *schedcache.Snapshot, _ *pb.
 	return pl.inj.estimateReplicaResult.replica, pl.inj.estimateReplicaResult.ret
 }
 
-func (pl *TestPlugin) EstimateComponents(_ context.Context, _ *schedcache.Snapshot, _ []*pb.Component, _ string) (int32, *framework.Result) {
+func (pl *TestPlugin) EstimateComponents(_ context.Context, _ framework.ComponentEstimationContext) (int32, *framework.Result) {
 	return pl.inj.estimateComponentsResult.sets, pl.inj.estimateComponentsResult.ret
 }
 
@@ -452,7 +452,9 @@ func Test_frameworkImpl_RunEstimateComponentsPlugins(t *testing.T) {
 			if err != nil {
 				t.Errorf("create frame work error:%v", err)
 			}
-			sets, ret := f.RunEstimateComponentsPlugins(ctx, nil, []*pb.Component{}, "")
+			sets, ret := f.RunEstimateComponentsPlugins(ctx, framework.ComponentEstimationContext{
+				Components: []*pb.Component{},
+			})
 
 			require.Equal(t, tt.expected.ret.Code(), ret.Code())
 			assert.ElementsMatch(t, tt.expected.ret.Reasons(), ret.Reasons())


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Add `assumedWrokloads` to estimator server framework.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7481

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-scheduler-estimator`: Replaced input parameters in RunEstimateComponentsPlugins with a single structure ComponentEstimationContext. 
```

