### PR TITLE
add AssumedWrokloads info to the grpc proto and MaxAvailableReplicas

### DIFF
--- a/pkg/estimator/client/accurate.go
+++ b/pkg/estimator/client/accurate.go
@@ -55,15 +55,14 @@ func NewSchedulerEstimator(cache *SchedulerEstimatorCache, timeout time.Duration
 // MaxAvailableReplicas estimates the maximum replicas that can be applied to the target cluster by calling karmada-scheduler-estimator.
 func (se *SchedulerEstimator) MaxAvailableReplicas(
 	parentCtx context.Context,
-	clusters []*clusterv1alpha1.Cluster,
-	replicaRequirements *workv1alpha2.ReplicaRequirements,
+	req ReplicaEstimationRequest,
 ) ([]workv1alpha2.TargetCluster, error) {
-	clusterNames := make([]string, len(clusters))
-	for i, cluster := range clusters {
+	clusterNames := make([]string, len(req.Clusters))
+	for i, cluster := range req.Clusters {
 		clusterNames[i] = cluster.Name
 	}
 	return getClusterReplicasConcurrently(parentCtx, clusterNames, se.timeout, func(ctx context.Context, cluster string) (int32, error) {
-		return se.maxAvailableReplicas(ctx, cluster, replicaRequirements.DeepCopy())
+		return se.maxAvailableReplicas(ctx, cluster, req.ReplicaRequirements, req.AssumedWorkloads[cluster])
 	})
 }
 
@@ -151,7 +150,7 @@ func toPBReplicaRequirements(cr *workv1alpha2.ComponentReplicaRequirements) (*pb
 	return out, nil
 }
 
-func (se *SchedulerEstimator) maxAvailableReplicas(ctx context.Context, cluster string, replicaRequirements *workv1alpha2.ReplicaRequirements) (int32, error) {
+func (se *SchedulerEstimator) maxAvailableReplicas(ctx context.Context, cluster string, replicaRequirements *workv1alpha2.ReplicaRequirements, assumedWorkloads []AssumedWorkload) (int32, error) {
 	client, err := se.cache.GetClient(cluster)
 	if err != nil {
 		return UnauthenticReplica, err
@@ -178,6 +177,16 @@ func (se *SchedulerEstimator) maxAvailableReplicas(ctx context.Context, cluster 
 			if err = req.ReplicaRequirements.NodeClaim.SetTolerations(replicaRequirements.NodeClaim.Tolerations); err != nil {
 				return UnauthenticReplica, err
 			}
+		}
+	}
+	if len(assumedWorkloads) > 0 {
+		req.AssumedWorkloads = make([]*pb.AssumedWorkload, 0, len(assumedWorkloads))
+		for _, aw := range assumedWorkloads {
+			pbAW, err := toAssumedWorkload(aw)
+			if err != nil {
+				return UnauthenticReplica, err
+			}
+			req.AssumedWorkloads = append(req.AssumedWorkloads, pbAW)
 		}
 	}
 	res, err := client.MaxAvailableReplicas(ctx, req)
@@ -267,4 +276,24 @@ func getClusterComponentSetsConcurrently(
 		}
 	}
 	return results, utilerrors.AggregateGoroutines(funcs...)
+}
+
+// toAssumedWorkload converts an AssumedWorkload client value to its pb wire representation.
+func toAssumedWorkload(aw AssumedWorkload) (*pb.AssumedWorkload, error) {
+	out := &pb.AssumedWorkload{
+		Namespace:  aw.Namespace,
+		Components: make([]*pb.Component, 0, len(aw.Components)),
+	}
+	for _, comp := range aw.Components {
+		reqs, err := toPBReplicaRequirements(comp.ReplicaRequirements)
+		if err != nil {
+			return nil, err
+		}
+		out.Components = append(out.Components, &pb.Component{
+			Name:                comp.Name,
+			Replicas:            comp.Replicas,
+			ReplicaRequirements: reqs,
+		})
+	}
+	return out, nil
 }

--- a/pkg/estimator/client/accurate_test.go
+++ b/pkg/estimator/client/accurate_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/estimator/pb"
+	estimatorservice "github.com/karmada-io/karmada/pkg/estimator/service"
+)
+
+// fakeEstimatorClient is a hand-written stub for estimatorservice.EstimatorClient.
+// It avoids testify/mock's Arguments.Diff, which formats proto messages via %v and
+// triggers a lazyInitOnce deadlock caused by the incomplete rawDescGZIP in estimator.pb.go.
+type fakeEstimatorClient struct {
+	capturedReq *pb.MaxAvailableReplicasRequest
+	maxReplicas int32
+	err         error
+}
+
+func (f *fakeEstimatorClient) MaxAvailableReplicas(_ context.Context, in *pb.MaxAvailableReplicasRequest, _ ...grpc.CallOption) (*pb.MaxAvailableReplicasResponse, error) {
+	f.capturedReq = in
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &pb.MaxAvailableReplicasResponse{MaxReplicas: f.maxReplicas}, nil
+}
+
+func (f *fakeEstimatorClient) MaxAvailableComponentSets(_ context.Context, _ *pb.MaxAvailableComponentSetsRequest, _ ...grpc.CallOption) (*pb.MaxAvailableComponentSetsResponse, error) {
+	return nil, nil
+}
+
+func (f *fakeEstimatorClient) GetUnschedulableReplicas(_ context.Context, _ *pb.UnschedulableReplicasRequest, _ ...grpc.CallOption) (*pb.UnschedulableReplicasResponse, error) {
+	return nil, nil
+}
+
+// compile-time check
+var _ estimatorservice.EstimatorClient = (*fakeEstimatorClient)(nil)
+
+func Test_toAssumedWorkload(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          AssumedWorkload
+		wantNS         string
+		wantLen        int
+		wantComponents func(t *testing.T, comps []*pb.Component)
+		wantErr        bool
+	}{
+		{
+			name: "no components",
+			input: AssumedWorkload{
+				Namespace:  "default",
+				Components: nil,
+			},
+			wantNS:  "default",
+			wantLen: 0,
+			wantComponents: func(t *testing.T, comps []*pb.Component) {
+				assert.Empty(t, comps)
+			},
+		},
+		{
+			name: "component with nil ReplicaRequirements",
+			input: AssumedWorkload{
+				Namespace: "ns1",
+				Components: []workv1alpha2.Component{
+					{
+						Name:                "worker",
+						Replicas:            3,
+						ReplicaRequirements: nil,
+					},
+				},
+			},
+			wantNS:  "ns1",
+			wantLen: 1,
+			wantComponents: func(t *testing.T, comps []*pb.Component) {
+				assert.Equal(t, "worker", comps[0].Name)
+				assert.EqualValues(t, 3, comps[0].Replicas)
+				assert.Nil(t, comps[0].ReplicaRequirements)
+			},
+		},
+		{
+			name: "component with ReplicaRequirements",
+			input: AssumedWorkload{
+				Namespace: "ns2",
+				Components: []workv1alpha2.Component{
+					{
+						Name:     "server",
+						Replicas: 2,
+						ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+							ResourceRequest: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+						},
+					},
+				},
+			},
+			wantNS:  "ns2",
+			wantLen: 1,
+			wantComponents: func(t *testing.T, comps []*pb.Component) {
+				assert.Equal(t, "server", comps[0].Name)
+				assert.EqualValues(t, 2, comps[0].Replicas)
+				require.NotNil(t, comps[0].ReplicaRequirements)
+			},
+		},
+		{
+			name: "multiple components",
+			input: AssumedWorkload{
+				Namespace: "ns3",
+				Components: []workv1alpha2.Component{
+					{Name: "a", Replicas: 1, ReplicaRequirements: nil},
+					{Name: "b", Replicas: 2, ReplicaRequirements: nil},
+				},
+			},
+			wantNS:  "ns3",
+			wantLen: 2,
+			wantComponents: func(t *testing.T, comps []*pb.Component) {
+				assert.Equal(t, "a", comps[0].Name)
+				assert.Equal(t, "b", comps[1].Name)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toAssumedWorkload(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantNS, got.Namespace)
+			assert.Len(t, got.Components, tt.wantLen)
+			if tt.wantComponents != nil {
+				tt.wantComponents(t, got.Components)
+			}
+		})
+	}
+}
+
+func Test_maxAvailableReplicas_assumedWorkloads(t *testing.T) {
+	const clusterName = "cluster-a"
+	const wantMaxReplicas = int32(10)
+
+	tests := []struct {
+		name             string
+		assumedWorkloads []AssumedWorkload
+		wantPBCount      int
+	}{
+		{
+			name:             "no assumed workloads — AssumedWorkloads field empty in request",
+			assumedWorkloads: nil,
+			wantPBCount:      0,
+		},
+		{
+			name: "single assumed workload forwarded in gRPC request",
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Namespace: "default",
+					Components: []workv1alpha2.Component{
+						{Name: "web", Replicas: 2, ReplicaRequirements: nil},
+					},
+				},
+			},
+			wantPBCount: 1,
+		},
+		{
+			name: "multiple assumed workloads forwarded in gRPC request",
+			assumedWorkloads: []AssumedWorkload{
+				{Namespace: "ns1", Components: []workv1alpha2.Component{{Name: "a", Replicas: 1}}},
+				{Namespace: "ns2", Components: []workv1alpha2.Component{{Name: "b", Replicas: 3}}},
+			},
+			wantPBCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeEstimatorClient{maxReplicas: wantMaxReplicas}
+
+			c := NewSchedulerEstimatorCache()
+			c.AddCluster(clusterName, nil, fake)
+
+			se := NewSchedulerEstimator(c, 5*time.Second)
+			got, err := se.maxAvailableReplicas(context.Background(), clusterName, nil, tt.assumedWorkloads)
+
+			require.NoError(t, err)
+			assert.Equal(t, wantMaxReplicas, got)
+
+			require.NotNil(t, fake.capturedReq, "expected gRPC request to be captured")
+			assert.Len(t, fake.capturedReq.AssumedWorkloads, tt.wantPBCount)
+
+			// Verify namespace is preserved for each assumed workload.
+			for i, aw := range tt.assumedWorkloads {
+				assert.Equal(t, aw.Namespace, fake.capturedReq.AssumedWorkloads[i].Namespace)
+			}
+		})
+	}
+}

--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -54,10 +54,10 @@ func NewGeneralEstimator() *GeneralEstimator {
 }
 
 // MaxAvailableReplicas estimates the maximum replicas that can be applied to the target cluster by cluster ResourceSummary.
-func (ge *GeneralEstimator) MaxAvailableReplicas(_ context.Context, clusters []*clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) ([]workv1alpha2.TargetCluster, error) {
-	availableTargetClusters := make([]workv1alpha2.TargetCluster, len(clusters))
-	for i, cluster := range clusters {
-		maxReplicas := ge.maxAvailableReplicas(cluster, replicaRequirements)
+func (ge *GeneralEstimator) MaxAvailableReplicas(_ context.Context, req ReplicaEstimationRequest) ([]workv1alpha2.TargetCluster, error) {
+	availableTargetClusters := make([]workv1alpha2.TargetCluster, len(req.Clusters))
+	for i, cluster := range req.Clusters {
+		maxReplicas := ge.maxAvailableReplicas(cluster, req.ReplicaRequirements)
 		availableTargetClusters[i] = workv1alpha2.TargetCluster{Name: cluster.Name, Replicas: maxReplicas}
 	}
 	return availableTargetClusters, nil

--- a/pkg/estimator/client/general_test.go
+++ b/pkg/estimator/client/general_test.go
@@ -623,7 +623,10 @@ func TestMaxAvailableReplicas(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			estimator := NewGeneralEstimator()
-			targets, err := estimator.MaxAvailableReplicas(context.Background(), tt.clusters, tt.replicaRequirements)
+			targets, err := estimator.MaxAvailableReplicas(context.Background(), ReplicaEstimationRequest{
+				Clusters:            tt.clusters,
+				ReplicaRequirements: tt.replicaRequirements,
+			})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedTargets, targets)
 		})

--- a/pkg/estimator/client/interface.go
+++ b/pkg/estimator/client/interface.go
@@ -38,7 +38,7 @@ var (
 // based on resource availability and node constraints.
 type ReplicaEstimator interface {
 	// MaxAvailableReplicas returns the maximum number of replicas of a single-component workload that each cluster can host.
-	MaxAvailableReplicas(ctx context.Context, clusters []*clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) ([]workv1alpha2.TargetCluster, error)
+	MaxAvailableReplicas(ctx context.Context, req ReplicaEstimationRequest) ([]workv1alpha2.TargetCluster, error)
 	// MaxAvailableComponentSets returns the maximum number of complete multi-component sets (in terms of replicas) that each cluster can host.
 	MaxAvailableComponentSets(ctx context.Context, req ComponentSetEstimationRequest) ([]ComponentSetEstimationResponse, error)
 }
@@ -53,6 +53,21 @@ type AssumedWorkload struct {
 	// Components lists the component types and their per-replica resource requirements
 	// that are assumed on the target cluster.
 	Components []workv1alpha2.Component
+}
+
+// ReplicaEstimationRequest carries input parameters for estimating single-template workload
+// replica availability per cluster.
+type ReplicaEstimationRequest struct {
+	// Clusters represents a list of feasible clusters to estimate against.
+	Clusters []*clusterv1alpha1.Cluster
+	// ReplicaRequirements describes the resource requirements of a single-template workload replica.
+	ReplicaRequirements *workv1alpha2.ReplicaRequirements
+	// AssumedWorkloads maps cluster name to the in-flight workloads that have already
+	// been assigned to that cluster but whose pods have not yet been bound to nodes.
+	// The estimator deducts each cluster's assumed footprint from available capacity
+	// to avoid over-commitment during back-to-back scheduling cycles.
+	// +optional
+	AssumedWorkloads map[string][]AssumedWorkload
 }
 
 // ComponentSetEstimationRequest carries input parameters for estimating multi-component set availability per cluster.

--- a/pkg/estimator/pb/estimator.pb.go
+++ b/pkg/estimator/pb/estimator.pb.go
@@ -396,8 +396,14 @@ type MaxAvailableReplicasRequest struct {
 	// ReplicaRequirements represents the resource and scheduling requirements for each replica.
 	// +required
 	ReplicaRequirements *ReplicaRequirements `protobuf:"bytes,2,opt,name=replicaRequirements,proto3" json:"replicaRequirements,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// AssumedWorkloads lists in-flight workloads that have already been assigned
+	// to this cluster but whose pods have not yet been bound to nodes.
+	// The estimator deducts their resource footprint from the available capacity
+	// to avoid over-commitment during back-to-back scheduling cycles.
+	// +optional
+	AssumedWorkloads []*AssumedWorkload `protobuf:"bytes,3,rep,name=assumedWorkloads,proto3" json:"assumedWorkloads,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *MaxAvailableReplicasRequest) Reset() {
@@ -440,6 +446,13 @@ func (x *MaxAvailableReplicasRequest) GetCluster() string {
 func (x *MaxAvailableReplicasRequest) GetReplicaRequirements() *ReplicaRequirements {
 	if x != nil {
 		return x.ReplicaRequirements
+	}
+	return nil
+}
+
+func (x *MaxAvailableReplicasRequest) GetAssumedWorkloads() []*AssumedWorkload {
+	if x != nil {
+		return x.AssumedWorkloads
 	}
 	return nil
 }
@@ -921,10 +934,11 @@ const file_pkg_estimator_pb_estimator_proto_rawDesc = "" +
 	"\tnamespace\x18\x03 \x01(\tR\tnamespace\x12k\n" +
 	"\x10assumedWorkloads\x18\x04 \x03(\v2?.github.com.karmada_io.karmada.pkg.estimator.pb.AssumedWorkloadR\x10assumedWorkloads\"=\n" +
 	"!MaxAvailableComponentSetsResponse\x12\x18\n" +
-	"\amaxSets\x18\x01 \x01(\x05R\amaxSets\"\xae\x01\n" +
+	"\amaxSets\x18\x01 \x01(\x05R\amaxSets\"\x9b\x02\n" +
 	"\x1bMaxAvailableReplicasRequest\x12\x18\n" +
 	"\acluster\x18\x01 \x01(\tR\acluster\x12u\n" +
-	"\x13replicaRequirements\x18\x02 \x01(\v2C.github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirementsR\x13replicaRequirements\"@\n" +
+	"\x13replicaRequirements\x18\x02 \x01(\v2C.github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirementsR\x13replicaRequirements\x12k\n" +
+	"\x10assumedWorkloads\x18\x03 \x03(\v2?.github.com.karmada_io.karmada.pkg.estimator.pb.AssumedWorkloadR\x10assumedWorkloads\"@\n" +
 	"\x1cMaxAvailableReplicasResponse\x12 \n" +
 	"\vmaxReplicas\x18\x01 \x01(\x05R\vmaxReplicas\"\xbd\x03\n" +
 	"\tNodeClaim\x12M\n" +
@@ -1009,20 +1023,21 @@ var file_pkg_estimator_pb_estimator_proto_depIdxs = []int32{
 	0,  // 5: github.com.karmada_io.karmada.pkg.estimator.pb.MaxAvailableComponentSetsRequest.components:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.Component
 	2,  // 6: github.com.karmada_io.karmada.pkg.estimator.pb.MaxAvailableComponentSetsRequest.assumedWorkloads:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.AssumedWorkload
 	9,  // 7: github.com.karmada_io.karmada.pkg.estimator.pb.MaxAvailableReplicasRequest.replicaRequirements:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements
-	17, // 8: github.com.karmada_io.karmada.pkg.estimator.pb.NodeClaim.nodeAffinity:type_name -> k8s.io.api.core.v1.NodeSelector
-	14, // 9: github.com.karmada_io.karmada.pkg.estimator.pb.NodeClaim.nodeSelector:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.NodeClaim.NodeSelectorEntry
-	18, // 10: github.com.karmada_io.karmada.pkg.estimator.pb.NodeClaim.tolerations:type_name -> k8s.io.api.core.v1.Toleration
-	7,  // 11: github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements.nodeClaim:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.NodeClaim
-	15, // 12: github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements.resourceRequest:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements.ResourceRequestEntry
-	16, // 13: github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements.resourceRequestBytes:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements.ResourceRequestBytesEntry
-	8,  // 14: github.com.karmada_io.karmada.pkg.estimator.pb.UnschedulableReplicasRequest.resource:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.ObjectReference
-	19, // 15: github.com.karmada_io.karmada.pkg.estimator.pb.ComponentReplicaRequirements.ResourceRequestEntry.value:type_name -> k8s.io.apimachinery.pkg.api.resource.Quantity
-	19, // 16: github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements.ResourceRequestEntry.value:type_name -> k8s.io.apimachinery.pkg.api.resource.Quantity
-	17, // [17:17] is the sub-list for method output_type
-	17, // [17:17] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	2,  // 8: github.com.karmada_io.karmada.pkg.estimator.pb.MaxAvailableReplicasRequest.assumedWorkloads:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.AssumedWorkload
+	17, // 9: github.com.karmada_io.karmada.pkg.estimator.pb.NodeClaim.nodeAffinity:type_name -> k8s.io.api.core.v1.NodeSelector
+	14, // 10: github.com.karmada_io.karmada.pkg.estimator.pb.NodeClaim.nodeSelector:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.NodeClaim.NodeSelectorEntry
+	18, // 11: github.com.karmada_io.karmada.pkg.estimator.pb.NodeClaim.tolerations:type_name -> k8s.io.api.core.v1.Toleration
+	7,  // 12: github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements.nodeClaim:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.NodeClaim
+	15, // 13: github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements.resourceRequest:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements.ResourceRequestEntry
+	16, // 14: github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements.resourceRequestBytes:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements.ResourceRequestBytesEntry
+	8,  // 15: github.com.karmada_io.karmada.pkg.estimator.pb.UnschedulableReplicasRequest.resource:type_name -> github.com.karmada_io.karmada.pkg.estimator.pb.ObjectReference
+	19, // 16: github.com.karmada_io.karmada.pkg.estimator.pb.ComponentReplicaRequirements.ResourceRequestEntry.value:type_name -> k8s.io.apimachinery.pkg.api.resource.Quantity
+	19, // 17: github.com.karmada_io.karmada.pkg.estimator.pb.ReplicaRequirements.ResourceRequestEntry.value:type_name -> k8s.io.apimachinery.pkg.api.resource.Quantity
+	18, // [18:18] is the sub-list for method output_type
+	18, // [18:18] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_pkg_estimator_pb_estimator_proto_init() }

--- a/pkg/estimator/pb/estimator.proto
+++ b/pkg/estimator/pb/estimator.proto
@@ -125,6 +125,13 @@ message MaxAvailableReplicasRequest {
   // ReplicaRequirements represents the resource and scheduling requirements for each replica.
   // +required
   ReplicaRequirements replicaRequirements = 2;
+
+  // AssumedWorkloads lists in-flight workloads that have already been assigned
+  // to this cluster but whose pods have not yet been bound to nodes.
+  // The estimator deducts their resource footprint from the available capacity
+  // to avoid over-commitment during back-to-back scheduling cycles.
+  // +optional
+  repeated AssumedWorkload assumedWorkloads = 3;
 }
 
 // MaxAvailableReplicasResponse represents the response that sent by gRPC server to calculate max available replicas.

--- a/pkg/scheduler/core/estimation_test.go
+++ b/pkg/scheduler/core/estimation_test.go
@@ -38,7 +38,7 @@ type mockReplicaEstimator struct {
 	lastComponentSetRequest           estimatorclient.ComponentSetEstimationRequest
 }
 
-func (m *mockReplicaEstimator) MaxAvailableReplicas(_ context.Context, _ []*clusterv1alpha1.Cluster, _ *workv1alpha2.ReplicaRequirements) ([]workv1alpha2.TargetCluster, error) {
+func (m *mockReplicaEstimator) MaxAvailableReplicas(_ context.Context, _ estimatorclient.ReplicaEstimationRequest) ([]workv1alpha2.TargetCluster, error) {
 	return nil, nil
 }
 

--- a/pkg/scheduler/core/util.go
+++ b/pkg/scheduler/core/util.go
@@ -76,6 +76,9 @@ func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha
 	estimators := estimatorclient.GetReplicaEstimators()
 	ctx := context.WithValue(context.TODO(), util.ContextKeyObject,
 		fmt.Sprintf("kind=%s, name=%s/%s", spec.Resource.Kind, spec.Resource.Namespace, spec.Resource.Name))
+	// Build assumed workloads once outside the estimator loop as it only depends on
+	// clusters and assigningCache, both of which are constant for the entire loop.
+	assumedWorkloads := buildAssumedWorkloadsByCluster(clusters, assigningCache)
 	for name, estimator := range estimators {
 		if features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) && isMultiTemplateSchedulingApplicable(spec) {
 			var err error
@@ -91,7 +94,11 @@ func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha
 				continue
 			}
 		} else {
-			res, err := estimator.MaxAvailableReplicas(ctx, clusters, spec.ReplicaRequirements)
+			res, err := estimator.MaxAvailableReplicas(ctx, estimatorclient.ReplicaEstimationRequest{
+				Clusters:            clusters,
+				ReplicaRequirements: spec.ReplicaRequirements,
+				AssumedWorkloads:    assumedWorkloads,
+			})
 			if err != nil {
 				klog.Errorf("Max cluster available replicas error: %v", err)
 				continue


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:


- R1 — Proto: extend MaxAvailableReplicasRequest
- R2 — Scheduler client: populate AssumedWorkloads in gRPC request
- R3 — Scheduler core: thread assumed workloads through calAvailableReplicas

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7481

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-scheduler-estimator`: Introduce AssumedWorkload into the gRPC message MaxAvailableReplicasRequest.
```

