### PR TITLE
Fix ComponentResource for flink deployment custom interpreter

### DIFF
--- a/pkg/resourceinterpreter/customized/declarative/luavm/kube.go
+++ b/pkg/resourceinterpreter/customized/declarative/luavm/kube.go
@@ -58,12 +58,11 @@ func KubeLoader(ls *lua.LState) int {
 }
 
 var kubeFuncs = map[string]lua.LGFunction{
-	"resourceAdd":               resourceAdd,
-	"accuratePodRequirements":   accuratePodRequirements,
-	"getPodDependencies":        getPodDependencies,
-	"getResourceQuantity":       getResourceQuantity,
-	"getResourceQuantityString": getResourceQuantityString,
-	"parseFlinkMemory":          parseFlinkMemory,
+	"resourceAdd":             resourceAdd,
+	"accuratePodRequirements": accuratePodRequirements,
+	"getPodDependencies":      getPodDependencies,
+	"getResourceQuantity":     getResourceQuantity,
+	"parseFlinkMemory":        parseFlinkMemory,
 }
 
 func resourceAdd(ls *lua.LState) int {
@@ -158,36 +157,25 @@ func getResourceQuantity(ls *lua.LState) int {
 	return 1
 }
 
-func getResourceQuantityString(ls *lua.LState) int {
-	if ls.GetTop() != 1 {
-		ls.RaiseError("getResourceQuantityString only accepts one argument")
-		return 0
-	}
-
-	q := checkResourceQuantity(ls, 1)
-	ls.Push(lua.LString(q.String())) // preserves suffix/format
-	return 1
-}
-
 // flinkMemoryMultipliers maps Flink MemorySize suffixes to byte multipliers.
 // Flink uses binary (1024-based) multipliers: b=1, k=1024, m=1024^2, g=1024^3, t=1024^4.
 // See: org.apache.flink.configuration.MemorySize.MemoryUnit
 var flinkMemoryMultipliers = map[string]int64{
-	"":           1,
-	"b":          1,
-	"bytes":      1,
-	"k":          1024,
-	"kb":         1024,
-	"kibibytes":  1024,
-	"m":          1048576,
-	"mb":         1048576,
-	"mebibytes":  1048576,
-	"g":          1073741824,
-	"gb":         1073741824,
-	"gibibytes":  1073741824,
-	"t":          1099511627776,
-	"tb":         1099511627776,
-	"tebibytes":  1099511627776,
+	"":          1,
+	"b":         1,
+	"bytes":     1,
+	"k":         1024,
+	"kb":        1024,
+	"kibibytes": 1024,
+	"m":         1048576,
+	"mb":        1048576,
+	"mebibytes": 1048576,
+	"g":         1073741824,
+	"gb":        1073741824,
+	"gibibytes": 1073741824,
+	"t":         1099511627776,
+	"tb":        1099511627776,
+	"tebibytes": 1099511627776,
 }
 
 // parseFlinkMemory parses a Flink memory string (e.g., "4096m", "2g") and returns

--- a/pkg/resourceinterpreter/customized/declarative/luavm/kube.go
+++ b/pkg/resourceinterpreter/customized/declarative/luavm/kube.go
@@ -18,6 +18,8 @@ package luavm
 
 import (
 	"math"
+	"strconv"
+	"strings"
 
 	lua "github.com/yuin/gopher-lua"
 	corev1 "k8s.io/api/core/v1"
@@ -56,10 +58,12 @@ func KubeLoader(ls *lua.LState) int {
 }
 
 var kubeFuncs = map[string]lua.LGFunction{
-	"resourceAdd":             resourceAdd,
-	"accuratePodRequirements": accuratePodRequirements,
-	"getPodDependencies":      getPodDependencies,
-	"getResourceQuantity":     getResourceQuantity,
+	"resourceAdd":               resourceAdd,
+	"accuratePodRequirements":   accuratePodRequirements,
+	"getPodDependencies":        getPodDependencies,
+	"getResourceQuantity":       getResourceQuantity,
+	"getResourceQuantityString": getResourceQuantityString,
+	"parseFlinkMemory":          parseFlinkMemory,
 }
 
 func resourceAdd(ls *lua.LState) int {
@@ -151,6 +155,86 @@ func getResourceQuantity(ls *lua.LState) int {
 	}
 
 	ls.Push(lua.LNumber(num))
+	return 1
+}
+
+func getResourceQuantityString(ls *lua.LState) int {
+	if ls.GetTop() != 1 {
+		ls.RaiseError("getResourceQuantityString only accepts one argument")
+		return 0
+	}
+
+	q := checkResourceQuantity(ls, 1)
+	ls.Push(lua.LString(q.String())) // preserves suffix/format
+	return 1
+}
+
+// flinkMemoryMultipliers maps Flink MemorySize suffixes to byte multipliers.
+// Flink uses binary (1024-based) multipliers: b=1, k=1024, m=1024^2, g=1024^3, t=1024^4.
+// See: org.apache.flink.configuration.MemorySize.MemoryUnit
+var flinkMemoryMultipliers = map[string]int64{
+	"":           1,
+	"b":          1,
+	"bytes":      1,
+	"k":          1024,
+	"kb":         1024,
+	"kibibytes":  1024,
+	"m":          1048576,
+	"mb":         1048576,
+	"mebibytes":  1048576,
+	"g":          1073741824,
+	"gb":         1073741824,
+	"gibibytes":  1073741824,
+	"t":          1099511627776,
+	"tb":         1099511627776,
+	"tebibytes":  1099511627776,
+}
+
+// parseFlinkMemory parses a Flink memory string (e.g., "4096m", "2g") and returns
+// the value in bytes as a Lua number. This is needed because Flink's "m" suffix means
+// mebibytes (1024^2), while Kubernetes' resource.MustParse interprets "m" as milli (10^-3).
+func parseFlinkMemory(ls *lua.LState) int {
+	if ls.GetTop() != 1 {
+		ls.RaiseError("parseFlinkMemory only accepts one argument")
+		return 0
+	}
+
+	v := ls.Get(1)
+	if v.Type() == lua.LTNil {
+		ls.Push(lua.LNumber(0))
+		return 1
+	}
+
+	s := strings.TrimSpace(ls.CheckString(1))
+	if len(s) == 0 {
+		ls.Push(lua.LNumber(0))
+		return 1
+	}
+
+	// Extract leading digits.
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		ls.Push(lua.LNumber(0))
+		return 1
+	}
+
+	value, err := strconv.ParseInt(s[:i], 10, 64)
+	if err != nil {
+		ls.RaiseError("parseFlinkMemory: invalid number %q: %v", s[:i], err)
+		return 0
+	}
+
+	suffix := strings.ToLower(strings.TrimSpace(s[i:]))
+	mult, ok := flinkMemoryMultipliers[suffix]
+	if !ok {
+		ls.RaiseError("parseFlinkMemory: unrecognized suffix %q", suffix)
+		return 0
+	}
+
+	ls.Push(lua.LNumber(value * mult))
 	return 1
 }
 

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
@@ -169,7 +169,7 @@ spec:
             jm_requires.resourceRequest.cpu = jm_cpu
           end
           if jm_memory ~= nil then
-            jm_requires.resourceRequest.memory = kube.getResourceQuantity(jm_memory)
+            jm_requires.resourceRequest.memory = kube.parseFlinkMemory(jm_memory)
           end
           apply_pod_template(pt_spec, jm_requires)
 
@@ -203,7 +203,7 @@ spec:
             tm_requires.resourceRequest.cpu = tm_cpu
           end
           if tm_memory ~= nil then
-            tm_requires.resourceRequest.memory = kube.getResourceQuantity(tm_memory)
+            tm_requires.resourceRequest.memory = kube.parseFlinkMemory(tm_memory)
           end
           apply_pod_template(pt_spec, tm_requires)
 
@@ -286,17 +286,17 @@ spec:
           local jm_memory = get(observedObj, {"spec","jobManager","resource","memory"})
           local tm_memory = get(observedObj, {"spec","taskManager","resource","memory"})
           if jm_memory ~= nil and tm_memory ~= nil then
-            local jm_memory_value = kube.getResourceQuantity(jm_memory)
-            local tm_memory_value = kube.getResourceQuantity(tm_memory)
+            local jm_memory_value = kube.parseFlinkMemory(jm_memory)
+            local tm_memory_value = kube.parseFlinkMemory(tm_memory)
             if jm_memory_value > tm_memory_value then
-              requires.resourceRequest.memory = jm_memory
+              requires.resourceRequest.memory = jm_memory_value
             else
-              requires.resourceRequest.memory = tm_memory
+              requires.resourceRequest.memory = tm_memory_value
             end
           elseif jm_memory ~= nil then
-            requires.resourceRequest.memory = jm_memory
+            requires.resourceRequest.memory = kube.parseFlinkMemory(jm_memory)
           elseif tm_memory ~= nil then
-            requires.resourceRequest.memory = tm_memory
+            requires.resourceRequest.memory = kube.parseFlinkMemory(tm_memory)
           end
 
           -- Until multiple podTemplates are supported, interpreter will only take affinity, toleration, and priorityclass input to common podTemplate

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/testdata/interpretcomponent-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/testdata/interpretcomponent-test.yaml
@@ -42,13 +42,13 @@ output:
       replicaRequirements:
         resourceRequest:
           "cpu": "1"
-          "memory": "2048m"
+          "memory": "2147483648"
     - name: taskmanager
       replicas: 1
       replicaRequirements:
         resourceRequest:
           "cpu": "1"
-          "memory": "2048m"
+          "memory": "2147483648"
 
 ---
 name: "FlinkDeployment with taskManager.replicas not set, use parallelism/numberOfTaskSlots"
@@ -86,13 +86,13 @@ output:
       replicaRequirements:
         resourceRequest:
           "cpu": "1"
-          "memory": "2048m"
+          "memory": "2147483648"
     - name: taskmanager
       replicas: 5
       replicaRequirements:
         resourceRequest:
           "cpu": "1"
-          "memory": "2048m"
+          "memory": "2147483648"
 
 ---
 name: "FlinkDeployment with podTemplate containing nodeSelector, tolerations, and priorityClassName"
@@ -137,7 +137,7 @@ output:
       replicaRequirements:
         resourceRequest:
           "cpu": "1"
-          "memory": "2048m"
+          "memory": "2147483648"
         nodeClaim:
           nodeSelector:
             disktype: ssd
@@ -153,7 +153,7 @@ output:
       replicaRequirements:
         resourceRequest:
           "cpu": "1"
-          "memory": "2048m"
+          "memory": "2147483648"
         nodeClaim:
           nodeSelector:
             disktype: ssd
@@ -194,13 +194,13 @@ output:
       replicaRequirements:
         resourceRequest:
           "cpu": "1"
-          "memory": "2048m"
+          "memory": "2147483648"
     - name: taskmanager
       replicas: 1
       replicaRequirements:
         resourceRequest:
           "cpu": "1"
-          "memory": "2048m"
+          "memory": "2147483648"
 
 ---
 name: "FlinkDeployment with jobManager.replicas not set should default to 1"
@@ -233,11 +233,11 @@ output:
       replicaRequirements:
         resourceRequest:
           "cpu": "1"
-          "memory": "2048m"
+          "memory": "2147483648"
     - name: taskmanager
       replicas: 2
       replicaRequirements:
         resourceRequest:
           "cpu": "1"
-          "memory": "2048m"
+          "memory": "2147483648"
 

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/testdata/interpretreplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/testdata/interpretreplica-test.yaml
@@ -44,7 +44,7 @@ output:
   requires:
     resourceRequest:
       "cpu": "1"
-      "memory": "2048m"
+      "memory": "2147483648"
     namespace: "test-namespace"
 
 ---
@@ -81,7 +81,7 @@ output:
   requires:
     resourceRequest:
       "cpu": "1"
-      "memory": "2048m"
+      "memory": "2147483648"
     namespace: "test-namespace"
 
 ---
@@ -125,7 +125,7 @@ output:
   requires:
     resourceRequest:
       "cpu": "1"
-      "memory": "2048m"
+      "memory": "2147483648"
     nodeClaim:
       nodeSelector:
         disktype: ssd
@@ -167,7 +167,7 @@ output:
   requires:
     resourceRequest:
       "cpu": "1"
-      "memory": "2048m"
+      "memory": "2147483648"
     namespace: "test-namespace"
 
 ---
@@ -199,7 +199,7 @@ output:
   requires:
     resourceRequest:
       "cpu": "1"
-      "memory": "2048m"
+      "memory": "2147483648"
     namespace: "test-namespace"
 
 ---
@@ -232,7 +232,7 @@ output:
   requires:
     resourceRequest:
       "cpu": "2"
-      "memory": "4096m"
+      "memory": "4294967296"
     namespace: "test-namespace"
 
 ---
@@ -265,7 +265,7 @@ output:
   requires:
     resourceRequest:
       "cpu": "2"
-      "memory": "8192m"
+      "memory": "8589934592"
     namespace: "test-namespace"
 
 ---
@@ -293,7 +293,7 @@ output:
   requires:
     resourceRequest:
       "cpu": "1"
-      "memory": "2048m"
+      "memory": "2147483648"
     namespace: "test-namespace"
 
 ---
@@ -329,6 +329,5 @@ output:
   requires:
     resourceRequest:
       "cpu": "1"
-      "memory": "2048m"
-    namespace: "test-namespace"
+      "memory": "2147483648"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
For resource notion, Apache Flink uses "m" for mebibyte, however, Kuberentes uses "m" for millibyte. The current resource interpreter uses Kubernetes resource parser for parsing flink component resource requirements. This incorrectly interprets flink JM/TM memory (e.g. 1024 MiB to 1.024 Bytes in resourcebinding)

This PR adds a function to interpret flink resource notion in flink custom interpreter.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->


<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`resource-interpreter`: Fix flink interpreter to correctly parse flink memory requirements
```

