### PR TITLE
Fixed the issue when cluster resources are insufficient, multiple template resources can still be scheduled

### DIFF
--- a/pkg/scheduler/core/common.go
+++ b/pkg/scheduler/core/common.go
@@ -23,6 +23,7 @@ import (
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/features"
 	schedulercache "github.com/karmada-io/karmada/pkg/scheduler/cache"
 	"github.com/karmada-io/karmada/pkg/scheduler/core/spreadconstraint"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework"
@@ -38,6 +39,11 @@ func SelectClusters(clustersScore framework.ClusterScoreList, placement *policyv
 		return calAvailableReplicas(clusters, spec, assigningCache)
 	}
 	groupClustersInfo := spreadconstraint.GroupClustersWithScore(clustersScore, placement, spec, status, calAvailableReplicasFunc)
+	if features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) && isMultiTemplateSchedulingApplicable(spec) {
+		// For multi-component workloads, they are scheduled as a whole and do not support replica division.
+		// The scheduling unit is 1 (i.e., 1 instance of the multi-component template), so we require 1 available replica.
+		return spreadconstraint.SelectBestClusters(placement, groupClustersInfo, 1)
+	}
 	return spreadconstraint.SelectBestClusters(placement, groupClustersInfo, spec.Replicas)
 }
 

--- a/test/e2e/suites/base/federatedresourcequota_test.go
+++ b/test/e2e/suites/base/federatedresourcequota_test.go
@@ -588,18 +588,6 @@ var _ = framework.SerialDescribe("Multi-Components: FederatedResourceQuota enfor
 
 				flinkDeploymentObj.SetNamespace(flinkDeploymentNamespace)
 				flinkDeploymentObj.SetName(flinkDeploymentName)
-				err = unstructured.SetNestedField(flinkDeploymentObj.Object, int64(3), "spec", "jobManager", "replicas")
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				err = unstructured.SetNestedField(flinkDeploymentObj.Object, map[string]any{
-					"cpu":    int64(2),
-					"memory": "50Mi",
-				}, "spec", "jobManager", "resource")
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				err = unstructured.SetNestedField(flinkDeploymentObj.Object, map[string]any{
-					"cpu":    int64(1),
-					"memory": "100Mi",
-				}, "spec", "taskManager", "resource")
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 				flinkDeploymentGVR = schema.GroupVersionResource{
 					Group:    flinkDeploymentObj.GroupVersionKind().Group,
@@ -650,9 +638,12 @@ var _ = framework.SerialDescribe("Multi-Components: FederatedResourceQuota enfor
 		ginkgo.It("FederatedResourceQuota usage should be calculated correctly", func() {
 			framework.WaitFederatedResourceQuotaFitWith(karmadaClient, frqNamespace, frqName, func(frq *policyv1alpha1.FederatedResourceQuota) bool {
 				expectedUsed := corev1.ResourceList{
-					"cpu":    resource.MustParse("7"),
-					"memory": resource.MustParse("250Mi"),
+					"cpu":    resource.MustParse("150m"),
+					"memory": resource.MustParse("200m"),
 				}
+				ginkgo.GinkgoLogr.Info("FederatedResourceQuota OverallUsed",
+					"cpu", frq.Status.OverallUsed.Cpu().String(),
+					"memory", frq.Status.OverallUsed.Memory().String())
 				return frq.Status.OverallUsed != nil && frq.Status.OverallUsed.Cpu().Equal(*expectedUsed.Cpu()) &&
 					frq.Status.OverallUsed.Memory().Equal(*expectedUsed.Memory())
 			})

--- a/test/e2e/suites/base/manifest/flinkdeployment-cr.yaml
+++ b/test/e2e/suites/base/manifest/flinkdeployment-cr.yaml
@@ -16,10 +16,10 @@ spec:
   jobManager:
     replicas: 1
     resource:
-      cpu: 1
+      cpu: 0.05
       memory: 100m
   serviceAccount: flink
   taskManager:
     resource:
-      cpu: 1
+      cpu: 0.1
       memory: 100m

--- a/test/e2e/suites/base/schedule_multi_template_test.go
+++ b/test/e2e/suites/base/schedule_multi_template_test.go
@@ -200,8 +200,8 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 				gomega.Expect(jobManagerComponent).ShouldNot(gomega.BeNil(), "jobmanager component should exist")
 				gomega.Expect(taskManagerComponent).ShouldNot(gomega.BeNil(), "taskmanager component should exist")
 				// Verify the detailed content of components (including ReplicaRequirements and resource values)
-				verifyComponentResources(jobManagerComponent, 1, "1", "100m")
-				verifyComponentResources(taskManagerComponent, 1, "1", "100m")
+				verifyComponentResources(jobManagerComponent, 1, "50m", "100m")
+				verifyComponentResources(taskManagerComponent, 1, "100m", "100m")
 			})
 
 			var targetClusterName string


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #7550 

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

Due to the existence of a bug, larger CPU requests can also cause FlinkDeployment resources to be distributed. After the issue is fixed, the existing CPU requests related to FlinkDeployment need to be adjusted to a smaller value to ensure that resources are properly allocated.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-scheduler`: fixed the issue when cluster resources are insufficient, multiple template resources can still be scheduled.
```

