### PR TITLE
Fix data race in credential tests by waiting for polling goroutines to exit

### DIFF
--- a/pkg/util/credential_test.go
+++ b/pkg/util/credential_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"context"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -59,7 +60,10 @@ func TestObtainCredentialsFromMemberCluster(t *testing.T) {
 				},
 				aop: func(t *testing.T, clusterKubeClient kubernetes.Interface) func() {
 					ctx, cancel := context.WithCancel(context.TODO())
+					var wg sync.WaitGroup
+					wg.Add(1)
 					go func(clusterKubeClient kubernetes.Interface) {
+						defer wg.Done()
 						_ = wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
 							impersonationSA, err := clusterKubeClient.CoreV1().ServiceAccounts("karmada-cluster").Get(ctx, names.GenerateServiceAccountName("impersonator"), metav1.GetOptions{})
 							if err != nil {
@@ -86,6 +90,7 @@ func TestObtainCredentialsFromMemberCluster(t *testing.T) {
 					}(clusterKubeClient)
 					return func() {
 						cancel()
+						wg.Wait()
 					}
 				},
 			},
@@ -103,7 +108,10 @@ func TestObtainCredentialsFromMemberCluster(t *testing.T) {
 				},
 				aop: func(t *testing.T, clusterKubeClient kubernetes.Interface) func() {
 					ctx, cancel := context.WithCancel(context.TODO())
+					var wg sync.WaitGroup
+					wg.Add(1)
 					go func(clusterKubeClient kubernetes.Interface) {
+						defer wg.Done()
 						_ = wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
 							impersonationSA, err := clusterKubeClient.CoreV1().ServiceAccounts("karmada-cluster").Get(ctx, names.GenerateServiceAccountName("impersonator"), metav1.GetOptions{})
 							if err != nil {
@@ -151,6 +159,7 @@ func TestObtainCredentialsFromMemberCluster(t *testing.T) {
 					}(clusterKubeClient)
 					return func() {
 						cancel()
+						wg.Wait()
 					}
 				},
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Fix a Go race detector failure triggered during pkg/util tests by ensuring background polling goroutines are properly stopped before each subtest returns.

ref #7530 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #7530

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

