### PR TITLE
fix(karmadactl): return error from DeleteConfirmation instead of calling os.Exit

### DIFF
--- a/pkg/karmadactl/addons/init/disable_option.go
+++ b/pkg/karmadactl/addons/init/disable_option.go
@@ -68,8 +68,14 @@ func (o *CommandAddonsDisableOption) Validate(args []string) error {
 // Run start disable Karmada addons
 func (o *CommandAddonsDisableOption) Run(args []string) error {
 	fmt.Printf("Disable Karmada addon %s\n", args)
-	if !o.Force && !cmdutil.DeleteConfirmation() {
-		return nil
+	if !o.Force {
+		confirmed, err := cmdutil.DeleteConfirmation()
+		if err != nil {
+			return fmt.Errorf("failed to get user confirmation: %w", err)
+		}
+		if !confirmed {
+			return nil
+		}
 	}
 
 	var disableAddons = map[string]*Addon{}

--- a/pkg/karmadactl/deinit/deinit.go
+++ b/pkg/karmadactl/deinit/deinit.go
@@ -255,9 +255,15 @@ func removeLabels(node *corev1.Node, removesLabel string) {
 // Run start delete
 func (o *CommandDeInitOption) Run() error {
 	fmt.Println("removes Karmada from Kubernetes")
-	// delete confirmation,exit the delete action when false.
-	if !o.Force && !util.DeleteConfirmation() {
-		return nil
+	// delete confirmation, exit the delete action when user declines or input fails.
+	if !o.Force {
+		confirmed, err := util.DeleteConfirmation()
+		if err != nil {
+			return fmt.Errorf("failed to get user confirmation: %w", err)
+		}
+		if !confirmed {
+			return nil
+		}
 	}
 
 	if err := o.delete(); err != nil {

--- a/pkg/karmadactl/util/deleteconfirmation.go
+++ b/pkg/karmadactl/util/deleteconfirmation.go
@@ -18,26 +18,28 @@ package util
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
-// DeleteConfirmation delete karmada resource confirmation
-func DeleteConfirmation() bool {
-	fmt.Print("Please type (y)es or (n)o and then press enter:")
-	var response string
-	_, err := fmt.Scanln(&response)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+// DeleteConfirmation prompts the user for a yes/no confirmation.
+// It returns true if the user confirms with "y" or "yes", false on "n" or "no",
+// and an error if stdin cannot be read (e.g. non-interactive environment).
+func DeleteConfirmation() (bool, error) {
+	for {
+		fmt.Print("Please type (y)es or (n)o and then press enter:")
+		var response string
+		_, err := fmt.Scanln(&response)
+		if err != nil {
+			return false, fmt.Errorf("failed to read user confirmation: %w", err)
+		}
 
-	switch strings.ToLower(response) {
-	case "y", "yes":
-		return true
-	case "n", "no":
-		return false
-	default:
-		return DeleteConfirmation()
+		switch strings.ToLower(response) {
+		case "y", "yes":
+			return true, nil
+		case "n", "no":
+			return false, nil
+		default:
+			fmt.Println("invalid input, please type (y)es or (n)o")
+		}
 	}
 }

--- a/pkg/karmadactl/util/deleteconfirmation_test.go
+++ b/pkg/karmadactl/util/deleteconfirmation_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// substituteStdin replaces os.Stdin with a pipe seeded with input and returns
+// a cleanup func that restores the original stdin.
+func substituteStdin(t *testing.T, input string) func() {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	if _, err = w.WriteString(input); err != nil {
+		t.Fatalf("failed to write to pipe: %v", err)
+	}
+	w.Close()
+
+	orig := os.Stdin
+	os.Stdin = r
+	return func() {
+		os.Stdin = orig
+		r.Close()
+	}
+}
+
+func TestDeleteConfirmation(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantOk  bool
+		wantErr bool
+	}{
+		{
+			name:    "DeleteConfirmation_WithYes_ReturnsTrue",
+			input:   "yes\n",
+			wantOk:  true,
+			wantErr: false,
+		},
+		{
+			name:    "DeleteConfirmation_WithY_ReturnsTrue",
+			input:   "y\n",
+			wantOk:  true,
+			wantErr: false,
+		},
+		{
+			name:    "DeleteConfirmation_WithNo_ReturnsFalse",
+			input:   "no\n",
+			wantOk:  false,
+			wantErr: false,
+		},
+		{
+			name:    "DeleteConfirmation_WithN_ReturnsFalse",
+			input:   "n\n",
+			wantOk:  false,
+			wantErr: false,
+		},
+		{
+			name:    "DeleteConfirmation_WithUppercaseYES_ReturnsTrue",
+			input:   "YES\n",
+			wantOk:  true,
+			wantErr: false,
+		},
+		{
+			name:    "DeleteConfirmation_WithUppercaseNO_ReturnsFalse",
+			input:   "NO\n",
+			wantOk:  false,
+			wantErr: false,
+		},
+		{
+			name:    "DeleteConfirmation_WithEmptyInput_ReturnsError",
+			input:   "",
+			wantOk:  false,
+			wantErr: true,
+		},
+		{
+			// Exercises the retry loop: first input is unrecognized,
+			// second input is valid. Relies on the iterative for-loop
+			// rather than recursion.
+			name:    "DeleteConfirmation_WithInvalidThenYes_ReturnsTrue",
+			input:   "maybe\nyes\n",
+			wantOk:  true,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := substituteStdin(t, tt.input)
+			defer restore()
+
+			got, err := DeleteConfirmation()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteConfirmation() error = %v, wantErr = %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.wantOk {
+				t.Errorf("DeleteConfirmation() = %v, want %v", got, tt.wantOk)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), "failed to read user confirmation") {
+				t.Errorf("expected error to contain 'failed to read user confirmation', got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
`DeleteConfirmation()` in `pkg/karmadactl/util/deleteconfirmation.go` called
`os.Exit(1)` when `fmt.Scanln` failed — in CI, piped stdin, or any
non-interactive environment. That's the wrong tool for a library function: callers
can't catch it, tests can't survive it, and the user gets no context about what
went wrong or which command triggered it.

Changes in this PR:

- Signature changes from `func DeleteConfirmation() bool` to
  `func DeleteConfirmation() (bool, error)` so callers can handle stdin failures
  instead of dying
- `os.Exit(1)` is replaced with `return false, fmt.Errorf("failed to read user
  confirmation: %w", err)`
- The recursive `default: return DeleteConfirmation()` retry is replaced with a
  `for` loop; it also now prints `"invalid input, please type (y)es or (n)o"` so
  users aren't left wondering why nothing happened
- Both callers (`deinit/deinit.go` and `addons/init/disable_option.go`) are
  updated to handle the `(bool, error)` return and propagate failures through
  cobra's `RunE`
- `deleteconfirmation_test.go` is new: 8 table-driven tests covering `y/n/yes/no`,
  uppercase variants, empty stdin (the previously unkillable error path), and an
  invalid-then-valid retry sequence

**Which issue(s) this PR fixes**:
Fixes #7516

**Note for reviewer**:
The stdin error path had no test coverage before this change because hitting it
called `os.Exit(1)`, which killed the test binary. The new tests use `os.Pipe()`
to swap out stdin — no subprocess, no PTY needed.

A follow-up worth considering (out of scope here): inject `io.Reader` and
`io.Writer` into `DeleteConfirmation()` to remove the dependency on `os.Stdin`
and `os.Stdout` entirely.

**Does this PR introduce a user-facing change?**:
```release-note
karmadactl: `deinit` and `addons disable` no longer exit the process silently
when stdin is unavailable (e.g. in CI or piped usage). They now return an error
that cobra surfaces to the user. Passing `--force` remains the supported way to
skip confirmation in non-interactive environments.
```