### PR TITLE
Implement scheduler estimator assumption for single template

### DIFF
--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -57,17 +57,21 @@ func NewGeneralEstimator() *GeneralEstimator {
 func (ge *GeneralEstimator) MaxAvailableReplicas(_ context.Context, req ReplicaEstimationRequest) ([]workv1alpha2.TargetCluster, error) {
 	availableTargetClusters := make([]workv1alpha2.TargetCluster, len(req.Clusters))
 	for i, cluster := range req.Clusters {
-		maxReplicas := ge.maxAvailableReplicas(cluster, req.ReplicaRequirements)
+		maxReplicas := ge.maxAvailableReplicas(cluster, req.ReplicaRequirements, req.AssumedWorkloads[cluster.Name])
 		availableTargetClusters[i] = workv1alpha2.TargetCluster{Name: cluster.Name, Replicas: maxReplicas}
 	}
 	return availableTargetClusters, nil
 }
 
-func (ge *GeneralEstimator) maxAvailableReplicas(cluster *clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) int32 {
+func (ge *GeneralEstimator) maxAvailableReplicas(cluster *clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements, assumedWorkloads []AssumedWorkload) int32 {
 	// Note: resourceSummary must be deep-copied before using in the function to avoid modifying the original data structure.
 	resourceSummary := cluster.Status.ResourceSummary.DeepCopy()
 	if resourceSummary == nil {
 		return 0
+	}
+	// Deduct assumed in-flight workloads before computing max replicas.
+	if len(assumedWorkloads) > 0 {
+		deductAssumedWorkloadsFromSummary(resourceSummary, assumedWorkloads)
 	}
 
 	maximumReplicas := getAllowedPodNumber(resourceSummary)
@@ -101,6 +105,49 @@ func (ge *GeneralEstimator) maxAvailableReplicas(cluster *clusterv1alpha1.Cluste
 	}
 
 	return int32(maximumReplicas) // #nosec G115: integer overflow conversion int64 -> int32
+}
+
+// deductAssumedWorkloadsFromSummary adds the resource demands of assumed in-flight workloads
+// to resourceSummary.Allocating so that existing estimation functions account for them.
+// It also deducts the pod count from the allowed pod budget.
+func deductAssumedWorkloadsFromSummary(resourceSummary *clusterv1alpha1.ResourceSummary, assumedWorkloads []AssumedWorkload) {
+	if resourceSummary.Allocating == nil {
+		resourceSummary.Allocating = make(corev1.ResourceList)
+	}
+	for _, aw := range assumedWorkloads {
+		for _, comp := range aw.Components {
+			replicas := int64(comp.Replicas)
+			if replicas <= 0 {
+				continue
+			}
+			// Deduct pod count.
+			existingPods := resourceSummary.Allocating.Pods()
+			resourceSummary.Allocating[corev1.ResourcePods] = *resource.NewQuantity(existingPods.Value()+replicas, resource.DecimalSI)
+
+			if comp.ReplicaRequirements == nil {
+				continue
+			}
+			// Deduct per-resource demands.
+			for resName, qty := range comp.ReplicaRequirements.ResourceRequest {
+				// Use MilliValue only for CPU (millicores are its natural unit).
+				// For all other resources (memory, extended resources, etc.) use Value() to
+				// avoid the ×1000 amplification that MilliValue introduces, which can overflow
+				// int64 for large quantities (e.g. 1Ti memory × 10000 replicas).
+				var total resource.Quantity
+				if resName == corev1.ResourceCPU {
+					total = *resource.NewMilliQuantity(qty.MilliValue()*replicas, qty.Format)
+				} else {
+					total = *resource.NewQuantity(qty.Value()*replicas, qty.Format)
+				}
+				if existing, ok := resourceSummary.Allocating[resName]; ok {
+					existing.Add(total)
+					resourceSummary.Allocating[resName] = existing
+				} else {
+					resourceSummary.Allocating[resName] = total
+				}
+			}
+		}
+	}
 }
 
 // MaxAvailableComponentSets (generic estimator) – resourceSummary only.

--- a/pkg/estimator/client/general_test.go
+++ b/pkg/estimator/client/general_test.go
@@ -564,6 +564,7 @@ func TestMaxAvailableReplicas(t *testing.T) {
 		name                string
 		clusters            []*clusterv1alpha1.Cluster
 		replicaRequirements *workv1alpha2.ReplicaRequirements
+		assumedWorkloads    map[string][]AssumedWorkload
 		expectedTargets     []workv1alpha2.TargetCluster
 	}{
 		{
@@ -618,6 +619,58 @@ func TestMaxAvailableReplicas(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "assumed workloads reduce replicas",
+			clusters: []*clusterv1alpha1.Cluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "member1"},
+					Status: clusterv1alpha1.ClusterStatus{
+						ResourceSummary: &clusterv1alpha1.ResourceSummary{
+							Allocatable: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("8Gi"),
+								corev1.ResourcePods:   resource.MustParse("100"),
+							},
+							Allocated: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("2Gi"),
+								corev1.ResourcePods:   resource.MustParse("20"),
+							},
+						},
+					},
+				},
+			},
+			replicaRequirements: &workv1alpha2.ReplicaRequirements{
+				ResourceRequest: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			assumedWorkloads: map[string][]AssumedWorkload{
+				"member1": {
+					{
+						Namespace: "default",
+						Components: []workv1alpha2.Component{
+							{
+								Replicas: 2,
+								ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+									ResourceRequest: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("1Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTargets: []workv1alpha2.TargetCluster{
+				{
+					Name:     "member1",
+					Replicas: 4,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -626,9 +679,212 @@ func TestMaxAvailableReplicas(t *testing.T) {
 			targets, err := estimator.MaxAvailableReplicas(context.Background(), ReplicaEstimationRequest{
 				Clusters:            tt.clusters,
 				ReplicaRequirements: tt.replicaRequirements,
+				AssumedWorkloads:    tt.assumedWorkloads,
 			})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedTargets, targets)
+		})
+	}
+}
+
+func TestDeductAssumedWorkloadsFromSummary(t *testing.T) {
+	tests := []struct {
+		name             string
+		summary          clusterv1alpha1.ResourceSummary
+		assumedWorkloads []AssumedWorkload
+		wantAllocating   corev1.ResourceList
+	}{
+		{
+			name: "empty assumed workloads — summary unchanged",
+			summary: clusterv1alpha1.ResourceSummary{
+				Allocating: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("500m"),
+				},
+			},
+			assumedWorkloads: nil,
+			wantAllocating: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("500m"),
+			},
+		},
+		{
+			name:    "nil Allocating is initialized before deduction",
+			summary: clusterv1alpha1.ResourceSummary{},
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Components: []workv1alpha2.Component{
+						{
+							Replicas: 1,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantAllocating: corev1.ResourceList{
+				corev1.ResourcePods: resource.MustParse("1"),
+				corev1.ResourceCPU:  resource.MustParse("100m"),
+			},
+		},
+		{
+			name:    "component with zero replicas is skipped",
+			summary: clusterv1alpha1.ResourceSummary{},
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Components: []workv1alpha2.Component{
+						{
+							Replicas: 0,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantAllocating: corev1.ResourceList{},
+		},
+		{
+			name:    "component with nil ReplicaRequirements only deducts pod count",
+			summary: clusterv1alpha1.ResourceSummary{},
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Components: []workv1alpha2.Component{
+						{Replicas: 3, ReplicaRequirements: nil},
+					},
+				},
+			},
+			wantAllocating: corev1.ResourceList{
+				corev1.ResourcePods: resource.MustParse("3"),
+			},
+		},
+		{
+			name:    "multiple replicas — resources multiplied correctly",
+			summary: clusterv1alpha1.ResourceSummary{},
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Components: []workv1alpha2.Component{
+						{
+							Replicas: 3,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantAllocating: corev1.ResourceList{
+				corev1.ResourcePods:   resource.MustParse("3"),
+				corev1.ResourceCPU:    resource.MustParse("600m"),  // 200m × 3
+				corev1.ResourceMemory: resource.MustParse("768Mi"), // 256Mi × 3
+			},
+		},
+		{
+			name:    "multiple workloads accumulate into Allocating",
+			summary: clusterv1alpha1.ResourceSummary{},
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Components: []workv1alpha2.Component{
+						{
+							Replicas: 1,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+				{
+					Components: []workv1alpha2.Component{
+						{
+							Replicas: 2,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantAllocating: corev1.ResourceList{
+				corev1.ResourcePods: resource.MustParse("3"),    // 1 + 2
+				corev1.ResourceCPU:  resource.MustParse("300m"), // 100m + 200m
+			},
+		},
+		{
+			// Validates that memory scaling uses Value() not MilliValue() to avoid int64 overflow.
+			// 1Ti × 10000 replicas: MilliValue()-based math (1Ti×1000×10000 ≈ 1.1e19) would overflow int64 (max 9.2e18).
+			name:    "large memory replicas do not overflow",
+			summary: clusterv1alpha1.ResourceSummary{},
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Components: []workv1alpha2.Component{
+						{
+							Replicas: 10000,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("1Ti"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantAllocating: corev1.ResourceList{
+				corev1.ResourcePods:   resource.MustParse("10000"),
+				corev1.ResourceMemory: resource.MustParse("10000Ti"),
+			},
+		},
+		{
+			name: "existing Allocating values are accumulated, not replaced",
+			summary: clusterv1alpha1.ResourceSummary{
+				Allocating: corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("400m"),
+					corev1.ResourcePods: resource.MustParse("5"),
+				},
+			},
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Components: []workv1alpha2.Component{
+						{
+							Replicas: 2,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantAllocating: corev1.ResourceList{
+				corev1.ResourcePods: resource.MustParse("7"),    // 5 + 2
+				corev1.ResourceCPU:  resource.MustParse("600m"), // 400m + 200m
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary := tt.summary.DeepCopy()
+			deductAssumedWorkloadsFromSummary(summary, tt.assumedWorkloads)
+
+			assert.Equal(t, len(tt.wantAllocating), len(summary.Allocating),
+				"Allocating map length mismatch")
+			for resName, wantQty := range tt.wantAllocating {
+				gotQty, ok := summary.Allocating[resName]
+				assert.True(t, ok, "resource %s missing from Allocating", resName)
+				assert.True(t, wantQty.Cmp(gotQty) == 0,
+					"resource %s: want %s, got %s", resName, wantQty.String(), gotQty.String())
+			}
 		})
 	}
 }
@@ -638,6 +894,7 @@ func TestMaxAvailableReplicasGeneral(t *testing.T) {
 		name                string
 		cluster             *clusterv1alpha1.Cluster
 		replicaRequirements *workv1alpha2.ReplicaRequirements
+		assumedWorkloads    []AssumedWorkload
 		expected            int32
 	}{
 		{
@@ -702,12 +959,54 @@ func TestMaxAvailableReplicasGeneral(t *testing.T) {
 			},
 			expected: 6,
 		},
+		{
+			name: "assumed workloads are deducted",
+			cluster: &clusterv1alpha1.Cluster{
+				Status: clusterv1alpha1.ClusterStatus{
+					ResourceSummary: &clusterv1alpha1.ResourceSummary{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourcePods:   resource.MustParse("100"),
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+						Allocated: corev1.ResourceList{
+							corev1.ResourcePods:   resource.MustParse("20"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+			replicaRequirements: &workv1alpha2.ReplicaRequirements{
+				ResourceRequest: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Namespace: "default",
+					Components: []workv1alpha2.Component{
+						{
+							Replicas: 2,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: 4,
+		},
 	}
 
 	estimator := NewGeneralEstimator()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := estimator.maxAvailableReplicas(tt.cluster, tt.replicaRequirements)
+			result := estimator.maxAvailableReplicas(tt.cluster, tt.replicaRequirements, tt.assumedWorkloads)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/estimator/server/estimate.go
+++ b/pkg/estimator/server/estimate.go
@@ -43,7 +43,12 @@ func (es *AccurateSchedulerEstimatorServer) EstimateReplicas(ctx context.Context
 		return 0, nil
 	}
 
-	maxAvailableReplicas, err := es.estimateReplicas(ctx, snapShot, request.GetReplicaRequirements())
+	estCtx := framework.ReplicaEstimationContext{
+		Snapshot:            snapShot,
+		ReplicaRequirements: request.GetReplicaRequirements(),
+		AssumedWorkloads:    request.GetAssumedWorkloads(),
+	}
+	maxAvailableReplicas, err := es.estimateReplicas(ctx, estCtx)
 	if err != nil {
 		return 0, err
 	}
@@ -52,8 +57,8 @@ func (es *AccurateSchedulerEstimatorServer) EstimateReplicas(ctx context.Context
 	return maxAvailableReplicas, nil
 }
 
-func (es *AccurateSchedulerEstimatorServer) estimateReplicas(ctx context.Context, snapshot *schedcache.Snapshot, requirements *pb.ReplicaRequirements) (int32, error) {
-	replicas, ret := es.estimateFramework.RunEstimateReplicasPlugins(ctx, snapshot, requirements)
+func (es *AccurateSchedulerEstimatorServer) estimateReplicas(ctx context.Context, estCtx framework.ReplicaEstimationContext) (int32, error) {
+	replicas, ret := es.estimateFramework.RunEstimateReplicasPlugins(ctx, estCtx)
 
 	// No replicas can be scheduled on the cluster, skip further checks and return 0
 	if ret.IsUnschedulable() {

--- a/pkg/estimator/server/framework/interface.go
+++ b/pkg/estimator/server/framework/interface.go
@@ -32,12 +32,12 @@ import (
 type Framework interface {
 	Handle
 	// RunEstimateReplicasPlugins runs the set of configured EstimateReplicasPlugins
-	// for estimating replicas based on the given replicaRequirements.
+	// for estimating replicas based on the given estCtx.
 	// It returns an integer and a Result.
 	// The integer represents the minimum calculated value of estimated replicas from each EstimateReplicasPlugin.
 	// The Result contains code, reasons and error.
 	// It is merged from all plugins' returned result codes.
-	RunEstimateReplicasPlugins(ctx context.Context, snapshot *schedcache.Snapshot, replicaRequirements *pb.ReplicaRequirements) (int32, *Result)
+	RunEstimateReplicasPlugins(ctx context.Context, estCtx ReplicaEstimationContext) (int32, *Result)
 	// RunEstimateComponentsPlugins runs the set of configured EstimateComponentsPlugins
 	// for estimating the maximum number of complete component sets based on the given estCtx.
 	// It returns an integer and a Result.
@@ -62,7 +62,7 @@ type EstimateReplicasPlugin interface {
 	// The integer represents the number of calculated replicas for the given replicaRequirements.
 	// The Result contains code, reasons and error.
 	// It is merged from all plugins' returned result codes.
-	Estimate(ctx context.Context, snapshot *schedcache.Snapshot, replicaRequirements *pb.ReplicaRequirements) (int32, *Result)
+	Estimate(ctx context.Context, estCtx ReplicaEstimationContext) (int32, *Result)
 }
 
 // EstimateComponentsPlugin is an interface for component set estimation plugins.
@@ -87,6 +87,17 @@ type ComponentEstimationContext struct {
 	Components []*pb.Component
 	// Namespace is the workload namespace (used by quota-aware plugins).
 	Namespace string
+	// AssumedWorkloads are in-flight workloads already assigned to this target cluster.
+	AssumedWorkloads []*pb.AssumedWorkload
+}
+
+// ReplicaEstimationContext contains the business context required by replica estimators.
+// It decouples plugin interfaces from transport-level request objects.
+type ReplicaEstimationContext struct {
+	// Snapshot is the scheduler cache snapshot used for estimation.
+	Snapshot *schedcache.Snapshot
+	// ReplicaRequirements describes the resource requirements of a single-template workload replica.
+	ReplicaRequirements *pb.ReplicaRequirements
 	// AssumedWorkloads are in-flight workloads already assigned to this target cluster.
 	AssumedWorkloads []*pb.AssumedWorkload
 }

--- a/pkg/estimator/server/framework/plugins/noderesource/noderesource.go
+++ b/pkg/estimator/server/framework/plugins/noderesource/noderesource.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/karmada-io/karmada/pkg/estimator"
-	"github.com/karmada-io/karmada/pkg/estimator/pb"
 	"github.com/karmada-io/karmada/pkg/estimator/server/framework"
 	"github.com/karmada-io/karmada/pkg/util"
 	schedcache "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/cache"
@@ -67,49 +66,68 @@ func (pl *nodeResourceEstimator) Name() string {
 	return Name
 }
 
-// Estimate the replica allowed by the node resources for a given pb.ReplicaRequirements.
-func (pl *nodeResourceEstimator) Estimate(ctx context.Context, snapshot *schedcache.Snapshot, requirements *pb.ReplicaRequirements) (int32, *framework.Result) {
+// Estimate the replica allowed by the node resources for a given ReplicaEstimationContext.
+func (pl *nodeResourceEstimator) Estimate(ctx context.Context, estCtx framework.ReplicaEstimationContext) (int32, *framework.Result) {
 	if !pl.enabled {
 		return pl.disabledResult()
 	}
 
-	allNodes, err := snapshot.NodeInfos().List()
-	if err != nil {
-		return 0, framework.AsResult(err)
-	}
-
+	requirements := estCtx.ReplicaRequirements
 	var affinity nodeaffinity.RequiredNodeAffinity
 	var tolerations []corev1.Toleration
 	var resourceRequest corev1.ResourceList
+	var err error
 	if requirements != nil {
 		affinity, tolerations, err = estimator.GetAffinityAndTolerations(requirements.NodeClaim)
 		if err != nil {
 			return 0, framework.AsResult(err)
 		}
-
 		resourceRequest, err = requirements.UnmarshalResourceRequest()
 		if err != nil {
 			return 0, framework.AsResult(err)
 		}
 	}
 
+	if estCtx.Snapshot == nil {
+		return 0, framework.AsResult(fmt.Errorf("snapshot is nil"))
+	}
+	nodes, err := getNodesAvailableResources(estCtx.Snapshot)
+	if err != nil {
+		return 0, framework.AsResult(err)
+	}
+
+	// Deduct assumed (in-flight) workloads before running main estimation.
+	// Each assumed workload represents pods being started that may not yet be
+	// reflected in the cluster's node resource accounting.
+	// Note: SimulateScheduling mutates nodes in-place by consuming their Allocatable
+	// resources as it places components. The subsequent per-node MaxDivided calls
+	// therefore operate on the already-reduced node capacity.
+	if len(estCtx.AssumedWorkloads) > 0 {
+		sim := estimator.NewSchedulingSimulator(nodes)
+		for _, assumed := range estCtx.AssumedWorkloads {
+			if len(assumed.GetComponents()) == 0 {
+				continue
+			}
+			deductedSets, deductErr := sim.SimulateScheduling(assumed.GetComponents(), 1)
+			if deductErr != nil {
+				return 0, framework.AsResult(deductErr)
+			}
+			if deductedSets == 0 {
+				klog.V(4).Infof("%s: could not deduct assumed workload (namespace=%s) from node resources", pl.Name(), assumed.GetNamespace())
+			}
+		}
+	}
+
 	var res int32
 	processNode := func(i int) {
-		node := allNodes[i].Clone()
+		node := nodes[i]
 		if !estimator.MatchNode(node, affinity, tolerations) {
 			return
 		}
-		maxReplica := pl.nodeMaxAvailableReplica(node, resourceRequest)
-		atomic.AddInt32(&res, maxReplica)
+		atomic.AddInt32(&res, int32(node.Allocatable.MaxDivided(resourceRequest))) // #nosec G115
 	}
-	pl.parallelizer.Until(ctx, len(allNodes), processNode)
-
+	pl.parallelizer.Until(ctx, len(nodes), processNode)
 	return res, framework.NewResult(framework.Success)
-}
-
-func (pl *nodeResourceEstimator) nodeMaxAvailableReplica(node *schedulerframework.NodeInfo, rl corev1.ResourceList) int32 {
-	rest := getNodeAvailableResource(node)
-	return int32(rest.MaxDivided(rl)) // #nosec G115: integer overflow conversion int64 -> int32
 }
 
 // getNodeAvailableResource calculates a node's available resources after deducting requested resources

--- a/pkg/estimator/server/framework/plugins/resourcequota/resourcequota.go
+++ b/pkg/estimator/server/framework/plugins/resourcequota/resourcequota.go
@@ -35,7 +35,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/features"
 	"github.com/karmada-io/karmada/pkg/util"
 	corev1helper "github.com/karmada-io/karmada/pkg/util/lifted"
-	schedcache "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/cache"
 )
 
 const (
@@ -93,12 +92,15 @@ func (pl *resourceQuotaEstimator) Name() string {
 }
 
 // Estimate estimates the replicas allowed by the ResourceQuota constraints.
-func (pl *resourceQuotaEstimator) Estimate(_ context.Context, _ *schedcache.Snapshot, replicaRequirements *pb.ReplicaRequirements) (int32, *framework.Result) {
+// Before computing the maximum allowed replicas it deducts any assumed (in-flight) workloads
+// so that pods already assigned but not yet reflected in ResourceQuota status are accounted for.
+func (pl *resourceQuotaEstimator) Estimate(_ context.Context, estCtx framework.ReplicaEstimationContext) (int32, *framework.Result) {
 	var replica int32 = noQuotaConstraint
 	if !pl.enabled {
 		klog.V(5).Info("Estimator Plugin", "name", Name, "enabled", pl.enabled)
 		return replica, framework.NewResult(framework.Noopperation, fmt.Sprintf("%s is disabled", pl.Name()))
 	}
+	replicaRequirements := estCtx.ReplicaRequirements
 	if replicaRequirements == nil {
 		return noQuotaConstraint, framework.NewResult(framework.Success, fmt.Sprintf("%s found no quota constraints", pl.Name()))
 	}
@@ -117,11 +119,17 @@ func (pl *resourceQuotaEstimator) Estimate(_ context.Context, _ *schedcache.Snap
 	if err != nil {
 		return 0, framework.AsResult(err)
 	}
+
+	// Flatten all assumed workload components for this namespace once, then filter per-quota.
+	assumedComponents := flattenAssumedWorkloadComponents(estCtx.AssumedWorkloads, namespace)
+
 	for _, rq := range rqList {
-		rqEvaluator := newResourceQuotaEvaluator(rq, priorityClassName)
-		replicaFromRqEvaluator := rqEvaluator.evaluate(requirements)
-		if replicaFromRqEvaluator < replica {
-			replica = replicaFromRqEvaluator
+		replicaFromRq, err := pl.evaluateReplicasAgainstQuota(rq, priorityClassName, requirements, assumedComponents)
+		if err != nil {
+			return 0, framework.AsResult(err)
+		}
+		if replicaFromRq < replica {
+			replica = replicaFromRq
 		}
 	}
 
@@ -391,79 +399,82 @@ func (pl *resourceQuotaEstimator) evaluateResourcesAgainstQuota(
 	return int32(allowed) // #nosec G115: integer overflow conversion int64 -> int32
 }
 
-type resourceQuotaEvaluator struct {
-	// key (string) is the name of the resource quota
-	// value (ResourceList) is the free resources calculated by (hard - used) from the resource quota status
-	resourceRequest map[string]corev1.ResourceList
-}
-
-func newResourceQuotaEvaluator(rq *corev1.ResourceQuota, priorityClassName string) *resourceQuotaEvaluator {
+// evaluateReplicasAgainstQuota evaluates per-replica resource requirements against a single ResourceQuota.
+// Steps:
+//  1. Check if the quota applies based on scope selectors and priorityClassName
+//  2. If not applicable → return noQuotaConstraint
+//  3. Compute free resources (Hard - Used)
+//  4. Deduct assumed in-flight workload resources from free resources
+//  5. Calculate replicas = freeResources / per-replica-requirements
+func (pl *resourceQuotaEstimator) evaluateReplicasAgainstQuota(
+	rq *corev1.ResourceQuota,
+	priorityClassName string,
+	requirements corev1.ResourceList,
+	assumedComponents []*pb.Component,
+) (int32, error) {
 	selectors := getScopeSelectorsFromQuota(rq)
-	resources := make(map[string]corev1.ResourceList)
 
-	// Determine if this quota applies based on scope selectors
-	quotaApplies := false
-	if len(selectors) == 0 {
-		// If there are no scope selectors, the quota applies to all pods
-		quotaApplies = true
-	} else {
-		quotaApplies = quotaAppliesToPriority(selectors, priorityClassName)
+	// Determine if this quota applies based on scope selectors.
+	// If there are no scope selectors, the quota applies to all pods.
+	quotaApplies := len(selectors) == 0 || quotaAppliesToPriority(selectors, priorityClassName)
+	if !quotaApplies {
+		return noQuotaConstraint, nil
 	}
 
-	// If the quota applies, extract the free resources
-	if quotaApplies {
-		matchResource := matchingResources(resourceNames(rq.Status.Hard))
-		if len(matchResource) != 0 {
-			freeResource := calculateFreeResources(rq, matchResource)
-			resources[rq.Name] = freeResource
+	// If the quota applies, extract the free resources.
+	matchResource := matchingResources(resourceNames(rq.Status.Hard))
+	if len(matchResource) == 0 {
+		return noQuotaConstraint, nil
+	}
+
+	availableResources := calculateFreeResources(rq, matchResource)
+	if len(availableResources) == 0 {
+		return noQuotaConstraint, nil
+	}
+
+	// Deduct assumed in-flight workload demands before estimating replicas.
+	if len(assumedComponents) > 0 {
+		matchedAssumed := filterComponentsBySelectors(assumedComponents, selectors)
+		if len(matchedAssumed) > 0 {
+			available, err := pl.deductAssumedResources(availableResources, matchedAssumed, rq)
+			if err != nil {
+				return 0, err
+			}
+			if available == nil {
+				// Quota already exhausted by assumed workloads.
+				return 0, nil
+			}
+			availableResources = available
 		}
 	}
 
-	return &resourceQuotaEvaluator{
-		resourceRequest: resources,
-	}
-}
+	// Filter to only include resources that are constrained by this ResourceQuota.
+	filteredRequirements := filterConstrainedResources(availableResources, requirements)
 
-// evaluate evaluates resource requirements against all applicable ResourceQuotas
-// and returns the most restrictive constraint (minimum allowed replicas).
-func (e *resourceQuotaEvaluator) evaluate(requirements corev1.ResourceList) int32 {
-	var result int32 = noQuotaConstraint
-
-	for _, availableResources := range e.resourceRequest {
-		// Filter to only include resources that are constrained by this ResourceQuota
-		filteredRequirements := filterConstrainedResources(availableResources, requirements)
-
-		// If no resources are constrained by this quota, skip it
-		if len(filteredRequirements) == 0 {
-			continue
-		}
-
-		// Create a Resource object with available quota
-		availableResource := util.NewResource(availableResources)
-
-		// Pod quota is not supported in the current implementation.
-		// To add pod quota support in the future:
-		// 1. Include pod count in aggregateComponentRequirements()
-		// 2. Remove this line to let AllowedPodNumber be calculated from availableResources
-		// 3. Add test cases for pod quota constraints
-		availableResource.AllowedPodNumber = math.MaxInt64
-
-		// Calculate how many replicas/sets can fit within the quota
-		allowed := availableResource.MaxDivided(filteredRequirements)
-
-		// Handle integer overflow: treat very large numbers as no constraint for this quota
-		if allowed > math.MaxInt32 {
-			continue
-		}
-
-		// Take the minimum across all ResourceQuotas (most restrictive)
-		count := int32(allowed) // #nosec G115: integer overflow conversion int64 -> int32
-		if count < result {
-			result = count
-		}
+	// If no resources are constrained by this quota, skip it.
+	if len(filteredRequirements) == 0 {
+		return noQuotaConstraint, nil
 	}
 
-	return result
+	// Create a Resource object with available quota.
+	availableResource := util.NewResource(availableResources)
+
+	// Pod quota is not supported in the current implementation.
+	// To add pod quota support in the future:
+	// 1. Include pod count in aggregateComponentRequirements()
+	// 2. Remove this line to let AllowedPodNumber be calculated from availableResources
+	// 3. Add test cases for pod quota constraints
+	availableResource.AllowedPodNumber = math.MaxInt64
+
+	// Calculate how many replicas can fit within the quota.
+	allowed := availableResource.MaxDivided(filteredRequirements)
+
+	// Handle integer overflow: treat very large numbers as no constraint for this quota.
+	if allowed > math.MaxInt32 {
+		return noQuotaConstraint, nil
+	}
+
+	return int32(allowed), nil // #nosec G115: integer overflow conversion int64 -> int32
 }
 
 // filterConstrainedResources returns only the resources from requirements that are actually

--- a/pkg/estimator/server/framework/plugins/resourcequota/resourcequota_test.go
+++ b/pkg/estimator/server/framework/plugins/resourcequota/resourcequota_test.go
@@ -223,6 +223,7 @@ func TestResourceQuotaEstimatorPlugin(t *testing.T) {
 	tests := map[string]struct {
 		replicaRequirements *pb.ReplicaRequirements
 		resourceQuotaList   []*corev1.ResourceQuota
+		assumedWorkloads    []*pb.AssumedWorkload
 		enabled             bool
 		expect              expect
 	}{
@@ -415,11 +416,143 @@ func TestResourceQuotaEstimatorPlugin(t *testing.T) {
 				ret:     framework.NewResult(framework.Noopperation, "ResourceQuotaEstimator is disabled"),
 			},
 		},
+		"assumed-workload-deducts-cpu": {
+			// fooResourceQuota free: 800m cpu (hard=1000m, used=200m)
+			// Assumed: 2 replicas × 200m = 400m deducted → effective free: 400m
+			// Request: 200m cpu → 400m / 200m = 2 replicas
+			replicaRequirements: (&pb.ReplicaRequirements{
+				Namespace:         fooNamespace,
+				PriorityClassName: fooPriorityClassName,
+			}).MustSetResourceRequest(corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(200, resource.DecimalSI),
+			}),
+			resourceQuotaList: []*corev1.ResourceQuota{fooResourceQuota},
+			assumedWorkloads: []*pb.AssumedWorkload{
+				{
+					Namespace: fooNamespace,
+					Components: []*pb.Component{
+						{
+							Name: "in-flight-app",
+							ReplicaRequirements: (&pb.ComponentReplicaRequirements{
+								PriorityClassName: fooPriorityClassName,
+							}).MustSetResourceRequest(corev1.ResourceList{
+								corev1.ResourceCPU: *resource.NewMilliQuantity(200, resource.DecimalSI),
+							}),
+							Replicas: 2,
+						},
+					},
+				},
+			},
+			enabled: true,
+			expect: expect{
+				replica: 2,
+				ret:     framework.NewResult(framework.Success),
+			},
+		},
+		"assumed-workload-exhausts-quota": {
+			// fooResourceQuota free: 800m cpu
+			// Assumed: 4 replicas × 200m = 800m deducted → effective free: 0m → 0 replicas
+			replicaRequirements: (&pb.ReplicaRequirements{
+				Namespace:         fooNamespace,
+				PriorityClassName: fooPriorityClassName,
+			}).MustSetResourceRequest(corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(200, resource.DecimalSI),
+			}),
+			resourceQuotaList: []*corev1.ResourceQuota{fooResourceQuota},
+			assumedWorkloads: []*pb.AssumedWorkload{
+				{
+					Namespace: fooNamespace,
+					Components: []*pb.Component{
+						{
+							Name: "in-flight-app",
+							ReplicaRequirements: (&pb.ComponentReplicaRequirements{
+								PriorityClassName: fooPriorityClassName,
+							}).MustSetResourceRequest(corev1.ResourceList{
+								corev1.ResourceCPU: *resource.NewMilliQuantity(200, resource.DecimalSI),
+							}),
+							Replicas: 4,
+						},
+					},
+				},
+			},
+			enabled: true,
+			expect: expect{
+				replica: 0,
+				ret:     framework.NewResult(framework.Unschedulable, "zero replica is estimated by ResourceQuotaEstimator"),
+			},
+		},
+		"assumed-workload-namespace-mismatch-ignored": {
+			// Assumed workload is in barNamespace; quota is in fooNamespace → no deduction
+			// fooResourceQuota free: 800m cpu → 800m / 200m = 4 replicas
+			replicaRequirements: (&pb.ReplicaRequirements{
+				Namespace:         fooNamespace,
+				PriorityClassName: fooPriorityClassName,
+			}).MustSetResourceRequest(corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(200, resource.DecimalSI),
+			}),
+			resourceQuotaList: []*corev1.ResourceQuota{fooResourceQuota},
+			assumedWorkloads: []*pb.AssumedWorkload{
+				{
+					Namespace: barNamespace,
+					Components: []*pb.Component{
+						{
+							Name: "in-flight-app",
+							ReplicaRequirements: (&pb.ComponentReplicaRequirements{
+								PriorityClassName: fooPriorityClassName,
+							}).MustSetResourceRequest(corev1.ResourceList{
+								corev1.ResourceCPU: *resource.NewMilliQuantity(400, resource.DecimalSI),
+							}),
+							Replicas: 2,
+						},
+					},
+				},
+			},
+			enabled: true,
+			expect: expect{
+				replica: 4,
+				ret:     framework.NewResult(framework.Success),
+			},
+		},
+		"assumed-workload-priority-mismatch-ignored": {
+			// fooResourceQuota scope: fooPriorityClassName only
+			// Assumed component has barPriorityClassName → filtered out → no deduction → 4 replicas
+			replicaRequirements: (&pb.ReplicaRequirements{
+				Namespace:         fooNamespace,
+				PriorityClassName: fooPriorityClassName,
+			}).MustSetResourceRequest(corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(200, resource.DecimalSI),
+			}),
+			resourceQuotaList: []*corev1.ResourceQuota{fooResourceQuota},
+			assumedWorkloads: []*pb.AssumedWorkload{
+				{
+					Namespace: fooNamespace,
+					Components: []*pb.Component{
+						{
+							Name: "in-flight-app",
+							ReplicaRequirements: (&pb.ComponentReplicaRequirements{
+								PriorityClassName: barPriorityClassName, // Mismatch: won't match fooPrioritySelector
+							}).MustSetResourceRequest(corev1.ResourceList{
+								corev1.ResourceCPU: *resource.NewMilliQuantity(400, resource.DecimalSI),
+							}),
+							Replicas: 2,
+						},
+					},
+				},
+			},
+			enabled: true,
+			expect: expect{
+				replica: 4,
+				ret:     framework.NewResult(framework.Success),
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			testCtx := setup(t, tt.resourceQuotaList, tt.enabled)
-			replica, ret := testCtx.p.Estimate(testCtx.ctx, nil, tt.replicaRequirements)
+			replica, ret := testCtx.p.Estimate(testCtx.ctx, framework.ReplicaEstimationContext{
+				ReplicaRequirements: tt.replicaRequirements,
+				AssumedWorkloads:    tt.assumedWorkloads,
+			})
 
 			require.Equal(t, tt.expect.ret.Code(), ret.Code())
 			assert.ElementsMatch(t, tt.expect.ret.Reasons(), ret.Reasons())

--- a/pkg/estimator/server/framework/runtime/framework.go
+++ b/pkg/estimator/server/framework/runtime/framework.go
@@ -27,10 +27,8 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
-	"github.com/karmada-io/karmada/pkg/estimator/pb"
 	"github.com/karmada-io/karmada/pkg/estimator/server/framework"
 	"github.com/karmada-io/karmada/pkg/estimator/server/metrics"
-	schedcache "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/cache"
 	utilmetrics "github.com/karmada-io/karmada/pkg/util/metrics"
 )
 
@@ -137,10 +135,10 @@ func (frw *frameworkImpl) Parallelism() int {
 }
 
 // RunEstimateReplicasPlugins runs the set of configured EstimateReplicasPlugins
-// for estimating replicas based on the given replicaRequirements.
-// It returns an integer and an error.
+// for estimating replicas based on the given estCtx.
+// It returns an integer and a Result.
 // The integer represents the minimum calculated value of estimated replicas from each EstimateReplicasPlugin.
-func (frw *frameworkImpl) RunEstimateReplicasPlugins(ctx context.Context, snapshot *schedcache.Snapshot, replicaRequirements *pb.ReplicaRequirements) (int32, *framework.Result) {
+func (frw *frameworkImpl) RunEstimateReplicasPlugins(ctx context.Context, estCtx framework.ReplicaEstimationContext) (int32, *framework.Result) {
 	startTime := time.Now()
 	defer func() {
 		// Emit metrics with both old and new labels for backward compatibility
@@ -151,7 +149,7 @@ func (frw *frameworkImpl) RunEstimateReplicasPlugins(ctx context.Context, snapsh
 	var replica int32 = math.MaxInt32
 	results := make(framework.PluginToResult)
 	for _, pl := range frw.estimateReplicasPlugins {
-		plReplica, ret := frw.runEstimateReplicasPlugins(ctx, pl, snapshot, replicaRequirements)
+		plReplica, ret := frw.runEstimateReplicasPlugins(ctx, pl, estCtx)
 		if (ret.IsSuccess() || ret.IsUnschedulable()) && plReplica < replica {
 			replica = plReplica
 		}
@@ -167,11 +165,10 @@ func (frw *frameworkImpl) RunEstimateReplicasPlugins(ctx context.Context, snapsh
 func (frw *frameworkImpl) runEstimateReplicasPlugins(
 	ctx context.Context,
 	pl framework.EstimateReplicasPlugin,
-	snapshot *schedcache.Snapshot,
-	replicaRequirements *pb.ReplicaRequirements,
+	estCtx framework.ReplicaEstimationContext,
 ) (int32, *framework.Result) {
 	startTime := time.Now()
-	replica, ret := pl.Estimate(ctx, snapshot, replicaRequirements)
+	replica, ret := pl.Estimate(ctx, estCtx)
 	// Emit metrics with both old and new labels for backward compatibility
 	// TODO: Remove estimator label in a future release (deprecated)
 	metrics.PluginExecutionDuration.WithLabelValues(pl.Name(), estimator).Observe(utilmetrics.DurationInSeconds(startTime))

--- a/pkg/estimator/server/framework/runtime/framework_test.go
+++ b/pkg/estimator/server/framework/runtime/framework_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/karmada-io/karmada/pkg/estimator/pb"
 	"github.com/karmada-io/karmada/pkg/estimator/server/framework"
-	schedcache "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/cache"
 )
 
 type estimateReplicaResult struct {
@@ -55,7 +54,7 @@ func (pl *TestPlugin) Name() string {
 	return pl.name
 }
 
-func (pl *TestPlugin) Estimate(_ context.Context, _ *schedcache.Snapshot, _ *pb.ReplicaRequirements) (int32, *framework.Result) {
+func (pl *TestPlugin) Estimate(_ context.Context, _ framework.ReplicaEstimationContext) (int32, *framework.Result) {
 	return pl.inj.estimateReplicaResult.replica, pl.inj.estimateReplicaResult.ret
 }
 
@@ -253,7 +252,7 @@ func Test_frameworkImpl_RunEstimateReplicasPlugins(t *testing.T) {
 			if err != nil {
 				t.Errorf("create frame work error:%v", err)
 			}
-			replica, ret := f.RunEstimateReplicasPlugins(ctx, nil, &pb.ReplicaRequirements{})
+			replica, ret := f.RunEstimateReplicasPlugins(ctx, framework.ReplicaEstimationContext{})
 
 			require.Equal(t, tt.expected.ret.Code(), ret.Code())
 			assert.ElementsMatch(t, tt.expected.ret.Reasons(), ret.Reasons())

--- a/test/e2e/framework/customresourcedefine.go
+++ b/test/e2e/framework/customresourcedefine.go
@@ -80,6 +80,28 @@ func WaitCRDPresentOnClusters(client karmada.Interface, clusters []string, crdAP
 	})
 }
 
+// WaitCRDEstablished waits until the CustomResourceDefinition has the Established condition on the control plane.
+func WaitCRDEstablished(client dynamic.Interface, name string) {
+	WaitCRDFitWith(client, name, func(crd *apiextensionsv1.CustomResourceDefinition) bool {
+		for _, cond := range crd.Status.Conditions {
+			if cond.Type == apiextensionsv1.Established && cond.Status == apiextensionsv1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// WaitCRDDisappeared waits for the CustomResourceDefinition to be absent from the control plane until timeout.
+func WaitCRDDisappeared(client dynamic.Interface, name string) {
+	ginkgo.By(fmt.Sprintf("Waiting for crd(%s) to be absent from control plane", name), func() {
+		gomega.Eventually(func() bool {
+			_, err := client.Resource(crdGVR).Get(context.TODO(), name, metav1.GetOptions{})
+			return apierrors.IsNotFound(err)
+		}, PollTimeout, PollInterval).Should(gomega.Equal(true))
+	})
+}
+
 // WaitCRDDisappearedOnClusters wait CustomResourceDefinition disappear on clusters until timeout.
 func WaitCRDDisappearedOnClusters(clusters []string, crdName string) {
 	ginkgo.By("Check if crd disappeared on member clusters", func() {

--- a/test/e2e/suites/base/estimator_test.go
+++ b/test/e2e/suites/base/estimator_test.go
@@ -213,8 +213,10 @@ var _ = framework.SerialDescribe("[EstimatorAssumption] ResourceQuota plugin ass
 			err := yaml.Unmarshal([]byte(flinkDeploymentCRDYAML), &flinkCRD)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			framework.CreateCRD(dynamicClient, &flinkCRD)
+			framework.WaitCRDEstablished(dynamicClient, flinkCRD.Name)
 			ginkgo.DeferCleanup(func() {
 				framework.RemoveCRD(dynamicClient, flinkCRD.Name)
+				framework.WaitCRDDisappeared(dynamicClient, flinkCRD.Name)
 			})
 		})
 
@@ -376,8 +378,10 @@ var _ = framework.SerialDescribe("[EstimatorAssumption] NodeResource plugin assu
 			err := yaml.Unmarshal([]byte(flinkDeploymentCRDYAML), &flinkCRD)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			framework.CreateCRD(dynamicClient, &flinkCRD)
+			framework.WaitCRDEstablished(dynamicClient, flinkCRD.Name)
 			ginkgo.DeferCleanup(func() {
 				framework.RemoveCRD(dynamicClient, flinkCRD.Name)
+				framework.WaitCRDDisappeared(dynamicClient, flinkCRD.Name)
 			})
 		})
 	})

--- a/test/e2e/suites/base/federatedresourcequota_test.go
+++ b/test/e2e/suites/base/federatedresourcequota_test.go
@@ -530,8 +530,10 @@ var _ = framework.SerialDescribe("Multi-Components: FederatedResourceQuota enfor
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 				framework.CreateCRD(dynamicClient, &flinkDeploymentCRD)
+				framework.WaitCRDEstablished(dynamicClient, flinkDeploymentCRD.Name)
 				ginkgo.DeferCleanup(func() {
 					framework.RemoveCRD(dynamicClient, flinkDeploymentCRD.Name)
+					framework.WaitCRDDisappeared(dynamicClient, flinkDeploymentCRD.Name)
 				})
 			})
 

--- a/test/e2e/suites/base/schedule_multi_template_test.go
+++ b/test/e2e/suites/base/schedule_multi_template_test.go
@@ -91,8 +91,10 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 				framework.CreateCRD(dynamicClient, &flinkDeploymentCRD)
+				framework.WaitCRDEstablished(dynamicClient, flinkDeploymentCRD.Name)
 				ginkgo.DeferCleanup(func() {
 					framework.RemoveCRD(dynamicClient, flinkDeploymentCRD.Name)
+					framework.WaitCRDDisappeared(dynamicClient, flinkDeploymentCRD.Name)
 				})
 			})
 		})


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7481

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-scheduler-estimator`: Replaced input parameters in EstimateReplicasPlugin with a single structure ReplicaEstimationContext. 
```

