### PR TITLE
fix: use os.IsNotExist for path existence check

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -415,7 +415,11 @@ func (i *CommandInitOption) initializeCommandLineArgs() {
 
 // initializeDirectory initializes a directory and makes sure it's empty.
 func initializeDirectory(path string) error {
-	if utils.IsExist(path) {
+	exist, err := utils.PathExists(path)
+	if err != nil {
+		return fmt.Errorf("failed to check path %q: %w", path, err)
+	}
+	if exist {
 		if err := os.RemoveAll(path); err != nil {
 			return err
 		}
@@ -518,7 +522,10 @@ func (i *CommandInitOption) prepareCRD() error {
 
 	for _, archive := range validation.CrdsArchive {
 		expectedDir := filepath.Join(i.KarmadaDataPath, archive)
-		exist, _ := utils.PathExists(expectedDir)
+		exist, err := utils.PathExists(expectedDir)
+		if err != nil {
+			return fmt.Errorf("failed to check path %q: %w", expectedDir, err)
+		}
 		if !exist {
 			return fmt.Errorf("lacking the necessary file path: %s", expectedDir)
 		}

--- a/pkg/karmadactl/cmdinit/utils/format.go
+++ b/pkg/karmadactl/cmdinit/utils/format.go
@@ -41,12 +41,6 @@ const (
 	MaxRespBodyLength = 1 << 20 // 1 MiB
 )
 
-// IsExist Determine whether the path exists
-func IsExist(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
 // StringToNetIP String To NetIP
 func StringToNetIP(addr string) net.IP {
 	if ip := net.ParseIP(addr); ip != nil {

--- a/pkg/karmadactl/cmdinit/utils/format_test.go
+++ b/pkg/karmadactl/cmdinit/utils/format_test.go
@@ -28,32 +28,6 @@ func stringInslice(target string, strArray []string) bool {
 	return slices.Contains(strArray, target)
 }
 
-func TestIsExist(t *testing.T) {
-	tests := []struct {
-		name string
-		path string
-		want bool
-	}{
-		{
-			name: "path exist",
-			path: "./",
-			want: true,
-		},
-		{
-			name: "path is not exist",
-			path: "for-a-not-exist-path" + randString(),
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := IsExist(tt.path); got != tt.want {
-				t.Errorf("IsExist() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestStringToNetIP(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/karmadactl/cmdinit/utils/util_test.go
+++ b/pkg/karmadactl/cmdinit/utils/util_test.go
@@ -137,3 +137,34 @@ func TestListFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestPathExists(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "path exist",
+			path: "./",
+			want: true,
+		},
+		{
+			name: "path is not exist",
+			path: "for-a-not-exist-path" + randString(),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PathExists(tt.path)
+			if err != nil {
+				t.Errorf("PathExists() error = %v", err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("PathExists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/karmadactl/util/apiclient/apiclient.go
+++ b/pkg/karmadactl/util/apiclient/apiclient.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/client-go/util/homedir"
 	aggregator "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	"k8s.io/utils/env"
+
+	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
 )
 
 var (
@@ -45,7 +47,12 @@ var (
 // RestConfig is to create a rest config from the context and kubeconfig passed as arguments.
 func RestConfig(context, kubeconfigPath string) (*rest.Config, error) {
 	kubeconfigPath = KubeConfigPath(kubeconfigPath)
-	if !Exists(kubeconfigPath) {
+	exist, err := utils.PathExists(kubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check kubeconfig path %q: %w", kubeconfigPath, err)
+	}
+
+	if !exist {
 		// Given no kubeconfig is provided, give it a try to load the config by
 		// in-cluster mode if the client running inside a pod running on kubernetes.
 		host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
@@ -103,12 +110,4 @@ func NewCRDsClient(c *rest.Config) (clientset.Interface, error) {
 // NewAPIRegistrationClient is to create an apiregistration ClientSet
 func NewAPIRegistrationClient(c *rest.Config) (aggregator.Interface, error) {
 	return aggregator.NewForConfig(c)
-}
-
-// Exists determine if path exists
-func Exists(path string) bool {
-	if _, err := os.Stat(path); err != nil {
-		return os.IsExist(err)
-	}
-	return true
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`os.Stat()` returns lookup-related errors such as `ENOENT`, `ENOTDIR`, or `EACCES`, but it does not return `EEXIST`.

The current implementation uses `os.IsExist(err)` after `os.Stat()` fails. This may incorrectly return `false` for errors that do not mean the path is absent, such as permission-denied errors.

This PR switches the check to `!os.IsNotExist(err)`, so the helper only returns `false` when the path is explicitly reported as non-existent.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note

NONE