### PR TITLE
Thread AssumeWorkloads into calculateMultiTemplateAvailableSets

### DIFF
--- a/pkg/estimator/client/interface.go
+++ b/pkg/estimator/client/interface.go
@@ -66,12 +66,12 @@ type ComponentSetEstimationRequest struct {
 	// It is used by the accurate estimator to check the quota configurations
 	// in the target member cluster. This field is required for quota-aware estimation.
 	Namespace string
-	// AssumedWorkloads lists in-flight workloads that have already been assigned
-	// to a cluster but whose pods have not yet been bound to nodes.
-	// The estimator deducts their resource footprint from the available capacity
+	// AssumedWorkloads maps cluster name to the in-flight workloads that have already
+	// been assigned to that cluster but whose pods have not yet been bound to nodes.
+	// The estimator deducts each cluster's assumed footprint from available capacity
 	// to avoid over-commitment during back-to-back scheduling cycles.
 	// +optional
-	AssumedWorkloads []AssumedWorkload
+	AssumedWorkloads map[string][]AssumedWorkload
 }
 
 // ComponentSetEstimationResponse represents how many complete component sets a cluster can accommodate.

--- a/pkg/scheduler/core/common.go
+++ b/pkg/scheduler/core/common.go
@@ -20,19 +20,24 @@ import (
 	"fmt"
 	"time"
 
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	schedulercache "github.com/karmada-io/karmada/pkg/scheduler/cache"
 	"github.com/karmada-io/karmada/pkg/scheduler/core/spreadconstraint"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework"
 	"github.com/karmada-io/karmada/pkg/scheduler/metrics"
 )
 
 // SelectClusters selects clusters based on the placement and resource binding spec.
-func SelectClusters(clustersScore framework.ClusterScoreList, placement *policyv1alpha1.Placement, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus) ([]spreadconstraint.ClusterDetailInfo, error) {
+func SelectClusters(clustersScore framework.ClusterScoreList, placement *policyv1alpha1.Placement, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus, assigningCache *schedulercache.AssigningResourceBindingCache) ([]spreadconstraint.ClusterDetailInfo, error) {
 	startTime := time.Now()
 	defer metrics.ScheduleStep(metrics.ScheduleStepSelect, startTime)
 
-	groupClustersInfo := spreadconstraint.GroupClustersWithScore(clustersScore, placement, spec, status, calAvailableReplicas)
+	calAvailableReplicasFunc := func(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha2.ResourceBindingSpec) []workv1alpha2.TargetCluster {
+		return calAvailableReplicas(clusters, spec, assigningCache)
+	}
+	groupClustersInfo := spreadconstraint.GroupClustersWithScore(clustersScore, placement, spec, status, calAvailableReplicasFunc)
 	return spreadconstraint.SelectBestClusters(placement, groupClustersInfo, spec.Replicas)
 }
 

--- a/pkg/scheduler/core/common_test.go
+++ b/pkg/scheduler/core/common_test.go
@@ -151,7 +151,7 @@ func TestSelectClusters(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.spec.Placement = tt.placement
-			result, err := SelectClusters(tt.clustersScore, tt.placement, tt.spec, tt.status)
+			result, err := SelectClusters(tt.clustersScore, tt.placement, tt.spec, tt.status, nil)
 
 			if tt.expectedError {
 				assert.Error(t, err)

--- a/pkg/scheduler/core/estimation.go
+++ b/pkg/scheduler/core/estimation.go
@@ -25,6 +25,7 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	estimatorclient "github.com/karmada-io/karmada/pkg/estimator/client"
+	schedulercache "github.com/karmada-io/karmada/pkg/scheduler/cache"
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
@@ -63,21 +64,31 @@ func isMultiTemplateSchedulingApplicable(spec *workv1alpha2.ResourceBindingSpec)
 	return false
 }
 
+type multiTemplateEstimationContext struct {
+	estimator               estimatorclient.ReplicaEstimator
+	estimatorName           string
+	clusters                []*clusterv1alpha1.Cluster
+	spec                    *workv1alpha2.ResourceBindingSpec
+	availableTargetClusters []workv1alpha2.TargetCluster
+	assigningCache          *schedulercache.AssigningResourceBindingCache
+}
+
 // calculateMultiTemplateAvailableSets calculates available sets for multi-template scheduling.
 // It uses MaxAvailableComponentSets to estimate capacity for workloads with multiple pod templates.
-func calculateMultiTemplateAvailableSets(ctx context.Context, estimator estimatorclient.ReplicaEstimator, name string, clusters []*clusterv1alpha1.Cluster, spec *workv1alpha2.ResourceBindingSpec, availableTargetClusters []workv1alpha2.TargetCluster) ([]workv1alpha2.TargetCluster, error) {
+func calculateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTemplateEstimationContext) ([]workv1alpha2.TargetCluster, error) {
 	req := estimatorclient.ComponentSetEstimationRequest{
-		Clusters:   clusters,
-		Components: spec.Components,
-		Namespace:  spec.Resource.Namespace,
+		Clusters:         estCtx.clusters,
+		Components:       estCtx.spec.Components,
+		Namespace:        estCtx.spec.Resource.Namespace,
+		AssumedWorkloads: buildAssumedWorkloadsByCluster(estCtx.clusters, estCtx.assigningCache),
 	}
 
-	namespacedKey := names.NamespacedKey(spec.Resource.Namespace, spec.Resource.Name)
-	resp, err := estimator.MaxAvailableComponentSets(ctx, req)
+	namespacedKey := names.NamespacedKey(estCtx.spec.Resource.Namespace, estCtx.spec.Resource.Name)
+	resp, err := estCtx.estimator.MaxAvailableComponentSets(ctx, req)
 	if err != nil {
 		klog.Errorf("Failed to calculate available component set with estimator(%s) for workload(%s, kind=%s, %s): %v",
-			name, spec.Resource.APIVersion, spec.Resource.Kind, namespacedKey, err)
-		return availableTargetClusters, err
+			estCtx.estimatorName, estCtx.spec.Resource.APIVersion, estCtx.spec.Resource.Kind, namespacedKey, err)
+		return estCtx.availableTargetClusters, err
 	}
 
 	// Use a map to safely update replicas regardless of order.
@@ -88,6 +99,8 @@ func calculateMultiTemplateAvailableSets(ctx context.Context, estimator estimato
 		}
 		resMap[resp[i].Name] = resp[i].Sets
 	}
+
+	availableTargetClusters := estCtx.availableTargetClusters
 	for i := range availableTargetClusters {
 		if newReplicas, ok := resMap[availableTargetClusters[i].Name]; ok {
 			if availableTargetClusters[i].Replicas > newReplicas {
@@ -95,9 +108,35 @@ func calculateMultiTemplateAvailableSets(ctx context.Context, estimator estimato
 			}
 		} else {
 			klog.Warningf("The estimator(%s) missed estimation from cluster(%s) when estimating for workload(%s, kind=%s, %s).",
-				name, availableTargetClusters[i].Name, spec.Resource.APIVersion, spec.Resource.Kind, namespacedKey)
+				estCtx.estimatorName, availableTargetClusters[i].Name, estCtx.spec.Resource.APIVersion, estCtx.spec.Resource.Kind, namespacedKey)
 		}
 	}
 
 	return availableTargetClusters, nil
+}
+
+// buildAssumedWorkloadsByCluster builds a map of assumed workloads for each cluster based on the assigning cache.
+func buildAssumedWorkloadsByCluster(clusters []*clusterv1alpha1.Cluster, assigningCache *schedulercache.AssigningResourceBindingCache) map[string][]estimatorclient.AssumedWorkload {
+	assumedWorkloads := make(map[string][]estimatorclient.AssumedWorkload, len(clusters))
+	if assigningCache == nil {
+		return assumedWorkloads
+	}
+
+	for _, cluster := range clusters {
+		clusterAssumptions := assigningCache.GetAssumedWorkloads(cluster.Name)
+		if len(clusterAssumptions) == 0 {
+			continue
+		}
+
+		assumed := make([]estimatorclient.AssumedWorkload, len(clusterAssumptions))
+		for i := range clusterAssumptions {
+			assumed[i] = estimatorclient.AssumedWorkload{
+				Namespace:  clusterAssumptions[i].Namespace,
+				Components: clusterAssumptions[i].Components,
+			}
+		}
+		assumedWorkloads[cluster.Name] = assumed
+	}
+
+	return assumedWorkloads
 }

--- a/pkg/scheduler/core/estimation_test.go
+++ b/pkg/scheduler/core/estimation_test.go
@@ -27,6 +27,7 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	estimatorclient "github.com/karmada-io/karmada/pkg/estimator/client"
+	schedulercache "github.com/karmada-io/karmada/pkg/scheduler/cache"
 	"github.com/karmada-io/karmada/test/helper"
 )
 
@@ -34,13 +35,15 @@ import (
 type mockReplicaEstimator struct {
 	maxAvailableComponentSetsResponse []estimatorclient.ComponentSetEstimationResponse
 	maxAvailableComponentSetsError    error
+	lastComponentSetRequest           estimatorclient.ComponentSetEstimationRequest
 }
 
 func (m *mockReplicaEstimator) MaxAvailableReplicas(_ context.Context, _ []*clusterv1alpha1.Cluster, _ *workv1alpha2.ReplicaRequirements) ([]workv1alpha2.TargetCluster, error) {
 	return nil, nil
 }
 
-func (m *mockReplicaEstimator) MaxAvailableComponentSets(_ context.Context, _ estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
+func (m *mockReplicaEstimator) MaxAvailableComponentSets(_ context.Context, req estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
+	m.lastComponentSetRequest = req
 	return m.maxAvailableComponentSetsResponse, m.maxAvailableComponentSetsError
 }
 
@@ -384,7 +387,14 @@ func Test_calculateMultiTemplateAvailableSets(t *testing.T) {
 				maxAvailableComponentSetsError:    tt.mockError,
 			}
 
-			result, err := calculateMultiTemplateAvailableSets(ctx, mockEstimator, estimatorName, clusters, spec, tt.availableTargetClusters)
+			result, err := calculateMultiTemplateAvailableSets(ctx, multiTemplateEstimationContext{
+				estimator:               mockEstimator,
+				estimatorName:           estimatorName,
+				clusters:                clusters,
+				spec:                    spec,
+				availableTargetClusters: tt.availableTargetClusters,
+				assigningCache:          nil,
+			})
 
 			if tt.expectedError {
 				assert.Error(t, err)
@@ -395,4 +405,63 @@ func Test_calculateMultiTemplateAvailableSets(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+func Test_buildAssumedWorkloadsByCluster(t *testing.T) {
+	t.Run("nil cache returns empty map", func(t *testing.T) {
+		clusters := []*clusterv1alpha1.Cluster{
+			helper.NewCluster("cluster1"),
+		}
+		got := buildAssumedWorkloadsByCluster(clusters, nil)
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("returns assumptions only for requested clusters", func(t *testing.T) {
+		cache := schedulercache.NewCache(nil, nil, 0).AssigningResourceBindings()
+		cache.Assume("default/rb1", "cluster1", schedulercache.AssumedWorkload{
+			Namespace: "default",
+			Components: []workv1alpha2.Component{
+				{Name: "jobmanager", Replicas: 1},
+			},
+		})
+		cache.Assume("default/rb2", "cluster2", schedulercache.AssumedWorkload{
+			Namespace: "default",
+			Components: []workv1alpha2.Component{
+				{Name: "taskmanager", Replicas: 2},
+			},
+		})
+
+		clusters := []*clusterv1alpha1.Cluster{
+			helper.NewCluster("cluster1"),
+			helper.NewCluster("cluster3"), // no assumption
+		}
+		got := buildAssumedWorkloadsByCluster(clusters, cache)
+
+		assert.Len(t, got, 1)
+		assert.Contains(t, got, "cluster1")
+		assert.NotContains(t, got, "cluster2")
+		assert.NotContains(t, got, "cluster3")
+
+		cluster1Assumed := got["cluster1"]
+		assert.Len(t, cluster1Assumed, 1)
+		assert.Equal(t, "default", cluster1Assumed[0].Namespace)
+		assert.Len(t, cluster1Assumed[0].Components, 1)
+		assert.Equal(t, "jobmanager", cluster1Assumed[0].Components[0].Name)
+		assert.Equal(t, int32(1), cluster1Assumed[0].Components[0].Replicas)
+	})
+
+	t.Run("empty clusters returns empty map", func(t *testing.T) {
+		cache := schedulercache.NewCache(nil, nil, 0).AssigningResourceBindings()
+		cache.Assume("default/rb1", "cluster1", schedulercache.AssumedWorkload{
+			Namespace: "default",
+			Components: []workv1alpha2.Component{
+				{Name: "jobmanager", Replicas: 1},
+			},
+		})
+
+		got := buildAssumedWorkloadsByCluster(nil, cache)
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
 }

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -195,7 +195,7 @@ func (g *genericScheduler) prioritizeClusters(
 
 func (g *genericScheduler) selectClusters(clustersScore framework.ClusterScoreList,
 	placement *policyv1alpha1.Placement, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus) ([]spreadconstraint.ClusterDetailInfo, error) {
-	return SelectClusters(clustersScore, placement, spec, status)
+	return SelectClusters(clustersScore, placement, spec, status, g.schedulerCache.AssigningResourceBindings())
 }
 
 func (g *genericScheduler) assignReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec,

--- a/pkg/scheduler/core/util.go
+++ b/pkg/scheduler/core/util.go
@@ -29,6 +29,7 @@ import (
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	estimatorclient "github.com/karmada-io/karmada/pkg/estimator/client"
 	"github.com/karmada-io/karmada/pkg/features"
+	schedulercache "github.com/karmada-io/karmada/pkg/scheduler/cache"
 	"github.com/karmada-io/karmada/pkg/scheduler/core/spreadconstraint"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/names"
@@ -53,7 +54,7 @@ func getDefaultWeightPreference(clusters []spreadconstraint.ClusterDetailInfo) *
 	}
 }
 
-func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha2.ResourceBindingSpec) []workv1alpha2.TargetCluster {
+func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha2.ResourceBindingSpec, assigningCache *schedulercache.AssigningResourceBindingCache) []workv1alpha2.TargetCluster {
 	availableTargetClusters := make([]workv1alpha2.TargetCluster, len(clusters))
 
 	// Set the boundary.
@@ -78,7 +79,14 @@ func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha
 	for name, estimator := range estimators {
 		if features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) && isMultiTemplateSchedulingApplicable(spec) {
 			var err error
-			availableTargetClusters, err = calculateMultiTemplateAvailableSets(ctx, estimator, name, clusters, spec, availableTargetClusters)
+			availableTargetClusters, err = calculateMultiTemplateAvailableSets(ctx, multiTemplateEstimationContext{
+				estimator:               estimator,
+				estimatorName:           name,
+				clusters:                clusters,
+				spec:                    spec,
+				availableTargetClusters: availableTargetClusters,
+				assigningCache:          assigningCache,
+			})
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Thread Scheduler cache's `AssumeWorkloads` info into `calculateMultiTemplateAvailableSets`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7481 

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

