### PR TITLE
docs: add lightweight WSL2 setup guide and fast local setup script

### DIFF
--- a/docs/userguide/setup-lightweight-wsl2.md
+++ b/docs/userguide/setup-lightweight-wsl2.md
@@ -422,3 +422,40 @@ This lightweight setup is useful for:
 
 It provides a significantly simpler environment for new contributors compared to the default multi-cluster local setup.
 
+
+
+## Tested Environment
+
+The lightweight setup was validated using:
+
+- Windows 11
+- WSL2 Ubuntu
+- Docker Desktop
+- 4 GB WSL2 memory limit
+- 2 vCPUs
+- 2 GB swap
+
+Using a minimal topology consisting of:
+- 1 Karmada host cluster
+- 1 member cluster
+
+Successfully verified:
+- Karmada control plane startup
+- Member cluster registration
+- Workload propagation
+- ResourceBinding creation
+- Deployment scheduling
+- Workload execution on the member cluster
+
+Observed resource usage:
+- WSL2 memory limit: ~3.8 GiB
+- Memory used after startup: ~2.2 GiB
+- Available memory: ~1.6 GiB
+- Swap usage: ~114 MiB
+
+Docker container memory consumption:
+- karmada-host-control-plane: ~1.4 GiB
+- member1-control-plane: ~686 MiB
+
+Note:
+This setup is intended for contributor onboarding, local development, and debugging workflows. It has not been evaluated as a replacement for the full CI-equivalent e2e environment.

--- a/docs/userguide/setup-lightweight-wsl2.md
+++ b/docs/userguide/setup-lightweight-wsl2.md
@@ -426,36 +426,46 @@ It provides a significantly simpler environment for new contributors compared to
 
 ## Tested Environment
 
-The lightweight setup was validated using:
+The lightweight setup was validated using the following environment:
 
-- Windows 11
-- WSL2 Ubuntu
-- Docker Desktop
-- 4 GB WSL2 memory limit
-- 2 vCPUs
-- 2 GB swap
+* Windows 11
+* WSL2 Ubuntu
+* Docker Desktop
+* 4 GB WSL2 memory limit
+* 2 vCPUs
+* 2 GB swap
 
-Using a minimal topology consisting of:
-- 1 Karmada host cluster
-- 1 member cluster
+### Cluster Topology
 
-Successfully verified:
-- Karmada control plane startup
-- Member cluster registration
-- Workload propagation
-- ResourceBinding creation
-- Deployment scheduling
-- Workload execution on the member cluster
+The validation used a minimal topology consisting of:
 
-Observed resource usage:
-- WSL2 memory limit: ~3.8 GiB
-- Memory used after startup: ~2.2 GiB
-- Available memory: ~1.6 GiB
-- Swap usage: ~114 MiB
+* 1 Karmada host cluster
+* 1 member cluster
 
-Docker container memory consumption:
-- karmada-host-control-plane: ~1.4 GiB
-- member1-control-plane: ~686 MiB
+### Validation Results
 
-Note:
-This setup is intended for contributor onboarding, local development, and debugging workflows. It has not been evaluated as a replacement for the full CI-equivalent e2e environment.
+The following functionality was successfully verified:
+
+* Karmada control plane startup
+* Member cluster registration
+* Workload propagation
+* ResourceBinding creation
+* Deployment scheduling
+* Successful workload execution on the member cluster
+
+### Resource Observations
+
+| Resource                      | Observed |
+| ----------------------------- | -------- |
+| WSL2 Memory Limit             | ~3.8 GiB |
+| Memory Used After Startup     | ~2.2 GiB |
+| Available Memory              | ~1.6 GiB |
+| Swap Used                     | ~114 MiB |
+| Host Cluster CPU Usage        | ~20%     |
+| Member Cluster CPU Usage      | ~7%      |
+| Host Cluster Memory           | ~1.4 GiB |
+| Member Cluster Memory         | ~686 MiB |
+| Host Cluster Writable Layer   | ~105 MB  |
+| Member Cluster Writable Layer | ~3.6 MB  |
+
+> **Note:** The lightweight setup was validated for contributor onboarding, local development, and debugging workflows. Overall Docker image cache and filesystem usage depend on the developer's local environment and are therefore not included as baseline requirements. This configuration has not been evaluated as a replacement for the full CI-equivalent end-to-end (e2e) test environment.

--- a/docs/userguide/setup-lightweight-wsl2.md
+++ b/docs/userguide/setup-lightweight-wsl2.md
@@ -422,8 +422,6 @@ This lightweight setup is useful for:
 
 It provides a significantly simpler environment for new contributors compared to the default multi-cluster local setup.
 
-
-
 ## Tested Environment
 
 The lightweight setup was validated using the following environment:

--- a/docs/userguide/setup-lightweight-wsl2.md
+++ b/docs/userguide/setup-lightweight-wsl2.md
@@ -1,0 +1,424 @@
+# Lightweight Karmada Setup on WSL2
+
+## Overview
+
+This guide explains how to run a lightweight local Karmada development environment on a low-resource Windows laptop using WSL2, Docker Desktop, Kind, and prebuilt Docker images.
+
+The setup is optimized for contributors who want a faster and less resource-intensive workflow compared to the default Karmada local setup.
+
+---
+
+# Why Use a Lightweight Setup?
+
+The default Karmada local setup can be resource intensive because it:
+
+- Builds images from source
+- Creates multiple Kind clusters
+- Consumes significant RAM and CPU
+- Takes longer to initialize
+
+This lightweight setup improves contributor experience by:
+
+- Using prebuilt Docker images
+- Creating only one host cluster and one member cluster
+- Reducing startup time
+- Lowering memory and CPU usage
+- Simplifying local debugging
+
+---
+
+# Environment Used
+
+The setup in this guide was successfully verified using:
+
+- Windows 11
+- WSL2 Ubuntu
+- Docker Desktop
+- Kind
+- kubectl
+- Karmada lightweight setup
+
+---
+
+# Recommended WSL2 Optimization
+
+Create the following file on Windows:
+
+```ini
+C:\Users\<username>\.wslconfig
+```
+
+Add:
+
+```ini
+[wsl2]
+memory=4GB
+processors=2
+swap=2GB
+```
+
+After saving the file, restart WSL:
+
+```powershell
+wsl --shutdown
+```
+
+Then reopen your terminal.
+
+---
+
+# Prerequisites
+
+Ensure the following tools are installed:
+
+- WSL2
+- Docker Desktop
+- kubectl
+- kind
+- git
+
+Verify installations:
+
+```bash
+kubectl version --client
+kind version
+docker --version
+```
+
+---
+
+# Running the Lightweight Setup
+
+Run the following command from the Karmada repository root:
+
+```bash
+bash hack/fast-local-up.sh
+```
+
+This setup:
+
+- Uses prebuilt Docker images
+- Avoids heavy source compilation
+- Creates:
+  - karmada-host cluster
+  - member1 cluster
+- Automatically joins member1 to the Karmada control plane
+
+---
+
+# Verify the Setup
+
+## Configure kubeconfig
+
+```bash
+export KUBECONFIG=$HOME/.kube/karmada.config
+```
+
+---
+
+## Switch Context
+
+```bash
+kubectl config use-context karmada-apiserver
+```
+
+---
+
+## Verify Joined Clusters
+
+```bash
+kubectl get clusters
+```
+
+Expected output:
+
+```text
+NAME      VERSION   MODE   READY
+member1   v1.35.0   Push   True
+```
+
+---
+
+## Verify Workload Deployment
+
+```bash
+kubectl get deployment nginx-sample
+```
+
+Expected output:
+
+```text
+NAME           READY   UP-TO-DATE   AVAILABLE
+nginx-sample   1/1     1            1
+```
+
+---
+
+## Verify ResourceBinding
+
+```bash
+kubectl get rb
+```
+
+Expected output:
+
+```text
+NAME                      SCHEDULED   FULLYAPPLIED
+nginx-sample-deployment   True        True
+```
+
+---
+
+# Verify Pods on Member Cluster
+
+The Karmada control plane stores workload templates, while actual Pods run on member clusters.
+
+To verify running Pods on the member cluster:
+
+```bash
+export KUBECONFIG=$HOME/.kube/members.config
+kubectl config use-context member1
+kubectl get pods -A
+```
+
+Expected output includes:
+
+```text
+default     nginx-sample-xxxxx     1/1     Running
+```
+
+---
+
+# Verify Docker Containers
+
+Run:
+
+```bash
+docker ps
+```
+
+Expected containers:
+
+```text
+karmada-host-control-plane
+member1-control-plane
+```
+
+---
+
+# Troubleshooting
+
+## PowerShell && Separator Issue
+
+Problem:
+
+```text
+The token '&&' is not a valid statement separator in this version.
+```
+
+Cause:
+
+Older PowerShell versions may not support Linux-style command chaining.
+
+Solution:
+
+Use:
+
+```bash
+wsl bash -c "command"
+```
+
+Instead of running chained Linux commands directly in PowerShell.
+
+---
+
+## Pods Not Visible on karmada-apiserver
+
+Problem:
+
+```text
+kubectl get pods -A
+No resources found
+```
+
+Explanation:
+
+The Karmada control plane stores workload templates and policies.
+Actual Pods run on member clusters.
+
+Solution:
+
+Switch to the member cluster kubeconfig:
+
+```bash
+export KUBECONFIG=$HOME/.kube/members.config
+kubectl config use-context member1
+kubectl get pods -A
+```
+
+---
+
+## Missing member1 Context
+
+Problem:
+
+```text
+error: no context exists with the name: "member1"
+```
+
+Cause:
+
+The member cluster context exists inside:
+
+```text
+~/.kube/members.config
+```
+
+not:
+
+```text
+~/.kube/karmada.config
+```
+
+Solution:
+
+Use the correct kubeconfig:
+
+```bash
+export KUBECONFIG=$HOME/.kube/members.config
+```
+
+---
+
+## Slow Startup Time
+
+Possible Causes:
+
+- Building images from source
+- Multiple cluster creation
+- Low system resources
+
+Solution:
+
+Use:
+
+- prebuilt Docker images
+- minimal clusters
+- lightweight setup script
+
+---
+
+## High RAM Usage
+
+Solution:
+
+Reduce WSL2 resources using:
+
+```ini
+[wsl2]
+memory=4GB
+processors=2
+swap=2GB
+```
+
+Also:
+
+- Close unused applications
+- Disable unused Docker Desktop features
+- Avoid running unnecessary clusters
+
+---
+
+## WSL Networking Considerations
+
+Some setups may experience:
+
+- port forwarding issues
+- kubeconfig access issues
+- Docker networking delays
+
+Recommendations:
+
+- Ensure Docker Desktop WSL integration is enabled
+- Restart WSL if networking becomes unstable
+- Restart Docker Desktop if clusters fail to connect
+
+---
+
+# Cleanup
+
+To remove the Kind clusters:
+
+```bash
+kind delete clusters karmada-host member1
+```
+
+---
+
+# Restart the Environment
+
+To recreate the environment:
+
+```bash
+bash hack/fast-local-up.sh
+```
+
+---
+
+# Useful Commands
+
+## List Clusters
+
+```bash
+kubectl get clusters
+```
+
+---
+
+## List Deployments
+
+```bash
+kubectl get deployment -A
+```
+
+---
+
+## List ResourceBindings
+
+```bash
+kubectl get rb
+```
+
+---
+
+## List Docker Containers
+
+```bash
+docker ps
+```
+
+---
+
+## List Pods on Member Cluster
+
+```bash
+export KUBECONFIG=$HOME/.kube/members.config
+kubectl config use-context member1
+kubectl get pods -A
+```
+
+---
+
+# Contributor Notes
+
+This lightweight setup is useful for:
+
+- local Karmada development
+- debugging
+- contributor onboarding
+- low-resource laptops
+- WSL2-based workflows
+- faster testing iterations
+
+It provides a significantly simpler environment for new contributors compared to the default multi-cluster local setup.
+

--- a/hack/fast-local-up.sh
+++ b/hack/fast-local-up.sh
@@ -1,3 +1,17 @@
+# Copyright 2024 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/usr/bin/env bash
 
 set -o errexit

--- a/hack/fast-local-up.sh
+++ b/hack/fast-local-up.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script starts a minimal local karmada control plane using prebuilt images.
+# Optimized for low RAM/CPU and automatic dependency handling.
+# Fixed for WSL2 + Docker Desktop connectivity.
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${REPO_ROOT}"/hack/util.sh
+
+# Variable definitions
+export KUBECONFIG_PATH=${KUBECONFIG_PATH:-"${HOME}/.kube"}
+export MAIN_KUBECONFIG=${MAIN_KUBECONFIG:-"${KUBECONFIG_PATH}/karmada.config"}
+export HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}
+export KARMADA_APISERVER_CLUSTER_NAME=${KARMADA_APISERVER_CLUSTER_NAME:-"karmada-apiserver"}
+export MEMBER_CLUSTER_KUBECONFIG=${MEMBER_CLUSTER_KUBECONFIG:-"${KUBECONFIG_PATH}/members.config"}
+export MEMBER_CLUSTER_NAME=${MEMBER_CLUSTER_NAME:-"member1"}
+export KIND_LOG_FILE=${KIND_LOG_FILE:-"/tmp/karmada"}
+export CLUSTER_VERSION=${CLUSTER_VERSION:-"${DEFAULT_CLUSTER_VERSION}"}
+
+# Set KUBECONFIG for all subsequent commands
+export KUBECONFIG="${MAIN_KUBECONFIG}"
+
+# Optimization: Skip building from source
+export BUILD_FROM_SOURCE=false
+
+# Step 0: Ensure dependencies are installed
+echo "Checking dependencies..."
+mkdir -p "${KIND_LOG_FILE}"
+
+# Install kind if missing
+if ! util::cmd_exist kind; then
+  echo "kind not found, installing..."
+  util::install_tools "sigs.k8s.io/kind" "${KIND_VERSION}"
+fi
+
+# Install kubectl if missing
+if ! util::cmd_exist kubectl; then
+  echo "kubectl not found, installing..."
+  util::install_kubectl "" "$(go env GOARCH)" "$(go env GOOS)"
+fi
+
+# Install cfssl if missing
+if ! util::cmd_exist cfssl || ! util::cmd_exist cfssljson; then
+  echo "cfssl/cfssljson not found, installing..."
+  util::cmd_must_exist_cfssl "v1.6.5"
+fi
+
+# Install karmadactl if missing
+if ! util::cmd_exist karmadactl; then
+  echo "karmadactl not found, installing..."
+  INSTALL_LOCATION="${REPO_ROOT}/_output/bin"
+  mkdir -p "${INSTALL_LOCATION}"
+  rm -f "${INSTALL_LOCATION}/karmadactl"
+  export INSTALL_LOCATION
+  "${REPO_ROOT}"/hack/install-cli.sh karmadactl
+  export PATH="${INSTALL_LOCATION}:${PATH}"
+fi
+
+# Step 1: Create clusters
+echo "Creating clusters (1 Host + 1 Member)..."
+kind delete clusters "${HOST_CLUSTER_NAME}" "${MEMBER_CLUSTER_NAME}" || true
+rm -f "${MAIN_KUBECONFIG}" "${MEMBER_CLUSTER_KUBECONFIG}"
+
+# Prepare host cluster config with port mapping
+TEMP_PATH=$(mktemp -d)
+trap '{ rm -rf ${TEMP_PATH}; }' EXIT
+cp -rf "${REPO_ROOT}"/artifacts/kindClusterConfig/karmada-host.yaml "${TEMP_PATH}"/karmada-host.yaml
+sed -i "s/{{host_ipaddress}}/127.0.0.1/g" "${TEMP_PATH}"/karmada-host.yaml
+
+util::create_cluster "${HOST_CLUSTER_NAME}" "${MAIN_KUBECONFIG}" "${CLUSTER_VERSION}" "${KIND_LOG_FILE}" "${TEMP_PATH}"/karmada-host.yaml
+util::create_cluster "${MEMBER_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${CLUSTER_VERSION}" "${KIND_LOG_FILE}"
+
+echo "Waiting for clusters to be ready..."
+util::check_clusters_ready "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}"
+util::check_clusters_ready "${MEMBER_CLUSTER_KUBECONFIG}" "${MEMBER_CLUSTER_NAME}"
+
+# Step 2: Deploy Karmada control plane
+echo "Deploying Karmada Control Plane..."
+export KARMADA_APISERVER_IP=$(util::get_docker_native_ipaddress "${HOST_CLUSTER_NAME}-control-plane")
+"${REPO_ROOT}"/hack/deploy-karmada.sh "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}"
+
+# Step 3: Join member cluster
+echo "Joining member cluster '${MEMBER_CLUSTER_NAME}' (In-Container Join)..."
+KARMADACTL_BIN=$(which karmadactl)
+
+CP_KUBECONFIG_INTERNAL="${TEMP_PATH}/karmada-internal.config"
+MEM_KUBECONFIG_INTERNAL="${TEMP_PATH}/members-internal.config"
+cp "${MAIN_KUBECONFIG}" "${CP_KUBECONFIG_INTERNAL}"
+cp "${MEMBER_CLUSTER_KUBECONFIG}" "${MEM_KUBECONFIG_INTERNAL}"
+
+kubectl config set-cluster "karmada-apiserver" --server="https://${KARMADA_APISERVER_IP}:5443" --insecure-skip-tls-verify=true --kubeconfig="${CP_KUBECONFIG_INTERNAL}"
+kubectl config set-cluster "kind-${MEMBER_CLUSTER_NAME}" --server="https://$(util::get_docker_native_ipaddress "${MEMBER_CLUSTER_NAME}-control-plane"):6443" --kubeconfig="${MEM_KUBECONFIG_INTERNAL}"
+
+docker cp "${KARMADACTL_BIN}" "${HOST_CLUSTER_NAME}-control-plane:/usr/local/bin/karmadactl"
+docker exec "${HOST_CLUSTER_NAME}-control-plane" chmod +x /usr/local/bin/karmadactl
+cat "${CP_KUBECONFIG_INTERNAL}" | docker exec -i "${HOST_CLUSTER_NAME}-control-plane" tee /tmp/karmada.config > /dev/null
+cat "${MEM_KUBECONFIG_INTERNAL}" | docker exec -i "${HOST_CLUSTER_NAME}-control-plane" tee /tmp/members.config > /dev/null
+
+docker exec "${HOST_CLUSTER_NAME}-control-plane" /usr/local/bin/karmadactl join "${MEMBER_CLUSTER_NAME}" \
+  --kubeconfig="/tmp/karmada.config" \
+  --karmada-context="${KARMADA_APISERVER_CLUSTER_NAME}" \
+  --cluster-kubeconfig="/tmp/members.config" \
+  --cluster-context="${MEMBER_CLUSTER_NAME}"
+
+# Fix local context for WSL access
+kubectl config set-cluster "karmada-apiserver" --server="https://127.0.0.1:5443" --insecure-skip-tls-verify=true --kubeconfig="${MAIN_KUBECONFIG}"
+
+# Step 4: Verify setup
+echo "Verifying setup..."
+util:wait_cluster_ready "${KARMADA_APISERVER_CLUSTER_NAME}" "${MEMBER_CLUSTER_NAME}"
+
+# Step 5: Run sample Nginx workload
+echo "Running sample Nginx workload..."
+cat <<EOF | kubectl --context="${KARMADA_APISERVER_CLUSTER_NAME}" apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-sample
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+---
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: nginx-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: nginx-sample
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - ${MEMBER_CLUSTER_NAME}
+EOF
+
+echo "Waiting for Nginx to be scheduled..."
+sleep 15
+kubectl --context="${KARMADA_APISERVER_CLUSTER_NAME}" get deployment nginx-sample
+
+echo ""
+echo "================================================================================"
+echo "      FAST LOCAL KARMADA SETUP COMPLETE"
+echo "================================================================================"
+echo "Karmada Control Plane: karmada-apiserver (localhost:5443)"
+echo "Member cluster: ${MEMBER_CLUSTER_NAME} (Ready)"
+echo "Sample Nginx workload: Running"
+echo ""
+echo "Verification Commands (Run from WSL):"
+echo "  export KUBECONFIG=${MAIN_KUBECONFIG}"
+echo "  kubectl config use-context ${KARMADA_APISERVER_CLUSTER_NAME}"
+echo "  kubectl get clusters"
+echo "  kubectl get deployment nginx-sample"
+echo "  karmadactl get pods -l app=nginx"
+echo ""
+echo "To Stop the environment:"
+echo "  kind delete clusters ${HOST_CLUSTER_NAME} ${MEMBER_CLUSTER_NAME}"
+echo "================================================================================"


### PR DESCRIPTION
## Summary

This PR adds a lightweight WSL2 setup guide along with a fast local setup script for contributors running Karmada on low-resource laptops.

## Motivation

The default Karmada local setup can be resource intensive due to:

* multiple Kind clusters
* source image builds
* high memory usage
* longer startup times

This contribution introduces a lightweight workflow optimized for:

* WSL2 environments
* low-resource laptops
* faster contributor onboarding
* simplified local development

## Changes

* Added `hack/fast-local-up.sh`

  * uses prebuilt Docker images
  * avoids heavy source builds
  * creates minimal clusters
  * optimizes local startup workflow

* Added `docs/userguide/setup-lightweight-wsl2.md`

  * setup instructions
  * verification commands
  * troubleshooting guide
  * cleanup and restart workflow

## Testing

Verified successfully using:

* Windows 11
* WSL2 Ubuntu
* Docker Desktop
* Kind
* Lightweight Karmada setup

Verified:

* cluster registration
* workload propagation
* ResourceBinding creation
* member cluster workloads
* kubeconfig workflow
* Docker container setup

Related to #7567
