### PR TITLE
Automated cherry pick of #7074: stop search watch connection when failed cluster recovered

### DIFF
--- a/pkg/search/proxy/store/util.go
+++ b/pkg/search/proxy/store/util.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog/v2"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 )
@@ -273,6 +274,65 @@ func (w *watchMux) startWatchSource(source watch.Interface, decorator func(watch
 		case w.result <- copyEvent:
 		}
 	}
+}
+
+// Check if watchMuxWithInvalidation implements watch.Interface
+var _ watch.Interface = &watchMuxWithInvalidation{}
+
+// watchMuxWithInvalidation extends watchMux with the ability to send invalidation events
+type watchMuxWithInvalidation struct {
+	*watchMux
+	stopped chan struct{} // Signals when the watch is stopped
+}
+
+func newWatchMuxWithInvalidation() *watchMuxWithInvalidation {
+	return &watchMuxWithInvalidation{
+		watchMux: newWatchMux(),
+		stopped:  make(chan struct{}),
+	}
+}
+
+// Start extends the base Start method to handle the stopped channel
+func (w *watchMuxWithInvalidation) Start() {
+	w.watchMux.Start()
+
+	// Close stopped channel when the watch ends
+	go func() {
+		<-w.watchMux.done
+		close(w.stopped)
+	}()
+}
+
+// Invalidate sends an error event to trigger client reconnection
+func (w *watchMuxWithInvalidation) Invalidate() {
+	select {
+	case <-w.watchMux.done:
+		// Watch already stopped, nothing to do
+		return
+	default:
+	}
+
+	klog.V(2).Infof("Invalidating watch: cluster topology changed, closing watch connection")
+
+	// Directly stop the watch.
+	// This will:
+	// 1. Close the w.watchMux.done channel.
+	// 2. Cause all source watchers to stop.
+	// 3. Close the w.watchMux.result channel.
+	// 4. ResultChan() on the client side will return ok=false when reading from it.
+	w.Stop()
+
+	klog.V(4).Infof("Watch connection closed successfully")
+}
+
+// StoppedCh returns a channel that is closed when the watch is stopped
+func (w *watchMuxWithInvalidation) StoppedCh() <-chan struct{} {
+	return w.stopped
+}
+
+// Stop extends the base Stop method
+func (w *watchMuxWithInvalidation) Stop() {
+	w.watchMux.Stop()
 }
 
 // MultiNamespace contains multiple namespaces.


### PR DESCRIPTION
Cherry pick of #7074 on release-1.17.
#7074: stop search watch connection when failed cluster recovered
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-search`: Fixed the issue that watch connect cannot reflect resources from recovered clusters immediately.
```