### PR TITLE
Watch AggregatedStatus changes in ResourceBinding update handler to release scheduler assumption cache

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -303,6 +303,15 @@ func (b *AssigningResourceBindingCache) GetAssumedWorkloads(clusterName string) 
 	return result
 }
 
+// IsAssumptionExist checks if there is an existing assumption for the given binding key.
+func (b *AssigningResourceBindingCache) IsAssumptionExist(bindingKey string) bool {
+	b.RLock()
+	defer b.RUnlock()
+
+	_, ok := b.assumptions[bindingKey]
+	return ok
+}
+
 // GC removes all assumptions whose TTL has expired.
 // It is intended to be called periodically (e.g., every minute) as a safety net for
 // assumptions whose normal release path (Healthy signal) was never triggered.

--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -39,6 +40,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 // addAllEventHandlers is a helper function used in Scheduler
@@ -190,6 +192,11 @@ func (s *Scheduler) onResourceBindingUpdate(old, cur any) {
 	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
 		s.schedulerCache.AssigningResourceBindings().OnBindingUpdate(newRB)
 	}
+
+	// Release per-cluster assumptions for any cluster whose workload just became Healthy.
+	// This must run before the generation check below because AggregatedStatus is a status
+	// field that does not bump the generation.
+	s.releaseHealthyClusterAssumptions(oldRB, newRB)
 
 	if oldRB.GetGeneration() == newRB.GetGeneration() {
 		klog.V(4).Infof("Ignore update event of resourceBinding %s/%s as specification no change", newRB.GetNamespace(), newRB.GetName())
@@ -474,4 +481,51 @@ func (s *Scheduler) enqueueAffectedCRBs(cluster *clusterv1alpha1.Cluster) error 
 	}
 
 	return nil
+}
+
+// releaseHealthyClusterAssumptions releases per-cluster assumptions for any cluster
+// whose workload transitioned to Healthy between the old and new ResourceBinding.
+// It is a no-op when the assumption cache is not initialized or old is not a ResourceBinding.
+func (s *Scheduler) releaseHealthyClusterAssumptions(oldRB, newRB *workv1alpha2.ResourceBinding) {
+	// Defensive check: schedulerCache is expected to be always initialized.
+	if s.schedulerCache == nil || s.schedulerCache.AssigningResourceBindings() == nil {
+		return
+	}
+
+	// Skip non-workload resources.
+	if !oldRB.Spec.IsWorkload() {
+		return
+	}
+
+	bindingKey := names.NamespacedKey(newRB.Namespace, newRB.Name)
+	// Skip when the target assumption does not exist.
+	if !s.schedulerCache.AssigningResourceBindings().IsAssumptionExist(bindingKey) {
+		return
+	}
+
+	for _, clusterName := range newlyHealthyClusters(oldRB.Status.AggregatedStatus, newRB.Status.AggregatedStatus) {
+		s.schedulerCache.AssigningResourceBindings().ReleaseClusterAssumption(bindingKey, clusterName)
+		klog.V(4).Infof("Released assumption for ResourceBinding(%s) on cluster(%s): workload became Healthy", bindingKey, clusterName)
+	}
+}
+
+// newlyHealthyClusters returns the cluster names that transitioned to Healthy
+// in newStatus compared to oldStatus. It is used to release per-cluster
+// assumptions once the workload has reached a stable running state.
+func newlyHealthyClusters(oldStatus, newStatus []workv1alpha2.AggregatedStatusItem) []string {
+	oldHealthy := sets.New[string]()
+	for _, item := range oldStatus {
+		if item.Health == workv1alpha2.ResourceHealthy {
+			oldHealthy.Insert(item.ClusterName)
+		}
+	}
+	var result []string
+	for _, item := range newStatus {
+		if item.Health == workv1alpha2.ResourceHealthy {
+			if !oldHealthy.Has(item.ClusterName) {
+				result = append(result, item.ClusterName)
+			}
+		}
+	}
+	return result
 }

--- a/pkg/scheduler/event_handler_test.go
+++ b/pkg/scheduler/event_handler_test.go
@@ -30,6 +30,7 @@ import (
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	schedulercache "github.com/karmada-io/karmada/pkg/scheduler/cache"
 )
 
 func TestResourceBindingEventFilter(t *testing.T) {
@@ -471,3 +472,136 @@ func (m *mockAsyncWorker) Enqueue(item any) {
 func (m *mockAsyncWorker) AddAfter(_ any, _ time.Duration) {}
 
 func (m *mockAsyncWorker) Run(_ context.Context, _ int) {}
+
+func TestNewlyHealthyClusters(t *testing.T) {
+	tests := []struct {
+		name      string
+		oldStatus []workv1alpha2.AggregatedStatusItem
+		newStatus []workv1alpha2.AggregatedStatusItem
+		want      []string
+	}{
+		{
+			name:      "no status entries: nothing released",
+			oldStatus: nil,
+			newStatus: nil,
+			want:      nil,
+		},
+		{
+			name: "cluster newly becomes Healthy",
+			oldStatus: []workv1alpha2.AggregatedStatusItem{
+				{ClusterName: "cluster1", Health: workv1alpha2.ResourceUnknown},
+			},
+			newStatus: []workv1alpha2.AggregatedStatusItem{
+				{ClusterName: "cluster1", Health: workv1alpha2.ResourceHealthy},
+			},
+			want: []string{"cluster1"},
+		},
+		{
+			name: "cluster already Healthy: not returned again",
+			oldStatus: []workv1alpha2.AggregatedStatusItem{
+				{ClusterName: "cluster1", Health: workv1alpha2.ResourceHealthy},
+			},
+			newStatus: []workv1alpha2.AggregatedStatusItem{
+				{ClusterName: "cluster1", Health: workv1alpha2.ResourceHealthy},
+			},
+			want: nil,
+		},
+		{
+			name: "cluster transitions from Healthy to Unhealthy: not returned",
+			oldStatus: []workv1alpha2.AggregatedStatusItem{
+				{ClusterName: "cluster1", Health: workv1alpha2.ResourceHealthy},
+			},
+			newStatus: []workv1alpha2.AggregatedStatusItem{
+				{ClusterName: "cluster1", Health: workv1alpha2.ResourceUnhealthy},
+			},
+			want: nil,
+		},
+		{
+			name: "one new Healthy cluster among multiple",
+			oldStatus: []workv1alpha2.AggregatedStatusItem{
+				{ClusterName: "cluster1", Health: workv1alpha2.ResourceHealthy},
+				{ClusterName: "cluster2", Health: workv1alpha2.ResourceUnknown},
+			},
+			newStatus: []workv1alpha2.AggregatedStatusItem{
+				{ClusterName: "cluster1", Health: workv1alpha2.ResourceHealthy},
+				{ClusterName: "cluster2", Health: workv1alpha2.ResourceHealthy},
+			},
+			want: []string{"cluster2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newlyHealthyClusters(tt.oldStatus, tt.newStatus)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestOnResourceBindingUpdate_ReleasesAssumptionOnHealthy(t *testing.T) {
+	components := []workv1alpha2.Component{
+		{Name: "jobmanager", Replicas: 1},
+		{Name: "taskmanager", Replicas: 2},
+	}
+	oldBinding := &workv1alpha2.ResourceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-binding", Namespace: "default", Generation: 1,
+		},
+		Spec: workv1alpha2.ResourceBindingSpec{
+			Components: components,
+			Clusters:   []workv1alpha2.TargetCluster{{Name: "cluster1"}},
+		},
+		Status: workv1alpha2.ResourceBindingStatus{
+			AggregatedStatus: []workv1alpha2.AggregatedStatusItem{
+				{ClusterName: "cluster1", Health: workv1alpha2.ResourceUnknown},
+			},
+		},
+	}
+	// Only status changed (AggregatedStatus); generation stays the same.
+	newBinding := oldBinding.DeepCopy()
+	newBinding.Status.AggregatedStatus = []workv1alpha2.AggregatedStatusItem{
+		{ClusterName: "cluster1", Health: workv1alpha2.ResourceHealthy},
+	}
+
+	sc := schedulercache.NewCache(nil, nil, 0)
+	bindingKey := "default/test-binding"
+	sc.AssigningResourceBindings().Assume(bindingKey, "cluster1", schedulercache.AssumedWorkload{
+		Namespace:  "default",
+		Components: components,
+	})
+
+	s := &Scheduler{schedulerCache: sc}
+	s.onResourceBindingUpdate(oldBinding, newBinding)
+
+	assert.Empty(t, sc.AssigningResourceBindings().GetAssumedWorkloads("cluster1"),
+		"assumption should be released when workload becomes Healthy")
+}
+
+func TestReleaseHealthyClusterAssumptions_SkipsNonWorkload(t *testing.T) {
+	// Non-workload binding: no Replicas, no ReplicaRequirements, no Components.
+	oldBinding := &workv1alpha2.ResourceBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm-binding", Namespace: "default", Generation: 1},
+		Spec:       workv1alpha2.ResourceBindingSpec{},
+		Status: workv1alpha2.ResourceBindingStatus{
+			AggregatedStatus: []workv1alpha2.AggregatedStatusItem{
+				{ClusterName: "cluster1", Health: workv1alpha2.ResourceUnknown},
+			},
+		},
+	}
+	newBinding := oldBinding.DeepCopy()
+	newBinding.Status.AggregatedStatus = []workv1alpha2.AggregatedStatusItem{
+		{ClusterName: "cluster1", Health: workv1alpha2.ResourceHealthy},
+	}
+
+	sc := schedulercache.NewCache(nil, nil, 0)
+	// Manually plant an entry to verify it is NOT released.
+	sc.AssigningResourceBindings().Assume("default/cm-binding", "cluster1", schedulercache.AssumedWorkload{
+		Namespace: "default",
+	})
+
+	s := &Scheduler{schedulerCache: sc}
+	s.releaseHealthyClusterAssumptions(oldBinding, newBinding)
+
+	assert.Len(t, sc.AssigningResourceBindings().GetAssumedWorkloads("cluster1"), 1,
+		"non-workload assumption should NOT be released")
+}


### PR DESCRIPTION
**What type of PR is this?**


/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Watch AggregatedStatus changes in ResourceBinding update handler to release scheduler assumption cache.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7481

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

