### PR TITLE
Distinguish event handlers registered for binding resources in the scheduler based on the type of the binding

### DIFF
--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -61,8 +61,8 @@ func (s *Scheduler) addAllEventHandlers() {
 	_, err = clusterBindingInformer.AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: s.resourceBindingEventFilter,
 		Handler: cache.ResourceEventHandlerFuncs{
-			AddFunc:    s.onResourceBindingAdd,
-			UpdateFunc: s.onResourceBindingUpdate,
+			AddFunc:    s.onClusterResourceBindingAdd,
+			UpdateFunc: s.onClusterResourceBindingUpdate,
 		},
 	})
 	if err != nil {
@@ -120,37 +120,36 @@ func (s *Scheduler) resourceBindingEventFilter(obj any) bool {
 		util.GetLabelValue(accessor.GetLabels(), workv1alpha2.BindingManagedByLabel) != ""
 }
 
-func newQueuedBindingInfo(obj any) *internalqueue.QueuedBindingInfo {
-	switch t := obj.(type) {
-	case *workv1alpha2.ResourceBinding:
-		return &internalqueue.QueuedBindingInfo{
-			NamespacedKey: cache.ObjectName{Namespace: t.GetNamespace(), Name: t.GetName()}.String(),
-			Priority:      t.Spec.SchedulePriorityValue(),
-		}
-	case *workv1alpha2.ClusterResourceBinding:
-		return &internalqueue.QueuedBindingInfo{
-			NamespacedKey: t.GetName(),
-			Priority:      t.Spec.SchedulePriorityValue(),
-		}
+// newQueuedBindingInfoFromRB converts a ResourceBinding to a QueuedBindingInfo.
+func newQueuedBindingInfoFromRB(rb *workv1alpha2.ResourceBinding) *internalqueue.QueuedBindingInfo {
+	return &internalqueue.QueuedBindingInfo{
+		NamespacedKey: cache.ObjectName{Namespace: rb.GetNamespace(), Name: rb.GetName()}.String(),
+		Priority:      rb.Spec.SchedulePriorityValue(),
 	}
-
-	return nil
 }
 
-func (s *Scheduler) onResourceBindingAdd(obj any) {
-	if features.FeatureGate.Enabled(features.PriorityBasedScheduling) {
-		bindingInfo := newQueuedBindingInfo(obj)
-		if bindingInfo == nil {
-			// shouldn't happen
-			klog.Errorf("couldn't convert to QueuedBindingInfo %#v", obj)
-			return
-		}
+// newQueuedBindingInfoFromCRB converts a ClusterResourceBinding to a QueuedBindingInfo.
+func newQueuedBindingInfoFromCRB(crb *workv1alpha2.ClusterResourceBinding) *internalqueue.QueuedBindingInfo {
+	return &internalqueue.QueuedBindingInfo{
+		NamespacedKey: crb.GetName(),
+		Priority:      crb.Spec.SchedulePriorityValue(),
+	}
+}
 
-		s.priorityQueue.Push(bindingInfo)
+// onResourceBindingAdd is called when an add event for a ResourceBinding is received from the Informer.
+func (s *Scheduler) onResourceBindingAdd(obj any) {
+	rb, ok := obj.(*workv1alpha2.ResourceBinding)
+	if !ok {
+		klog.Errorf("onResourceBindingAdd: unexpected object type %T", obj)
+		return
+	}
+
+	if features.FeatureGate.Enabled(features.PriorityBasedScheduling) {
+		s.priorityQueue.Push(newQueuedBindingInfoFromRB(rb))
 	} else {
-		key, err := cache.MetaNamespaceKeyFunc(obj)
+		key, err := cache.MetaNamespaceKeyFunc(rb)
 		if err != nil {
-			klog.Errorf("couldn't get key for object %#v: %v", obj, err)
+			klog.Errorf("couldn't get key for object %#v: %v", rb, err)
 			return
 		}
 		s.queue.Add(key)
@@ -158,49 +157,80 @@ func (s *Scheduler) onResourceBindingAdd(obj any) {
 	metrics.CountSchedulerBindings(metrics.BindingAdd)
 }
 
-func (s *Scheduler) onResourceBindingUpdate(old, cur any) {
-	oldMeta, err := meta.Accessor(old)
-	if err != nil {
-		klog.Errorf("Failed to transform oldObj as metav1.Object, error: %v", err)
-		return
-	}
-
-	newMeta, err := meta.Accessor(cur)
-	if err != nil {
-		klog.Errorf("Failed to transform newObj as metav1.Object, error: %v", err)
-		return
-	}
-
-	newResourceBinding, ok := cur.(*workv1alpha2.ResourceBinding)
-	if ok && features.FeatureGate.Enabled(features.WorkloadAffinity) {
-		s.schedulerCache.AssigningResourceBindings().OnBindingUpdate(newResourceBinding)
-	}
-
-	if oldMeta.GetGeneration() == newMeta.GetGeneration() {
-		if oldMeta.GetNamespace() != "" {
-			klog.V(4).Infof("Ignore update event of resourceBinding %s/%s as specification no change", oldMeta.GetNamespace(), oldMeta.GetName())
-		} else {
-			klog.V(4).Infof("Ignore update event of clusterResourceBinding %s as specification no change", oldMeta.GetName())
-		}
+// onClusterResourceBindingAdd is called when an add event for a ClusterResourceBinding is received from the Informer.
+func (s *Scheduler) onClusterResourceBindingAdd(obj any) {
+	crb, ok := obj.(*workv1alpha2.ClusterResourceBinding)
+	if !ok {
+		klog.Errorf("onClusterResourceBindingAdd: unexpected object type %T", obj)
 		return
 	}
 
 	if features.FeatureGate.Enabled(features.PriorityBasedScheduling) {
-		bindingInfo := newQueuedBindingInfo(cur)
-		if bindingInfo == nil {
-			// shouldn't happen
-			klog.Errorf("couldn't convert to QueuedBindingInfo %#v", cur)
-			return
-		}
-
-		s.priorityQueue.Push(bindingInfo)
+		s.priorityQueue.Push(newQueuedBindingInfoFromCRB(crb))
 	} else {
-		key, err := cache.MetaNamespaceKeyFunc(cur)
+		key, err := cache.MetaNamespaceKeyFunc(crb)
 		if err != nil {
-			klog.Errorf("couldn't get key for object %#v: %v", cur, err)
+			klog.Errorf("couldn't get key for object %#v: %v", crb, err)
 			return
 		}
+		s.queue.Add(key)
+	}
+	metrics.CountSchedulerBindings(metrics.BindingAdd)
+}
 
+// onResourceBindingUpdate is called when an update event for a ResourceBinding is received from the Informer.
+func (s *Scheduler) onResourceBindingUpdate(old, cur any) {
+	oldRB, ok1 := old.(*workv1alpha2.ResourceBinding)
+	newRB, ok2 := cur.(*workv1alpha2.ResourceBinding)
+	if !ok1 || !ok2 {
+		klog.Errorf("onResourceBindingUpdate: unexpected object type, old=%T cur=%T", old, cur)
+		return
+	}
+
+	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+		s.schedulerCache.AssigningResourceBindings().OnBindingUpdate(newRB)
+	}
+
+	if oldRB.GetGeneration() == newRB.GetGeneration() {
+		klog.V(4).Infof("Ignore update event of resourceBinding %s/%s as specification no change", newRB.GetNamespace(), newRB.GetName())
+		return
+	}
+
+	if features.FeatureGate.Enabled(features.PriorityBasedScheduling) {
+		s.priorityQueue.Push(newQueuedBindingInfoFromRB(newRB))
+	} else {
+		key, err := cache.MetaNamespaceKeyFunc(newRB)
+		if err != nil {
+			klog.Errorf("couldn't get key for object %#v: %v", newRB, err)
+			return
+		}
+		s.queue.Add(key)
+	}
+	metrics.CountSchedulerBindings(metrics.BindingUpdate)
+}
+
+// onClusterResourceBindingUpdate is called when an update event for a ClusterResourceBinding is received from the Informer.
+func (s *Scheduler) onClusterResourceBindingUpdate(old, cur any) {
+	oldCRB, ok1 := old.(*workv1alpha2.ClusterResourceBinding)
+	newCRB, ok2 := cur.(*workv1alpha2.ClusterResourceBinding)
+	if !ok1 || !ok2 {
+		klog.Errorf("onClusterResourceBindingUpdate: unexpected object type, old=%T cur=%T", old, cur)
+		return
+	}
+
+	if oldCRB.GetGeneration() == newCRB.GetGeneration() {
+		klog.V(4).Infof("Ignore update event of clusterResourceBinding %s as specification no change", newCRB.GetName())
+		return
+	}
+
+	if features.FeatureGate.Enabled(features.PriorityBasedScheduling) {
+		s.priorityQueue.Push(newQueuedBindingInfoFromCRB(newCRB))
+	} else {
+		key, err := cache.MetaNamespaceKeyFunc(newCRB)
+		if err != nil {
+			klog.Errorf("couldn't get key for object %#v: %v", newCRB, err)
+			return
+		}
 		s.queue.Add(key)
 	}
 	metrics.CountSchedulerBindings(metrics.BindingUpdate)
@@ -217,11 +247,11 @@ func (s *Scheduler) onResourceBindingDelete(obj any) {
 			var ok bool
 			binding, ok = t.Obj.(*workv1alpha2.ResourceBinding)
 			if !ok {
-				klog.Errorf("cannot convert to workv1alpha2.ResourceBinding: %v", t.Obj)
+				klog.Errorf("onResourceBindingDelete: cannot convert DeletedFinalStateUnknown.Obj to *workv1alpha2.ResourceBinding: %v", t.Obj)
 				return
 			}
 		default:
-			klog.Errorf("cannot convert to workv1alpha2.ResourceBinding: %v", t)
+			klog.Errorf("onResourceBindingDelete: unexpected object type %T", obj)
 			return
 		}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Compared with ClusterResourceBinding, ResourceBinding has some additional processing in the event handler. If the same function is still used for event processing, the differences will become larger and larger, which will bring more burdens or even errors to subsequent iterations. Therefore, the two functions are processed separately.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

