### PR TITLE
Start assumption gc goroutine in Scheduler.Run()

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -202,7 +202,6 @@ func (b *AssigningResourceBindingCache) OnBindingDelete(binding *workv1alpha2.Re
 
 	key := names.NamespacedKey(binding.Namespace, binding.Name)
 	delete(b.items, key)
-	delete(b.assumptions, key)
 }
 
 // Add records a ResourceBinding that has a new scheduling decision committed to the API server.

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -428,19 +428,6 @@ func TestGC(t *testing.T) {
 	assert.Contains(t, c.assumptions, "ns/rb3", "non-expired entry should be kept")
 }
 
-func TestOnBindingDelete_CleansAssumptions(t *testing.T) {
-	c := newTestAssumptionCache(time.Minute)
-	c.Assume("ns/rb1", "cluster1", makeAssumedWorkload("ns"))
-
-	binding := &workv1alpha2.ResourceBinding{}
-	binding.Namespace = "ns"
-	binding.Name = "rb1"
-	c.OnBindingDelete(binding)
-
-	assert.NotContains(t, c.assumptions, "ns/rb1", "OnBindingDelete should remove corresponding reservation")
-	assert.NotContains(t, c.items, "ns/rb1")
-}
-
 // BenchmarkGetAssumedWorkloads measures the performance of GetAssumedWorkloads under
 // varying cache sizes.  The benchmark covers the realistic operating range (N ≤ 50,
 // governed by the reservation TTL) as well as stress sizes to quantify O(N) scaling.

--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -245,25 +245,28 @@ func (s *Scheduler) onClusterResourceBindingUpdate(old, cur any) {
 
 // onResourceBindingDelete is called when a delete event for a ResourceBinding is received from the Informer.
 func (s *Scheduler) onResourceBindingDelete(obj any) {
-	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
-		var binding *workv1alpha2.ResourceBinding
-		switch t := obj.(type) {
-		case *workv1alpha2.ResourceBinding:
-			binding = t
-		case cache.DeletedFinalStateUnknown:
-			var ok bool
-			binding, ok = t.Obj.(*workv1alpha2.ResourceBinding)
-			if !ok {
-				klog.Errorf("onResourceBindingDelete: cannot convert DeletedFinalStateUnknown.Obj to *workv1alpha2.ResourceBinding: %v", t.Obj)
-				return
-			}
-		default:
-			klog.Errorf("onResourceBindingDelete: unexpected object type %T", obj)
+	var binding *workv1alpha2.ResourceBinding
+	switch t := obj.(type) {
+	case *workv1alpha2.ResourceBinding:
+		binding = t
+	case cache.DeletedFinalStateUnknown:
+		var ok bool
+		binding, ok = t.Obj.(*workv1alpha2.ResourceBinding)
+		if !ok {
+			klog.Errorf("cannot convert to workv1alpha2.ResourceBinding: %v", t.Obj)
 			return
 		}
+	default:
+		klog.Errorf("cannot convert to workv1alpha2.ResourceBinding: %v", t)
+		return
+	}
 
+	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
 		s.schedulerCache.AssigningResourceBindings().OnBindingDelete(binding)
 	}
+
+	bindingKey := names.NamespacedKey(binding.Namespace, binding.Name)
+	s.schedulerCache.AssigningResourceBindings().ReleaseAssumption(bindingKey)
 }
 
 func (s *Scheduler) onResourceBindingRequeue(binding *workv1alpha2.ResourceBinding, event string) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -326,6 +326,20 @@ func (s *Scheduler) Run(ctx context.Context) {
 
 	go wait.Until(s.worker, time.Second, ctx.Done())
 
+	// Defensive check: schedulerCache is expected to be always initialized.
+	if s.schedulerCache != nil && s.schedulerCache.AssigningResourceBindings() != nil {
+		assumptionCache := s.schedulerCache.AssigningResourceBindings()
+		// Periodically clean up stale assumptions in the cache to prevent memory leaks.
+		// This serves as a safety net for assumptions whose normal release path (e.g., Healthy signal)
+		// was never triggered.
+		go wait.Until(func() {
+			removed := assumptionCache.GC()
+			if removed > 0 {
+				klog.V(4).Infof("Assumption cache GC: removed %d expired entries", removed)
+			}
+		}, time.Minute, ctx.Done())
+	}
+
 	if features.FeatureGate.Enabled(features.PriorityBasedScheduling) {
 		s.priorityQueue.Run()
 		<-ctx.Done()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

The scheduler performs GC on the assumption information in the cache every minute and deletes elements whose TTL expires.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

Part of #7481

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

