### PR TITLE
fix duplicate wire strings on FRQ event reasons

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -96,14 +96,18 @@ const (
 
 // Define events for FederatedResourceQuota.
 const (
-	// EventReasonSyncFederatedResourceQuotaFailed indicates that Sync work failed.
-	EventReasonSyncFederatedResourceQuotaFailed = "SyncWorkFailed"
-	// EventReasonSyncFederatedResourceQuotaSucceed indicates that Sync work succeed.
-	EventReasonSyncFederatedResourceQuotaSucceed = "SyncWorkSucceed"
-	// EventReasonCollectFederatedResourceQuotaStatusFailed indicates that aggregate status failed.
-	EventReasonCollectFederatedResourceQuotaStatusFailed = "AggregateStatusFailed"
-	// EventReasonCollectFederatedResourceQuotaStatusSucceed indicates that aggregate status succeed.
-	EventReasonCollectFederatedResourceQuotaStatusSucceed = "AggregateStatusSucceed"
+	// EventReasonSyncFederatedResourceQuotaFailed indicates that syncing a
+	// FederatedResourceQuota to the relevant member clusters failed.
+	EventReasonSyncFederatedResourceQuotaFailed = "SyncFederatedResourceQuotaFailed"
+	// EventReasonSyncFederatedResourceQuotaSucceed indicates that syncing a
+	// FederatedResourceQuota to the relevant member clusters succeeded.
+	EventReasonSyncFederatedResourceQuotaSucceed = "SyncFederatedResourceQuotaSucceed"
+	// EventReasonCollectFederatedResourceQuotaStatusFailed indicates that
+	// collecting per-cluster status for a FederatedResourceQuota failed.
+	EventReasonCollectFederatedResourceQuotaStatusFailed = "CollectFederatedResourceQuotaStatusFailed"
+	// EventReasonCollectFederatedResourceQuotaStatusSucceed indicates that
+	// collecting per-cluster status for a FederatedResourceQuota succeeded.
+	EventReasonCollectFederatedResourceQuotaStatusSucceed = "CollectFederatedResourceQuotaStatusSucceed"
 	// EventReasonCollectFederatedResourceQuotaOverallStatusFailed indicates that Collect Overall Status failed.
 	EventReasonCollectFederatedResourceQuotaOverallStatusFailed = "CollectOverallStatusFailed"
 	// EventReasonCollectFederatedResourceQuotaOverallStatusSucceed indicates that Collect Overall Status succeed.

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -108,10 +108,12 @@ const (
 	// EventReasonCollectFederatedResourceQuotaStatusSucceed indicates that
 	// collecting per-cluster status for a FederatedResourceQuota succeeded.
 	EventReasonCollectFederatedResourceQuotaStatusSucceed = "CollectFederatedResourceQuotaStatusSucceed"
-	// EventReasonCollectFederatedResourceQuotaOverallStatusFailed indicates that Collect Overall Status failed.
-	EventReasonCollectFederatedResourceQuotaOverallStatusFailed = "CollectOverallStatusFailed"
-	// EventReasonCollectFederatedResourceQuotaOverallStatusSucceed indicates that Collect Overall Status succeed.
-	EventReasonCollectFederatedResourceQuotaOverallStatusSucceed = "CollectOverallStatusSucceed"
+	// EventReasonCollectFederatedResourceQuotaOverallStatusFailed indicates that
+	// collecting the overall cluster-wide status of a FederatedResourceQuota failed.
+	EventReasonCollectFederatedResourceQuotaOverallStatusFailed = "CollectFederatedResourceQuotaOverallStatusFailed"
+	// EventReasonCollectFederatedResourceQuotaOverallStatusSucceed indicates that
+	// collecting the overall cluster-wide status of a FederatedResourceQuota succeeded.
+	EventReasonCollectFederatedResourceQuotaOverallStatusSucceed = "CollectFederatedResourceQuotaOverallStatusSucceed"
 )
 
 // Define events for resource templates.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Six FederatedResourceQuota event reason constants in `pkg/events/events.go` had wire strings that either collided with the binding controller reasons (`SyncWorkFailed`, `SyncWorkSucceed`, `AggregateStatusFailed`, `AggregateStatusSucceed`) or were generic enough (`CollectOverallStatusFailed`, `CollectOverallStatusSucceed`) that filtering events by reason could not distinguish FRQ events from unrelated ones. This PR renames the six constants so their wire strings reflect the FRQ scope, and updates their doc comments. Call sites are unaffected, they reference the named constant.

**Which issue(s) this PR fixes**:
Fixes #7564

**Special notes for your reviewer**:

The externally visible reason strings on FRQ events change. Captured in the release note.

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: FederatedResourceQuota events now emit distinct reason strings: `SyncFederatedResourceQuotaFailed`, `SyncFederatedResourceQuotaSucceed`, `CollectFederatedResourceQuotaStatusFailed`, `CollectFederatedResourceQuotaStatusSucceed`, `CollectFederatedResourceQuotaOverallStatusFailed`, `CollectFederatedResourceQuotaOverallStatusSucceed`. They previously shared wire strings with the binding controller (`SyncWorkFailed`, `SyncWorkSucceed`, `AggregateStatusFailed`, `AggregateStatusSucceed`) or used the generic `CollectOverallStatusFailed` / `CollectOverallStatusSucceed`. Consumers filtering events by reason on FederatedResourceQuota objects should adjust their filters.
```