### PR TITLE
fix: command in karmadactl create should be karmadactl instead of kubectl

### DIFF
--- a/docs/command-line-flags/karmadactl_create_clusterrole.md
+++ b/docs/command-line-flags/karmadactl_create_clusterrole.md
@@ -16,22 +16,22 @@ karmadactl create clusterrole NAME --verb=verb --resource=resource.group [--reso
 
 ```
   # Create a cluster role named "pod-reader" that allows user to perform "get", "watch" and "list" on pods
-  kubectl create clusterrole pod-reader --verb=get,list,watch --resource=pods
+  karmadactl create clusterrole pod-reader --verb=get,list,watch --resource=pods
   
   # Create a cluster role named "pod-reader" with ResourceName specified
-  kubectl create clusterrole pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
+  karmadactl create clusterrole pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
   
   # Create a cluster role named "foo" with API Group specified
-  kubectl create clusterrole foo --verb=get,list,watch --resource=rs.apps
+  karmadactl create clusterrole foo --verb=get,list,watch --resource=rs.apps
   
   # Create a cluster role named "foo" with SubResource specified
-  kubectl create clusterrole foo --verb=get,list,watch --resource=pods,pods/status
+  karmadactl create clusterrole foo --verb=get,list,watch --resource=pods,pods/status
   
   # Create a cluster role name "foo" with NonResourceURL specified
-  kubectl create clusterrole "foo" --verb=get --non-resource-url=/logs/*
+  karmadactl create clusterrole "foo" --verb=get --non-resource-url=/logs/*
   
   # Create a cluster role name "monitoring" with AggregationRule specified
-  kubectl create clusterrole monitoring --aggregation-rule="rbac.example.com/aggregate-to-monitoring=true"
+  karmadactl create clusterrole monitoring --aggregation-rule="rbac.example.com/aggregate-to-monitoring=true"
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_clusterrolebinding.md
+++ b/docs/command-line-flags/karmadactl_create_clusterrolebinding.md
@@ -16,7 +16,7 @@ karmadactl create clusterrolebinding NAME --clusterrole=NAME [--user=username] [
 
 ```
   # Create a cluster role binding for user1, user2, and group1 using the cluster-admin cluster role
-  kubectl create clusterrolebinding cluster-admin --clusterrole=cluster-admin --user=user1 --user=user2 --group=group1
+  karmadactl create clusterrolebinding cluster-admin --clusterrole=cluster-admin --user=user1 --user=user2 --group=group1
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_configmap.md
+++ b/docs/command-line-flags/karmadactl_create_configmap.md
@@ -22,16 +22,16 @@ karmadactl create configmap NAME [--from-file=[key=]source] [--from-literal=key1
 
 ```
   # Create a new config map named my-config based on folder bar
-  kubectl create configmap my-config --from-file=path/to/bar
+  karmadactl create configmap my-config --from-file=path/to/bar
   
   # Create a new config map named my-config with specified keys instead of file basenames on disk
-  kubectl create configmap my-config --from-file=key1=/path/to/bar/file1.txt --from-file=key2=/path/to/bar/file2.txt
+  karmadactl create configmap my-config --from-file=key1=/path/to/bar/file1.txt --from-file=key2=/path/to/bar/file2.txt
   
   # Create a new config map named my-config with key1=config1 and key2=config2
-  kubectl create configmap my-config --from-literal=key1=config1 --from-literal=key2=config2
+  karmadactl create configmap my-config --from-literal=key1=config1 --from-literal=key2=config2
   
   # Create a new config map named my-config with key=value pairs from an env file
-  kubectl create configmap my-config --from-env-file=path/to/bar.env
+  karmadactl create configmap my-config --from-env-file=path/to/bar.env
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_cronjob.md
+++ b/docs/command-line-flags/karmadactl_create_cronjob.md
@@ -16,10 +16,10 @@ karmadactl create cronjob NAME --image=image --schedule='0/5 * * * ?' -- [COMMAN
 
 ```
   # Create a cron job
-  kubectl create cronjob my-job --image=busybox --schedule="*/1 * * * *"
+  karmadactl create cronjob my-job --image=busybox --schedule="*/1 * * * *"
   
   # Create a cron job with a command
-  kubectl create cronjob my-job --image=busybox --schedule="*/1 * * * *" -- date
+  karmadactl create cronjob my-job --image=busybox --schedule="*/1 * * * *" -- date
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_deployment.md
+++ b/docs/command-line-flags/karmadactl_create_deployment.md
@@ -16,19 +16,19 @@ karmadactl create deployment NAME --image=image -- [COMMAND] [args...]
 
 ```
   # Create a deployment named my-dep that runs the busybox image
-  kubectl create deployment my-dep --image=busybox
+  karmadactl create deployment my-dep --image=busybox
   
   # Create a deployment with a command
-  kubectl create deployment my-dep --image=busybox -- date
+  karmadactl create deployment my-dep --image=busybox -- date
   
   # Create a deployment named my-dep that runs the nginx image with 3 replicas
-  kubectl create deployment my-dep --image=nginx --replicas=3
+  karmadactl create deployment my-dep --image=nginx --replicas=3
   
   # Create a deployment named my-dep that runs the busybox image and expose port 5701
-  kubectl create deployment my-dep --image=busybox --port=5701
+  karmadactl create deployment my-dep --image=busybox --port=5701
   
   # Create a deployment named my-dep that runs multiple containers
-  kubectl create deployment my-dep --image=busybox:latest --image=ubuntu:latest --image=nginx
+  karmadactl create deployment my-dep --image=busybox:latest --image=ubuntu:latest --image=nginx
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_ingress.md
+++ b/docs/command-line-flags/karmadactl_create_ingress.md
@@ -17,37 +17,37 @@ karmadactl create ingress NAME --rule=host/path=service:port[,tls[=secret]]
 ```
   # Create a single ingress called 'simple' that directs requests to foo.com/bar to svc
   # svc1:8080 with a TLS secret "my-cert"
-  kubectl create ingress simple --rule="foo.com/bar=svc1:8080,tls=my-cert"
+  karmadactl create ingress simple --rule="foo.com/bar=svc1:8080,tls=my-cert"
   
   # Create a catch all ingress of "/path" pointing to service svc:port and Ingress Class as "otheringress"
-  kubectl create ingress catch-all --class=otheringress --rule="/path=svc:port"
+  karmadactl create ingress catch-all --class=otheringress --rule="/path=svc:port"
   
   # Create an ingress with two annotations: ingress.annotation1 and ingress.annotations2
-  kubectl create ingress annotated --class=default --rule="foo.com/bar=svc:port" \
+  karmadactl create ingress annotated --class=default --rule="foo.com/bar=svc:port" \
   --annotation ingress.annotation1=foo \
   --annotation ingress.annotation2=bla
   
   # Create an ingress with the same host and multiple paths
-  kubectl create ingress multipath --class=default \
+  karmadactl create ingress multipath --class=default \
   --rule="foo.com/=svc:port" \
   --rule="foo.com/admin/=svcadmin:portadmin"
   
   # Create an ingress with multiple hosts and the pathType as Prefix
-  kubectl create ingress ingress1 --class=default \
+  karmadactl create ingress ingress1 --class=default \
   --rule="foo.com/path*=svc:8080" \
   --rule="bar.com/admin*=svc2:http"
   
   # Create an ingress with TLS enabled using the default ingress certificate and different path types
-  kubectl create ingress ingtls --class=default \
+  karmadactl create ingress ingtls --class=default \
   --rule="foo.com/=svc:https,tls" \
   --rule="foo.com/path/subpath*=othersvc:8080"
   
   # Create an ingress with TLS enabled using a specific secret and pathType as Prefix
-  kubectl create ingress ingsecret --class=default \
+  karmadactl create ingress ingsecret --class=default \
   --rule="foo.com/*=svc:8080,tls=secret1"
   
   # Create an ingress with a default backend
-  kubectl create ingress ingdefault --class=default \
+  karmadactl create ingress ingdefault --class=default \
   --default-backend=defaultsvc:http \
   --rule="foo.com/*=svc:8080,tls=secret1"
 ```

--- a/docs/command-line-flags/karmadactl_create_job.md
+++ b/docs/command-line-flags/karmadactl_create_job.md
@@ -16,13 +16,13 @@ karmadactl create job NAME --image=image [--from=cronjob/name] -- [COMMAND] [arg
 
 ```
   # Create a job
-  kubectl create job my-job --image=busybox
+  karmadactl create job my-job --image=busybox
   
   # Create a job with a command
-  kubectl create job my-job --image=busybox -- date
+  karmadactl create job my-job --image=busybox -- date
   
   # Create a job from a cron job named "a-cronjob"
-  kubectl create job test-job --from=cronjob/a-cronjob
+  karmadactl create job test-job --from=cronjob/a-cronjob
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_namespace.md
+++ b/docs/command-line-flags/karmadactl_create_namespace.md
@@ -16,7 +16,7 @@ karmadactl create namespace NAME [--dry-run=server|client|none]
 
 ```
   # Create a new namespace named my-namespace
-  kubectl create namespace my-namespace
+  karmadactl create namespace my-namespace
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_poddisruptionbudget.md
+++ b/docs/command-line-flags/karmadactl_create_poddisruptionbudget.md
@@ -17,11 +17,11 @@ karmadactl create poddisruptionbudget NAME --selector=SELECTOR --min-available=N
 ```
   # Create a pod disruption budget named my-pdb that will select all pods with the app=rails label
   # and require at least one of them being available at any point in time
-  kubectl create poddisruptionbudget my-pdb --selector=app=rails --min-available=1
+  karmadactl create poddisruptionbudget my-pdb --selector=app=rails --min-available=1
   
   # Create a pod disruption budget named my-pdb that will select all pods with the app=nginx label
   # and require at least half of the pods selected to be available at any point in time
-  kubectl create pdb my-pdb --selector=app=nginx --min-available=50%
+  karmadactl create pdb my-pdb --selector=app=nginx --min-available=50%
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_priorityclass.md
+++ b/docs/command-line-flags/karmadactl_create_priorityclass.md
@@ -16,13 +16,13 @@ karmadactl create priorityclass NAME --value=VALUE --global-default=BOOL [--dry-
 
 ```
   # Create a priority class named high-priority
-  kubectl create priorityclass high-priority --value=1000 --description="high priority"
+  karmadactl create priorityclass high-priority --value=1000 --description="high priority"
   
   # Create a priority class named default-priority that is considered as the global default priority
-  kubectl create priorityclass default-priority --value=1000 --global-default=true --description="default priority"
+  karmadactl create priorityclass default-priority --value=1000 --global-default=true --description="default priority"
   
   # Create a priority class named high-priority that cannot preempt pods with lower priority
-  kubectl create priorityclass high-priority --value=1000 --description="high priority" --preemption-policy="Never"
+  karmadactl create priorityclass high-priority --value=1000 --description="high priority" --preemption-policy="Never"
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_quota.md
+++ b/docs/command-line-flags/karmadactl_create_quota.md
@@ -16,10 +16,10 @@ karmadactl create quota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1,S
 
 ```
   # Create a new resource quota named my-quota
-  kubectl create quota my-quota --hard=cpu=1,memory=1G,pods=2,services=3,replicationcontrollers=2,resourcequotas=1,secrets=5,persistentvolumeclaims=10
+  karmadactl create quota my-quota --hard=cpu=1,memory=1G,pods=2,services=3,replicationcontrollers=2,resourcequotas=1,secrets=5,persistentvolumeclaims=10
   
   # Create a new resource quota named best-effort
-  kubectl create quota best-effort --hard=pods=100 --scopes=BestEffort
+  karmadactl create quota best-effort --hard=pods=100 --scopes=BestEffort
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_role.md
+++ b/docs/command-line-flags/karmadactl_create_role.md
@@ -16,16 +16,16 @@ karmadactl create role NAME --verb=verb --resource=resource.group/subresource [-
 
 ```
   # Create a role named "pod-reader" that allows user to perform "get", "watch" and "list" on pods
-  kubectl create role pod-reader --verb=get --verb=list --verb=watch --resource=pods
+  karmadactl create role pod-reader --verb=get --verb=list --verb=watch --resource=pods
   
   # Create a role named "pod-reader" with ResourceName specified
-  kubectl create role pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
+  karmadactl create role pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
   
   # Create a role named "foo" with API Group specified
-  kubectl create role foo --verb=get,list,watch --resource=rs.apps
+  karmadactl create role foo --verb=get,list,watch --resource=rs.apps
   
   # Create a role named "foo" with SubResource specified
-  kubectl create role foo --verb=get,list,watch --resource=pods,pods/status
+  karmadactl create role foo --verb=get,list,watch --resource=pods,pods/status
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_rolebinding.md
+++ b/docs/command-line-flags/karmadactl_create_rolebinding.md
@@ -16,10 +16,10 @@ karmadactl create rolebinding NAME --clusterrole=NAME|--role=NAME [--user=userna
 
 ```
   # Create a role binding for user1, user2, and group1 using the admin cluster role
-  kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1
+  karmadactl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1
   
   # Create a role binding for service account monitoring:sa-dev using the admin role
-  kubectl create rolebinding admin-binding --role=admin --serviceaccount=monitoring:sa-dev
+  karmadactl create rolebinding admin-binding --role=admin --serviceaccount=monitoring:sa-dev
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_secret_docker-registry.md
+++ b/docs/command-line-flags/karmadactl_create_secret_docker-registry.md
@@ -27,10 +27,10 @@ karmadactl create secret docker-registry NAME --docker-username=user --docker-pa
 
 ```
   # If you do not already have a .dockercfg file, create a dockercfg secret directly
-  kubectl create secret docker-registry my-secret --docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL
+  karmadactl create secret docker-registry my-secret --docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL
   
   # Create a new secret named my-secret from ~/.docker/config.json
-  kubectl create secret docker-registry my-secret --from-file=path/to/.docker/config.json
+  karmadactl create secret docker-registry my-secret --from-file=path/to/.docker/config.json
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_secret_generic.md
+++ b/docs/command-line-flags/karmadactl_create_secret_generic.md
@@ -22,19 +22,19 @@ karmadactl create secret generic NAME [--type=string] [--from-file=[key=]source]
 
 ```
   # Create a new secret named my-secret with keys for each file in folder bar
-  kubectl create secret generic my-secret --from-file=path/to/bar
+  karmadactl create secret generic my-secret --from-file=path/to/bar
   
   # Create a new secret named my-secret with specified keys instead of names on disk
-  kubectl create secret generic my-secret --from-file=ssh-privatekey=path/to/id_rsa --from-file=ssh-publickey=path/to/id_rsa.pub
+  karmadactl create secret generic my-secret --from-file=ssh-privatekey=path/to/id_rsa --from-file=ssh-publickey=path/to/id_rsa.pub
   
   # Create a new secret named my-secret with key1=supersecret and key2=topsecret
-  kubectl create secret generic my-secret --from-literal=key1=supersecret --from-literal=key2=topsecret
+  karmadactl create secret generic my-secret --from-literal=key1=supersecret --from-literal=key2=topsecret
   
   # Create a new secret named my-secret using a combination of a file and a literal
-  kubectl create secret generic my-secret --from-file=ssh-privatekey=path/to/id_rsa --from-literal=passphrase=topsecret
+  karmadactl create secret generic my-secret --from-file=ssh-privatekey=path/to/id_rsa --from-literal=passphrase=topsecret
   
   # Create a new secret named my-secret from env files
-  kubectl create secret generic my-secret --from-env-file=path/to/foo.env --from-env-file=path/to/bar.env
+  karmadactl create secret generic my-secret --from-env-file=path/to/foo.env --from-env-file=path/to/bar.env
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_secret_tls.md
+++ b/docs/command-line-flags/karmadactl_create_secret_tls.md
@@ -18,7 +18,7 @@ karmadactl create secret tls NAME --cert=path/to/cert/file --key=path/to/key/fil
 
 ```
   # Create a new TLS secret named tls-secret with the given key pair
-  kubectl create secret tls tls-secret --cert=path/to/tls.crt --key=path/to/tls.key
+  karmadactl create secret tls tls-secret --cert=path/to/tls.crt --key=path/to/tls.key
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_service_clusterip.md
+++ b/docs/command-line-flags/karmadactl_create_service_clusterip.md
@@ -16,10 +16,10 @@ karmadactl create service clusterip NAME [--tcp=<port>:<targetPort>] [--dry-run=
 
 ```
   # Create a new ClusterIP service named my-cs
-  kubectl create service clusterip my-cs --tcp=5678:8080
+  karmadactl create service clusterip my-cs --tcp=5678:8080
   
   # Create a new ClusterIP service named my-cs (in headless mode)
-  kubectl create service clusterip my-cs --clusterip="None"
+  karmadactl create service clusterip my-cs --clusterip="None"
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_service_externalname.md
+++ b/docs/command-line-flags/karmadactl_create_service_externalname.md
@@ -18,7 +18,7 @@ karmadactl create service externalname NAME --external-name external.name [--dry
 
 ```
   # Create a new ExternalName service named my-ns
-  kubectl create service externalname my-ns --external-name bar.com
+  karmadactl create service externalname my-ns --external-name bar.com
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_service_loadbalancer.md
+++ b/docs/command-line-flags/karmadactl_create_service_loadbalancer.md
@@ -16,7 +16,7 @@ karmadactl create service loadbalancer NAME [--tcp=port:targetPort] [--dry-run=s
 
 ```
   # Create a new LoadBalancer service named my-lbs
-  kubectl create service loadbalancer my-lbs --tcp=5678:8080
+  karmadactl create service loadbalancer my-lbs --tcp=5678:8080
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_service_nodeport.md
+++ b/docs/command-line-flags/karmadactl_create_service_nodeport.md
@@ -16,7 +16,7 @@ karmadactl create service nodeport NAME [--tcp=port:targetPort] [--dry-run=serve
 
 ```
   # Create a new NodePort service named my-ns
-  kubectl create service nodeport my-ns --tcp=5678:8080
+  karmadactl create service nodeport my-ns --tcp=5678:8080
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_serviceaccount.md
+++ b/docs/command-line-flags/karmadactl_create_serviceaccount.md
@@ -16,7 +16,7 @@ karmadactl create serviceaccount NAME [--dry-run=server|client|none]
 
 ```
   # Create a new service account named my-service-account
-  kubectl create serviceaccount my-service-account
+  karmadactl create serviceaccount my-service-account
 ```
 
 ### Options

--- a/docs/command-line-flags/karmadactl_create_token.md
+++ b/docs/command-line-flags/karmadactl_create_token.md
@@ -16,22 +16,22 @@ karmadactl create token SERVICE_ACCOUNT_NAME
 
 ```
   # Request a token to authenticate to the kube-apiserver as the service account "myapp" in the current namespace
-  kubectl create token myapp
+  karmadactl create token myapp
   
   # Request a token for a service account in a custom namespace
-  kubectl create token myapp --namespace myns
+  karmadactl create token myapp --namespace myns
   
   # Request a token with a custom expiration
-  kubectl create token myapp --duration 10m
+  karmadactl create token myapp --duration 10m
   
   # Request a token with a custom audience
-  kubectl create token myapp --audience https://example.com
+  karmadactl create token myapp --audience https://example.com
   
   # Request a token bound to an instance of a Secret object
-  kubectl create token myapp --bound-object-kind Secret --bound-object-name mysecret
+  karmadactl create token myapp --bound-object-kind Secret --bound-object-name mysecret
   
   # Request a token bound to an instance of a Secret object with a specific UID
-  kubectl create token myapp --bound-object-kind Secret --bound-object-name mysecret --bound-object-uid 0d4691ed-659b-4935-a832-355f77ee47cc
+  karmadactl create token myapp --bound-object-kind Secret --bound-object-name mysecret --bound-object-uid 0d4691ed-659b-4935-a832-355f77ee47cc
 ```
 
 ### Options

--- a/pkg/karmadactl/create/create.go
+++ b/pkg/karmadactl/create/create.go
@@ -18,6 +18,7 @@ package create
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -60,5 +61,16 @@ func NewCmdCreate(f util.Factory, parentCommand string, ioStreams genericiooptio
 	utilcomp.RegisterCompletionFuncForKarmadaContextFlag(cmd)
 	utilcomp.RegisterCompletionFuncForNamespaceFlag(cmd, f)
 
+	replaceCreateSubcommandExamples(cmd, parentCommand)
+
 	return cmd
+}
+
+func replaceCreateSubcommandExamples(cmd *cobra.Command, parentCommand string) {
+	for _, subCmd := range cmd.Commands() {
+		if subCmd.Example != "" {
+			subCmd.Example = strings.ReplaceAll(subCmd.Example, "kubectl create", parentCommand+" create")
+		}
+		replaceCreateSubcommandExamples(subCmd, parentCommand)
+	}
 }


### PR DESCRIPTION


**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes https://github.com/karmada-io/karmada/issues/7542

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

