### PR TITLE
builds commands with non-TTY stdout to make environment consistent

### DIFF
--- a/hack/tools/gencomponentdocs/gen_component_docs.go
+++ b/hack/tools/gencomponentdocs/gen_component_docs.go
@@ -55,7 +55,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	cmds, err := generateCMDs(module)
+	cmds, err := generateCMDsForDocs(module)
 	if err != nil {
 		fmt.Fprint(os.Stderr, err.Error())
 		os.Exit(1)
@@ -74,6 +74,25 @@ func main() {
 			os.Exit(1)
 		}
 	}
+}
+
+// generateCMDsForDocs builds commands with non-TTY stdout to make environment consistent.
+func generateCMDsForDocs(module string) ([]*cobra.Command, error) {
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer devNull.Close()
+
+	oldStdout := os.Stdout
+	os.Stdout = devNull
+	cmds, err := generateCMDs(module)
+	os.Stdout = oldStdout
+	if err != nil {
+		return nil, err
+	}
+
+	return cmds, nil
 }
 
 func generateCMDs(module string) ([]*cobra.Command, error) {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

<img width="2290" height="1160" alt="image" src="https://github.com/user-attachments/assets/a3450d17-7d18-49cf-8690-bddf80d363d7" />

Different terminal lengths on different machines may result in different line breaks in the output flag document.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

