### PR TITLE
fix: avoid overwriting cluster summaries when node/pod listing fails

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -269,20 +269,20 @@ func (c *ClusterStatusController) setCurrentClusterStatus(clusterClient *util.Cl
 			// if clusterInformerManager fails to be built, should be returned, otherwise, it may cause a nil pointer
 			return nil, err
 		}
-		nodes, err := listNodes(clusterInformerManager)
-		if err != nil {
-			klog.ErrorS(err, "Failed to list nodes for Cluster", "cluster", cluster.GetName())
+		nodes, nodesErr := listNodes(clusterInformerManager)
+		if nodesErr != nil {
+			klog.ErrorS(nodesErr, "Failed to list nodes, preserving previous NodeSummary for cluster", "cluster", cluster.GetName())
+		} else {
+			currentClusterStatus.NodeSummary = getNodeSummary(nodes)
 		}
-
-		pods, err := listPods(clusterInformerManager)
-		if err != nil {
-			klog.ErrorS(err, "Failed to list pods for Cluster", "cluster", cluster.GetName())
-		}
-		currentClusterStatus.NodeSummary = getNodeSummary(nodes)
-		currentClusterStatus.ResourceSummary = getResourceSummary(nodes, pods)
-
-		if features.FeatureGate.Enabled(features.CustomizedClusterResourceModeling) {
-			currentClusterStatus.ResourceSummary.AllocatableModelings = getAllocatableModelings(cluster, nodes, pods)
+		pods, podsErr := listPods(clusterInformerManager)
+		if podsErr != nil {
+			klog.ErrorS(podsErr, "Failed to list pods, preserving previous ResourceSummary for cluster", "cluster", cluster.GetName())
+		} else if nodesErr == nil {
+			currentClusterStatus.ResourceSummary = getResourceSummary(nodes, pods)
+			if features.FeatureGate.Enabled(features.CustomizedClusterResourceModeling) {
+				currentClusterStatus.ResourceSummary.AllocatableModelings = getAllocatableModelings(cluster, nodes, pods)
+			}
 		}
 	}
 	return conditions, nil


### PR DESCRIPTION
 **What type of PR is this?**
  
  /kind bug
  /kind cleanup

---

  **What this PR does / why we need it:**

  Skip overwriting NodeSummary and ResourceSummary in setCurrentClusterStatus when listNodes or listPods returns
   an error or a nil slice. The last-good values on currentClusterStatus (already deep-copied from
  cluster.Status) are preserved while the rest of the status (KubernetesVersion, APIEnablements, Ready) still
  refreshes that cycle.

  Without this, a transient lister failure or empty result would zero out NodeSummary.TotalNum and
  ResourceSummary.Allocatable, which the scheduler then reads as "cluster has no capacity" and routes replicas
  elsewhere.

  Before:
```go
  nodes, err := listNodes(clusterInformerManager)
  if err != nil {
      klog.ErrorS(err, "Failed to list nodes for Cluster", "cluster", cluster.GetName())
  }
  pods, err := listPods(clusterInformerManager)
  if err != nil {
      klog.ErrorS(err, "Failed to list pods for Cluster", "cluster", cluster.GetName())
  }
  currentClusterStatus.NodeSummary = getNodeSummary(nodes)
  currentClusterStatus.ResourceSummary = getResourceSummary(nodes, pods)

  if features.FeatureGate.Enabled(features.CustomizedClusterResourceModeling) {
      currentClusterStatus.ResourceSummary.AllocatableModelings = getAllocatableModelings(cluster, nodes, pods)
  }
```

  After:
```go
  nodes, nodesErr := listNodes(clusterInformerManager)
  if nodesErr != nil {
      klog.ErrorS(nodesErr, "Failed to list nodes, preserving previous summaries for cluster", "cluster",
  cluster.GetName())
  }
  pods, podsErr := listPods(clusterInformerManager)
  if podsErr != nil {
      klog.ErrorS(podsErr, "Failed to list pods, preserving previous summaries for cluster", "cluster",
  cluster.GetName())
  }
  if nodesErr == nil && podsErr == nil && nodes != nil && pods != nil {
      currentClusterStatus.NodeSummary = getNodeSummary(nodes)
      currentClusterStatus.ResourceSummary = getResourceSummary(nodes, pods)

      if features.FeatureGate.Enabled(features.CustomizedClusterResourceModeling) {
          currentClusterStatus.ResourceSummary.AllocatableModelings = getAllocatableModelings(cluster, nodes,
  pods)
      }
  }
```
---

  **Which issue(s) this PR fixes:**

  Fixes #7511

  Special notes for your reviewer:

  - Minimal change, scoped to setCurrentClusterStatus.
  - No early return the caller still reaches updateStatusIfNeeded, so other status fields keep refreshing.
  - Covers both the error path and the nil, nil repro case from the issue.

  Does this PR introduce a user-facing change?

  `karmada-controller-manager`: Fixed a bug where transient node/pod listing failures could overwrite a
  cluster's `NodeSummary` and `ResourceSummary` with zeroed values, causing the scheduler to treat a healthy
  cluster as having zero capacity.