### PR TITLE
Reduce unnecessary watch events in endpointslice-dispatch-controller

### DIFF
--- a/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
@@ -155,10 +155,11 @@ func (c *EndpointsliceDispatchController) SetupWithManager(mgr controllerruntime
 				util.GetLabelValue(updateEvent.ObjectNew.GetLabels(), util.ServiceNameLabel) != "") &&
 				util.GetAnnotationValue(updateEvent.ObjectNew.GetAnnotations(), util.EndpointSliceProvisionClusterAnnotation) == ""
 		},
-		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
-			// We only care about the EndpointSlice work from provider clusters
-			return util.GetLabelValue(deleteEvent.Object.GetLabels(), util.MultiClusterServiceNameLabel) != "" &&
-				util.GetAnnotationValue(deleteEvent.Object.GetAnnotations(), util.EndpointSliceProvisionClusterAnnotation) == ""
+		DeleteFunc: func(event.DeleteEvent) bool {
+			// Work uses a finalizer (MCSEndpointSliceDispatchControllerFinalizer)
+			// and the controller already cleans up via DeletionTimestamp in the
+			// update path, so the final delete event is redundant.
+			return false
 		},
 		GenericFunc: func(event.GenericEvent) bool {
 			return false

--- a/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
@@ -139,16 +139,17 @@ func (c *EndpointsliceDispatchController) updateEndpointSliceDispatched(ctx cont
 	})
 }
 
-// SetupWithManager creates a controller and register to controller manager.
-func (c *EndpointsliceDispatchController) SetupWithManager(mgr controllerruntime.Manager) error {
-	workPredicateFun := predicate.Funcs{
+// workPredicateFunc returns the event filter for the Work objects watched by
+// this controller. We only care about the EndpointSlice work from provider
+// clusters, and we skip delete events because the controller cleans up via the
+// finalizer and the DeletionTimestamp transition handled in the update path.
+func (c *EndpointsliceDispatchController) workPredicateFunc() predicate.Funcs {
+	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
-			// We only care about the EndpointSlice work from provider clusters
 			return util.GetLabelValue(createEvent.Object.GetLabels(), util.MultiClusterServiceNameLabel) != "" &&
 				util.GetAnnotationValue(createEvent.Object.GetAnnotations(), util.EndpointSliceProvisionClusterAnnotation) == ""
 		},
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
-			// We only care about the EndpointSlice work from provider clusters
 			// TBD: We care about the work with label util.ServiceNameLabel because now service-export-controller and endpointslice-collect-controller
 			// will manage the work together, should delete this after the conflict is fixed
 			return (util.GetLabelValue(updateEvent.ObjectNew.GetLabels(), util.MultiClusterServiceNameLabel) != "" ||
@@ -156,18 +157,19 @@ func (c *EndpointsliceDispatchController) SetupWithManager(mgr controllerruntime
 				util.GetAnnotationValue(updateEvent.ObjectNew.GetAnnotations(), util.EndpointSliceProvisionClusterAnnotation) == ""
 		},
 		DeleteFunc: func(event.DeleteEvent) bool {
-			// Work uses a finalizer (MCSEndpointSliceDispatchControllerFinalizer)
-			// and the controller already cleans up via DeletionTimestamp in the
-			// update path, so the final delete event is redundant.
 			return false
 		},
 		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	}
+}
+
+// SetupWithManager creates a controller and register to controller manager.
+func (c *EndpointsliceDispatchController) SetupWithManager(mgr controllerruntime.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(EndpointsliceDispatchControllerName).
-		For(&workv1alpha1.Work{}, builder.WithPredicates(workPredicateFun)).
+		For(&workv1alpha1.Work{}, builder.WithPredicates(c.workPredicateFunc())).
 		Watches(&networkingv1alpha1.MultiClusterService{}, handler.EnqueueRequestsFromMapFunc(c.newMultiClusterServiceFunc())).
 		Watches(&clusterv1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(c.newClusterFunc())).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter[controllerruntime.Request](c.RateLimiterOptions)}).

--- a/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller_test.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
@@ -917,4 +918,42 @@ func (f *fakeClient) List(ctx context.Context, list client.ObjectList, opts ...c
 		return f.listError
 	}
 	return f.Client.List(ctx, list, opts...)
+}
+
+func TestWorkPredicateFunc(t *testing.T) {
+	c := &EndpointsliceDispatchController{}
+	predicateFuncs := c.workPredicateFunc()
+
+	providerWork := &workv1alpha1.Work{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{util.MultiClusterServiceNameLabel: "foo"},
+		},
+	}
+	consumerWork := &workv1alpha1.Work{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{util.MultiClusterServiceNameLabel: "foo"},
+			Annotations: map[string]string{util.EndpointSliceProvisionClusterAnnotation: "member1"},
+		},
+	}
+	unrelatedWork := &workv1alpha1.Work{ObjectMeta: metav1.ObjectMeta{}}
+
+	t.Run("CreateFunc keeps provider work only", func(t *testing.T) {
+		assert.True(t, predicateFuncs.Create(event.CreateEvent{Object: providerWork}))
+		assert.False(t, predicateFuncs.Create(event.CreateEvent{Object: consumerWork}))
+		assert.False(t, predicateFuncs.Create(event.CreateEvent{Object: unrelatedWork}))
+	})
+
+	t.Run("UpdateFunc keeps provider work only", func(t *testing.T) {
+		assert.True(t, predicateFuncs.Update(event.UpdateEvent{ObjectNew: providerWork}))
+		assert.False(t, predicateFuncs.Update(event.UpdateEvent{ObjectNew: consumerWork}))
+		assert.False(t, predicateFuncs.Update(event.UpdateEvent{ObjectNew: unrelatedWork}))
+	})
+
+	t.Run("DeleteFunc drops all delete events", func(t *testing.T) {
+		assert.False(t, predicateFuncs.Delete(event.DeleteEvent{Object: providerWork}))
+	})
+
+	t.Run("GenericFunc drops all generic events", func(t *testing.T) {
+		assert.False(t, predicateFuncs.Generic(event.GenericEvent{Object: providerWork}))
+	})
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The endpointslice-dispatch-controller already cleans up via the `MCSEndpointSliceDispatchControllerFinalizer`, and the reconcile path handles the `DeletionTimestamp` transition through the update event. The final delete event therefore doesn't add anything, it just re-enqueues a work that no longer exists. This PR makes the predicate's `DeleteFunc` return false so those events are dropped.

**Which issue(s) this PR fixes**:

Part of #6780

**Special notes for your reviewer**:

No new tests, the predicate functions are inline in `SetupWithManager` and aren't covered by existing tests.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```