### PR TITLE
Write/Release assumptions in patchScheduleResultForResourceBinding

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -227,7 +227,7 @@ func (b *AssigningResourceBindingCache) GetBindings() map[string]*workv1alpha2.R
 // Assume records (or replaces) the resource footprint for the given binding+cluster pair.
 // Calling Assume again for the same pair overwrites the previous entry and resets the TTL,
 // reflecting the latest scheduling decision.
-// entry.Components is deep-copied before storage to prevent callers from unintentionally
+// entry.Components are deep-copied before storage to prevent callers from unintentionally
 // mutating the cache's internal state via shared slice backing arrays.
 func (b *AssigningResourceBindingCache) Assume(bindingKey, clusterName string, entry AssumedWorkload) {
 	b.Lock()

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -62,6 +62,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/grpcconnection"
 	"github.com/karmada-io/karmada/pkg/util/helper"
 	utilmetrics "github.com/karmada-io/karmada/pkg/util/metrics"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 // ScheduleType defines the schedule type of a binding object should be performed.
@@ -690,9 +691,88 @@ func (s *Scheduler) patchScheduleResultForResourceBinding(oldBinding *workv1alph
 		// leading to a potential memory leak in AssigningResourceBindings cache if no further updates occur.
 		s.schedulerCache.AssigningResourceBindings().Add(result)
 	}
+	s.updateAssumptionsCache(oldBinding, scheduleResult)
 
 	klog.V(4).Infof("Patch schedule to ResourceBinding(%s/%s) succeed", oldBinding.Namespace, oldBinding.Name)
 	return nil
+}
+
+// updateAssumptionsCache maintains the assumption cache after the schedule result is
+// successfully patched to the API server (e.g. on first scheduling or after a scale event).
+//
+// Both single-template and multi-template workloads record the full current resource
+// footprint for every cluster in the new schedule result.
+//
+// Assumptions for clusters removed from the placement are released.
+// Non-workload resources (e.g. ConfigMap, Service) are skipped.
+func (s *Scheduler) updateAssumptionsCache(oldBinding *workv1alpha2.ResourceBinding, scheduleResult []workv1alpha2.TargetCluster) {
+	// can not reach here
+	if s.schedulerCache == nil || s.schedulerCache.AssigningResourceBindings() == nil {
+		return
+	}
+
+	// Skip non-workload resources.
+	if !oldBinding.Spec.IsWorkload() {
+		return
+	}
+
+	bindingKey := names.NamespacedKey(oldBinding.Namespace, oldBinding.Name)
+	assigningCache := s.schedulerCache.AssigningResourceBindings()
+
+	oldClusters := make(map[string]struct{}, len(oldBinding.Spec.Clusters))
+	for _, tc := range oldBinding.Spec.Clusters {
+		oldClusters[tc.Name] = struct{}{}
+	}
+
+	newClusters := make(map[string]struct{}, len(scheduleResult))
+	for _, tc := range scheduleResult {
+		newClusters[tc.Name] = struct{}{}
+	}
+
+	// Release assumptions for clusters removed from the placement.
+	for clusterName := range oldClusters {
+		if _, stillExists := newClusters[clusterName]; !stillExists {
+			assigningCache.ReleaseClusterAssumption(bindingKey, clusterName)
+		}
+	}
+
+	if len(oldBinding.Spec.Components) > 0 {
+		for clusterName := range newClusters {
+			assigningCache.Assume(bindingKey, clusterName, schedulercache.AssumedWorkload{
+				Namespace:  oldBinding.Spec.Resource.Namespace,
+				Components: oldBinding.Spec.Components,
+			})
+		}
+		return
+	}
+
+	// Single-template workload: each cluster has its own replica count; wrap into a
+	// synthetic Component so the estimator can deduct the correct resource footprint.
+	reqs := oldBinding.Spec.ReplicaRequirements
+	for _, tc := range scheduleResult {
+		components := singleTemplateAsComponents(oldBinding.Spec.Resource.Name, tc.Replicas, reqs)
+		assigningCache.Assume(bindingKey, tc.Name, schedulercache.AssumedWorkload{
+			Namespace:  oldBinding.Spec.Resource.Namespace,
+			Components: components,
+		})
+	}
+}
+
+// singleTemplateAsComponents wraps a single-template workload assignment into a Component slice
+// so it can be stored and consumed by the estimator in the same way as multi-template workloads.
+func singleTemplateAsComponents(name string, replicas int32, reqs *workv1alpha2.ReplicaRequirements) []workv1alpha2.Component {
+	c := workv1alpha2.Component{
+		Name:     name,
+		Replicas: replicas,
+	}
+	if reqs != nil {
+		c.ReplicaRequirements = &workv1alpha2.ComponentReplicaRequirements{
+			NodeClaim:         reqs.NodeClaim,
+			ResourceRequest:   reqs.ResourceRequest,
+			PriorityClassName: reqs.PriorityClassName,
+		}
+	}
+	return []workv1alpha2.Component{c}
 }
 
 func (s *Scheduler) scheduleClusterResourceBinding(crb *workv1alpha2.ClusterResourceBinding) (err error) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,6 +41,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/features"
 	karmadafake "github.com/karmada-io/karmada/pkg/generated/clientset/versioned/fake"
 	workv1alpha2lister "github.com/karmada-io/karmada/pkg/generated/listers/work/v1alpha2"
+	schedulercache "github.com/karmada-io/karmada/pkg/scheduler/cache"
 	"github.com/karmada-io/karmada/pkg/scheduler/core"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework"
 	internalqueue "github.com/karmada-io/karmada/pkg/scheduler/internal/queue"
@@ -772,8 +774,10 @@ func TestPatchScheduleResultForResourceBinding(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			cache := schedulercache.NewCache(nil, nil, 0)
 			s := &Scheduler{
-				KarmadaClient: karmadafake.NewClientset(tt.oldBinding),
+				KarmadaClient:  karmadafake.NewClientset(tt.oldBinding),
+				schedulerCache: cache,
 			}
 
 			err := s.patchScheduleResultForResourceBinding(tt.oldBinding, tt.placement, tt.scheduleResult)
@@ -790,6 +794,206 @@ func TestPatchScheduleResultForResourceBinding(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdatesAssumptions(t *testing.T) {
+	multiTemplateComponents := []workv1alpha2.Component{
+		{Name: "jobmanager", Replicas: 1},
+		{Name: "taskmanager", Replicas: 2},
+	}
+
+	t.Run("multi-template: writes full components on first scheduling", func(t *testing.T) {
+		oldBinding := &workv1alpha2.ResourceBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-binding", Namespace: "default"},
+			Spec: workv1alpha2.ResourceBindingSpec{
+				Resource:   workv1alpha2.ObjectReference{Namespace: "work-ns"},
+				Components: multiTemplateComponents,
+				Clusters:   nil,
+			},
+		}
+
+		cache := schedulercache.NewCache(nil, nil, 0)
+		s := &Scheduler{
+			KarmadaClient:  karmadafake.NewClientset(oldBinding),
+			schedulerCache: cache,
+		}
+
+		err := s.patchScheduleResultForResourceBinding(oldBinding, "test-placement", []workv1alpha2.TargetCluster{
+			{Name: "cluster1"},
+		})
+		assert.NoError(t, err)
+
+		assumed := cache.AssigningResourceBindings().GetAssumedWorkloads("cluster1")
+		assert.Len(t, assumed, 1)
+		assert.Equal(t, "work-ns", assumed[0].Namespace)
+		assert.Len(t, assumed[0].Components, 2)
+		assert.Equal(t, int32(1), assumed[0].Components[0].Replicas)
+		assert.Equal(t, int32(2), assumed[0].Components[1].Replicas)
+	})
+
+	t.Run("multi-template: always writes full components on reschedule", func(t *testing.T) {
+		// Components scaled up; Option B always writes the full current components.
+		scaledComponents := []workv1alpha2.Component{
+			{Name: "jobmanager", Replicas: 1},
+			{Name: "taskmanager", Replicas: 4},
+		}
+		oldBinding := &workv1alpha2.ResourceBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-binding", Namespace: "default"},
+			Spec: workv1alpha2.ResourceBindingSpec{
+				Resource:   workv1alpha2.ObjectReference{Namespace: "work-ns"},
+				Components: scaledComponents,
+				Clusters:   []workv1alpha2.TargetCluster{{Name: "cluster1"}},
+			},
+		}
+
+		cache := schedulercache.NewCache(nil, nil, 0)
+		s := &Scheduler{
+			KarmadaClient:  karmadafake.NewClientset(oldBinding),
+			schedulerCache: cache,
+		}
+
+		err := s.patchScheduleResultForResourceBinding(oldBinding, "test-placement", []workv1alpha2.TargetCluster{
+			{Name: "cluster1"},
+		})
+		assert.NoError(t, err)
+
+		assumed := cache.AssigningResourceBindings().GetAssumedWorkloads("cluster1")
+		assert.Len(t, assumed, 1)
+		// Full components are written, not just the delta.
+		assert.Len(t, assumed[0].Components, 2)
+		assert.Equal(t, int32(1), assumed[0].Components[0].Replicas)
+		assert.Equal(t, int32(4), assumed[0].Components[1].Replicas)
+	})
+
+	t.Run("multi-template: removed cluster releases assumption", func(t *testing.T) {
+		oldBinding := &workv1alpha2.ResourceBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-binding", Namespace: "default"},
+			Spec: workv1alpha2.ResourceBindingSpec{
+				Resource:   workv1alpha2.ObjectReference{Namespace: "work-ns"},
+				Components: multiTemplateComponents,
+				Clusters: []workv1alpha2.TargetCluster{
+					{Name: "cluster1"},
+					{Name: "cluster2"},
+				},
+			},
+		}
+
+		cache := schedulercache.NewCache(nil, nil, 0)
+		bindingKey := "default/test-binding"
+		cache.AssigningResourceBindings().Assume(bindingKey, "cluster2", schedulercache.AssumedWorkload{
+			Namespace:  "work-ns",
+			Components: multiTemplateComponents,
+		})
+
+		s := &Scheduler{
+			KarmadaClient:  karmadafake.NewClientset(oldBinding),
+			schedulerCache: cache,
+		}
+
+		err := s.patchScheduleResultForResourceBinding(oldBinding, "test-placement", []workv1alpha2.TargetCluster{
+			{Name: "cluster1"}, // cluster2 removed
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, cache.AssigningResourceBindings().GetAssumedWorkloads("cluster2"))
+	})
+
+	t.Run("single-template: wraps per-cluster replicas as component", func(t *testing.T) {
+		oldBinding := &workv1alpha2.ResourceBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "deploy-binding", Namespace: "default"},
+			Spec: workv1alpha2.ResourceBindingSpec{
+				Resource: workv1alpha2.ObjectReference{Name: "my-deploy", Namespace: "work-ns"},
+				ReplicaRequirements: &workv1alpha2.ReplicaRequirements{
+					ResourceRequest: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: 2}},
+			},
+		}
+
+		cache := schedulercache.NewCache(nil, nil, 0)
+		s := &Scheduler{
+			KarmadaClient:  karmadafake.NewClientset(oldBinding),
+			schedulerCache: cache,
+		}
+
+		err := s.patchScheduleResultForResourceBinding(oldBinding, "test-placement", []workv1alpha2.TargetCluster{
+			{Name: "cluster1", Replicas: 5},
+		})
+		assert.NoError(t, err)
+
+		assumed := cache.AssigningResourceBindings().GetAssumedWorkloads("cluster1")
+		assert.Len(t, assumed, 1)
+		assert.Equal(t, "work-ns", assumed[0].Namespace)
+		assert.Len(t, assumed[0].Components, 1)
+		assert.Equal(t, "my-deploy", assumed[0].Components[0].Name)
+		// replicas come from the new scheduleResult, not from oldBinding.Spec.Clusters
+		assert.Equal(t, int32(5), assumed[0].Components[0].Replicas)
+		assert.NotNil(t, assumed[0].Components[0].ReplicaRequirements)
+		assert.Equal(t, resource.MustParse("500m"), assumed[0].Components[0].ReplicaRequirements.ResourceRequest[corev1.ResourceCPU])
+	})
+
+	t.Run("single-template: per-cluster replica counts are independent", func(t *testing.T) {
+		oldBinding := &workv1alpha2.ResourceBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "deploy-binding", Namespace: "default"},
+			Spec: workv1alpha2.ResourceBindingSpec{
+				Resource: workv1alpha2.ObjectReference{Name: "my-deploy", Namespace: "work-ns"},
+				ReplicaRequirements: &workv1alpha2.ReplicaRequirements{
+					ResourceRequest: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					},
+				},
+				Clusters: []workv1alpha2.TargetCluster{
+					{Name: "cluster1", Replicas: 3},
+					{Name: "cluster2", Replicas: 3},
+				},
+			},
+		}
+
+		cache := schedulercache.NewCache(nil, nil, 0)
+		s := &Scheduler{
+			KarmadaClient:  karmadafake.NewClientset(oldBinding),
+			schedulerCache: cache,
+		}
+
+		err := s.patchScheduleResultForResourceBinding(oldBinding, "test-placement", []workv1alpha2.TargetCluster{
+			{Name: "cluster1", Replicas: 4},
+			{Name: "cluster2", Replicas: 2},
+		})
+		assert.NoError(t, err)
+
+		assumed1 := cache.AssigningResourceBindings().GetAssumedWorkloads("cluster1")
+		assert.Len(t, assumed1, 1)
+		assert.Equal(t, int32(4), assumed1[0].Components[0].Replicas)
+
+		assumed2 := cache.AssigningResourceBindings().GetAssumedWorkloads("cluster2")
+		assert.Len(t, assumed2, 1)
+		assert.Equal(t, int32(2), assumed2[0].Components[0].Replicas)
+	})
+
+	t.Run("no-components: no assumption written", func(t *testing.T) {
+		oldBinding := &workv1alpha2.ResourceBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-binding", Namespace: "default"},
+			Spec: workv1alpha2.ResourceBindingSpec{
+				Resource:   workv1alpha2.ObjectReference{Namespace: "work-ns"},
+				Components: nil,
+				Clusters:   []workv1alpha2.TargetCluster{{Name: "cluster1"}},
+			},
+		}
+
+		cache := schedulercache.NewCache(nil, nil, 0)
+		s := &Scheduler{
+			KarmadaClient:  karmadafake.NewClientset(oldBinding),
+			schedulerCache: cache,
+		}
+
+		err := s.patchScheduleResultForResourceBinding(oldBinding, "test-placement", []workv1alpha2.TargetCluster{
+			{Name: "cluster1"},
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, cache.AssigningResourceBindings().GetAssumedWorkloads("cluster1"))
+	})
 }
 
 func TestScheduleClusterResourceBindingWithClusterAffinity(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Write/Release assumptions in patchScheduleResultForResourceBinding.

- Only resources of the workload type need to be calculated. Therefore, you only need to set the scheduler assumption cache for resources of the workload type.
- Generally, workload resources are namespace-scoped resources. Therefore, you do not need to process the scheduling result of ClusterResourceBinding.

In addition, we first handle multi-template workloads. Single-template resources, such as Deployments and StatefulSets, are not processed for now.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7481

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

The current implementation writes the complete components of workloads into the assumption cache after each scheduling cycle. This approach has several drawbacks:

**Over-deduction**: The assumption cache includes resources occupied by pods that are already steadily running in clusters. When the Estimator evaluates remaining cluster capacity, it calculates both the resource usage of actually running pods and the full resource deductions recorded in assumptions simultaneously. This results in double deduction of available resources for the same cluster, leading to overly conservative scheduling decisions afterwards.

The duration of this issue is restricted by TTL and cache release mechanisms. Further optimization and mitigation can be implemented on the Estimator side in follow-up work.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

