### PR TITLE
Remove deprecated Estimator label from estimating_plugin_extension_point

### DIFF
--- a/pkg/estimator/server/framework/runtime/framework.go
+++ b/pkg/estimator/server/framework/runtime/framework.go
@@ -33,10 +33,12 @@ import (
 )
 
 const (
-	// estimator is the legacy label for replica estimation metrics.
-	// Deprecated: Use estimateReplicasExtension instead. This will be removed in a future release.
-	estimator                   = "Estimator"
-	estimateReplicasExtension   = "estimate_replicas"
+	// estimateReplicasExtension is used as the metric label value to identify
+	// the "estimate replicas" extension point when recording framework and plugin durations.
+	estimateReplicasExtension = "estimate_replicas"
+
+	// estimateComponentsExtension is used as the metric label value to identify
+	// the "estimate components" extension point when recording framework and plugin durations.
 	estimateComponentsExtension = "estimate_components"
 )
 
@@ -141,11 +143,9 @@ func (frw *frameworkImpl) Parallelism() int {
 func (frw *frameworkImpl) RunEstimateReplicasPlugins(ctx context.Context, estCtx framework.ReplicaEstimationContext) (int32, *framework.Result) {
 	startTime := time.Now()
 	defer func() {
-		// Emit metrics with both old and new labels for backward compatibility
-		// TODO: Remove estimator label in a future release (deprecated)
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(estimator).Observe(utilmetrics.DurationInSeconds(startTime))
 		metrics.FrameworkExtensionPointDuration.WithLabelValues(estimateReplicasExtension).Observe(utilmetrics.DurationInSeconds(startTime))
 	}()
+
 	var replica int32 = math.MaxInt32
 	results := make(framework.PluginToResult)
 	for _, pl := range frw.estimateReplicasPlugins {
@@ -162,16 +162,10 @@ func (frw *frameworkImpl) RunEstimateReplicasPlugins(ctx context.Context, estCtx
 	return replica, results.Merge()
 }
 
-func (frw *frameworkImpl) runEstimateReplicasPlugins(
-	ctx context.Context,
-	pl framework.EstimateReplicasPlugin,
-	estCtx framework.ReplicaEstimationContext,
-) (int32, *framework.Result) {
+func (frw *frameworkImpl) runEstimateReplicasPlugins(ctx context.Context, pl framework.EstimateReplicasPlugin, estCtx framework.ReplicaEstimationContext) (int32, *framework.Result) {
 	startTime := time.Now()
 	replica, ret := pl.Estimate(ctx, estCtx)
-	// Emit metrics with both old and new labels for backward compatibility
-	// TODO: Remove estimator label in a future release (deprecated)
-	metrics.PluginExecutionDuration.WithLabelValues(pl.Name(), estimator).Observe(utilmetrics.DurationInSeconds(startTime))
+
 	metrics.PluginExecutionDuration.WithLabelValues(pl.Name(), estimateReplicasExtension).Observe(utilmetrics.DurationInSeconds(startTime))
 	klog.V(4).InfoS("EstimateReplicas plugin result", "plugin", pl.Name(), "replicas", replica, "status", ret.Code())
 	return replica, ret
@@ -187,6 +181,7 @@ func (frw *frameworkImpl) RunEstimateComponentsPlugins(ctx context.Context, estC
 	defer func() {
 		metrics.FrameworkExtensionPointDuration.WithLabelValues(estimateComponentsExtension).Observe(utilmetrics.DurationInSeconds(startTime))
 	}()
+
 	var sets int32 = math.MaxInt32
 	results := make(framework.PluginToResult)
 	for _, pl := range frw.estimateComponentsPlugins {


### PR DESCRIPTION
**What type of PR is this?**

/kind deprecation

**What this PR does / why we need it**:

This PR removes the deprecated `estimator` label for the `estimating_plugin_extension_point` metric.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:

This label was deprecated in release-1.16 by PR #6864, now it's ok to remove it in release-1.18.

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-scheduler-estimator`: The deprecated `Estimator` label value for `estimating_plugin_extension_point` in the `estimating_plugin_execution_duration_seconds` and `estimating_plugin_extension_point_duration_seconds` metrics has now been removed. 
```

