### PR TITLE
FF-based assumption deduction within noderesource plugin

### DIFF
--- a/pkg/estimator/scheduling_simulator_components_test.go
+++ b/pkg/estimator/scheduling_simulator_components_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -353,6 +354,76 @@ func TestSchedulingSimulator_SimulateSchedulingFF(t *testing.T) {
 			}
 			if result != tt.expectedSets {
 				t.Errorf("SimulateScheduling() = %d, expected %d", result, tt.expectedSets)
+			}
+		})
+	}
+}
+
+// BenchmarkSimulateScheduling_AssumedWorkloadDeduction benchmarks the deduction loop
+// used in the noderesource estimator plugin: for each assumed workload, call
+// SimulateScheduling with upperBound=1 to consume its node resources.
+//
+// Scenario assumptions:
+//   - Scheduler throughput ~100 RB/min, TTL 5 min → up to 500 assumed workloads in cache
+//   - Each assumed workload has 2 components (typical multi-template app: web + db)
+//   - Node clusters of 100 / 500 / 1000 nodes
+func BenchmarkSimulateScheduling_AssumedWorkloadDeduction(b *testing.B) {
+	nodeSizes := []int{100, 500, 1000}
+	const assumedCount = 500
+
+	// Build a typical 2-component assumed workload (web + db pattern)
+	makeAssumedComponents := func() []*pb.Component {
+		return []*pb.Component{
+			{
+				Name:     "web",
+				Replicas: 2,
+				ReplicaRequirements: (&pb.ComponentReplicaRequirements{}).MustSetResourceRequest(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				}),
+			},
+			{
+				Name:     "db",
+				Replicas: 1,
+				ReplicaRequirements: (&pb.ComponentReplicaRequirements{}).MustSetResourceRequest(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				}),
+			},
+		}
+	}
+
+	// Build 500 assumed workloads
+	assumedWorkloads := make([][]*pb.Component, assumedCount)
+	for i := range assumedWorkloads {
+		assumedWorkloads[i] = makeAssumedComponents()
+	}
+
+	// makeNodes returns fresh node clones (nodes are mutated during simulation)
+	makeNodes := func(n int) []*schedulerframework.NodeInfo {
+		nodes := make([]*schedulerframework.NodeInfo, n)
+		for i := range nodes {
+			allocatable := corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("16"),
+				corev1.ResourceMemory: resource.MustParse("32Gi"),
+				corev1.ResourcePods:   resource.MustParse("110"),
+			}
+			nodes[i] = createNodeInfo(fmt.Sprintf("node-%d", i), allocatable)
+		}
+		return nodes
+	}
+
+	for _, nodeCount := range nodeSizes {
+		b.Run(fmt.Sprintf("nodes=%d/assumedWorkloads=%d", nodeCount, assumedCount), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				// Each benchmark iteration simulates one EstimateComponents call:
+				// clone fresh nodes (mimics getNodesAvailableResources) then deduct all assumed workloads
+				nodes := makeNodes(nodeCount)
+				simulator := NewSchedulingSimulator(nodes)
+				for _, components := range assumedWorkloads {
+					_, _ = simulator.SimulateScheduling(components, 1)
+				}
 			}
 		})
 	}

--- a/pkg/estimator/server/framework/plugins/noderesource/noderesource.go
+++ b/pkg/estimator/server/framework/plugins/noderesource/noderesource.go
@@ -127,6 +127,8 @@ func getNodeAvailableResource(node *schedulerframework.NodeInfo) *util.Resource 
 
 // EstimateComponents estimates the maximum number of complete component sets that can be scheduled.
 // It returns the number of sets that can fit on the available node resources.
+// Before running the main estimation, it deducts any assumed (in-flight) workloads so that
+// pods already assigned but not yet reflected in cluster metrics are accounted for.
 func (pl *nodeResourceEstimator) EstimateComponents(_ context.Context, estCtx framework.ComponentEstimationContext) (int32, *framework.Result) {
 	if !pl.enabled {
 		return pl.disabledResult()
@@ -143,7 +145,28 @@ func (pl *nodeResourceEstimator) EstimateComponents(_ context.Context, estCtx fr
 		return 0, framework.AsResult(err)
 	}
 
-	sets, err := estimator.NewSchedulingSimulator(nodes).SimulateScheduling(components, math.MaxInt32)
+	simulator := estimator.NewSchedulingSimulator(nodes)
+
+	// Deduct assumed (in-flight) workloads before running the main estimation.
+	// Each assumed workload represents pods that are being started but may not yet
+	// be reflected in the cluster's node resource accounting.
+	for _, assumed := range estCtx.AssumedWorkloads {
+		if len(assumed.GetComponents()) == 0 {
+			continue
+		}
+		deductedSets, deductErr := simulator.SimulateScheduling(assumed.GetComponents(), 1)
+		if deductErr != nil {
+			return 0, framework.AsResult(deductErr)
+		}
+		if deductedSets == 0 {
+			// The assumed workload could not be placed in the simulation. This is expected when
+			// the workload has already been admitted by the cluster and its resource usage is
+			// already reflected in node.Requested, so no additional deduction is needed.
+			klog.V(4).Infof("%s: could not deduct assumed workload (namespace=%s) from node resources", pl.Name(), assumed.GetNamespace())
+		}
+	}
+
+	sets, err := simulator.SimulateScheduling(components, math.MaxInt32)
 	if err != nil {
 		return 0, framework.AsResult(err)
 	}

--- a/pkg/estimator/server/framework/plugins/noderesource/noderesource_test.go
+++ b/pkg/estimator/server/framework/plugins/noderesource/noderesource_test.go
@@ -31,13 +31,14 @@ import (
 
 func TestNodeResourceEstimator_EstimateComponents(t *testing.T) {
 	tests := []struct {
-		name       string
-		enabled    bool
-		nodes      []*corev1.Node
-		pods       []*corev1.Pod
-		components []*pb.Component
-		expected   int32
-		wantCode   framework.Code
+		name             string
+		enabled          bool
+		nodes            []*corev1.Node
+		pods             []*corev1.Pod
+		components       []*pb.Component
+		assumedWorkloads []*pb.AssumedWorkload
+		expected         int32
+		wantCode         framework.Code
 	}{
 		{
 			name:    "plugin disabled",
@@ -314,6 +315,155 @@ func TestNodeResourceEstimator_EstimateComponents(t *testing.T) {
 			expected:   noNodeConstraint,
 			wantCode:   framework.Noopperation,
 		},
+		{
+			name:    "assumed workload reduces available capacity",
+			enabled: true,
+			nodes: []*corev1.Node{
+				makeNode("node1", map[string]string{}, corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				}),
+			},
+			components: []*pb.Component{
+				{
+					ReplicaRequirements: (&pb.ComponentReplicaRequirements{}).MustSetResourceRequest(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					}),
+					Replicas: 1,
+				},
+			},
+			assumedWorkloads: []*pb.AssumedWorkload{
+				{
+					Namespace: "default",
+					Components: []*pb.Component{
+						{
+							ReplicaRequirements: (&pb.ComponentReplicaRequirements{}).MustSetResourceRequest(corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							}),
+							Replicas: 1,
+						},
+					},
+				},
+			},
+			// node has 4 CPU; assumed workload consumes 1 CPU, leaving 3 CPU for 3 sets
+			expected: 3,
+			wantCode: framework.Success,
+		},
+		{
+			name:    "multiple assumed workloads reduce capacity",
+			enabled: true,
+			nodes: []*corev1.Node{
+				makeNode("node1", map[string]string{}, corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("6"),
+					corev1.ResourceMemory: resource.MustParse("6Gi"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				}),
+			},
+			components: []*pb.Component{
+				{
+					ReplicaRequirements: (&pb.ComponentReplicaRequirements{}).MustSetResourceRequest(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					}),
+					Replicas: 1,
+				},
+			},
+			assumedWorkloads: []*pb.AssumedWorkload{
+				{
+					Namespace: "ns1",
+					Components: []*pb.Component{
+						{
+							ReplicaRequirements: (&pb.ComponentReplicaRequirements{}).MustSetResourceRequest(corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							}),
+							Replicas: 1,
+						},
+					},
+				},
+				{
+					Namespace: "ns2",
+					Components: []*pb.Component{
+						{
+							ReplicaRequirements: (&pb.ComponentReplicaRequirements{}).MustSetResourceRequest(corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("2"),
+								corev1.ResourceMemory: resource.MustParse("2Gi"),
+							}),
+							Replicas: 1,
+						},
+					},
+				},
+			},
+			// node has 6 CPU; assumed workloads consume 1+2=3 CPU, leaving 3 CPU for 3 sets
+			expected: 3,
+			wantCode: framework.Success,
+		},
+		{
+			name:    "assumed workload cannot be placed - deduction skipped, capacity unchanged",
+			enabled: true,
+			nodes: []*corev1.Node{
+				makeNode("node1", map[string]string{}, corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				}),
+			},
+			components: []*pb.Component{
+				{
+					ReplicaRequirements: (&pb.ComponentReplicaRequirements{}).MustSetResourceRequest(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					}),
+					Replicas: 1,
+				},
+			},
+			assumedWorkloads: []*pb.AssumedWorkload{
+				{
+					Namespace: "default",
+					Components: []*pb.Component{
+						{
+							// This assumed workload is too large to fit on any node; deduction is skipped.
+							ReplicaRequirements: (&pb.ComponentReplicaRequirements{}).MustSetResourceRequest(corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100"),
+								corev1.ResourceMemory: resource.MustParse("100Gi"),
+							}),
+							Replicas: 1,
+						},
+					},
+				},
+			},
+			// assumed workload can't fit, deduction is skipped; node capacity is unchanged: 4 sets
+			expected: 4,
+			wantCode: framework.Success,
+		},
+		{
+			name:    "assumed workload with empty components is ignored",
+			enabled: true,
+			nodes: []*corev1.Node{
+				makeNode("node1", map[string]string{}, corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				}),
+			},
+			components: []*pb.Component{
+				{
+					ReplicaRequirements: (&pb.ComponentReplicaRequirements{}).MustSetResourceRequest(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					}),
+					Replicas: 1,
+				},
+			},
+			assumedWorkloads: []*pb.AssumedWorkload{
+				{Namespace: "default", Components: nil},
+			},
+			expected: 4,
+			wantCode: framework.Success,
+		},
 	}
 
 	for _, tt := range tests {
@@ -328,8 +478,9 @@ func TestNodeResourceEstimator_EstimateComponents(t *testing.T) {
 
 			// Execute test
 			result, status := pl.EstimateComponents(context.Background(), framework.ComponentEstimationContext{
-				Snapshot:   snapshot,
-				Components: tt.components,
+				Snapshot:         snapshot,
+				Components:       tt.components,
+				AssumedWorkloads: tt.assumedWorkloads,
 			})
 
 			// Verify results


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7481

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

The deduction loop adds one SimulateScheduling(components, 1) call per assumed workload before the main estimation. Since upperBound=1, each call exits after a single FF pass — there is no repeated unmarshal.

The natural upper bound on assumed workload count is: throughput × TTL = 100 RB/min × 5 min = 500. A benchmark over 500 assumed workloads at node scales of 100 / 500 / 1000 shows the deduction adds approximately 30 ms per EstimateComponents call, with negligible sensitivity to cluster size. This is considered acceptable for a gRPC estimation request.

> Benchmark environment: Intel Xeon Gold 6278C @ 2.60GHz, 4 vCPUs, 15 GiB RAM. Results may vary on production hardware with more cores, as Go benchmarks are single-goroutine by default.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

