### PR TITLE
Automated cherry pick of #7554: the scheduler process multiple templates in the

### DIFF
--- a/pkg/scheduler/core/common.go
+++ b/pkg/scheduler/core/common.go
@@ -22,6 +22,7 @@ import (
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/features"
 	"github.com/karmada-io/karmada/pkg/scheduler/core/spreadconstraint"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework"
 	"github.com/karmada-io/karmada/pkg/scheduler/metrics"
@@ -33,6 +34,11 @@ func SelectClusters(clustersScore framework.ClusterScoreList, placement *policyv
 	defer metrics.ScheduleStep(metrics.ScheduleStepSelect, startTime)
 
 	groupClustersInfo := spreadconstraint.GroupClustersWithScore(clustersScore, placement, spec, calAvailableReplicas)
+	if features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) && isMultiTemplateSchedulingApplicable(spec) {
+		// For multi-component workloads, they are scheduled as a whole and do not support replica division.
+		// The scheduling unit is 1 (i.e., 1 instance of the multi-component template), so we require 1 available replica.
+		return spreadconstraint.SelectBestClusters(placement, groupClustersInfo, 1)
+	}
 	return spreadconstraint.SelectBestClusters(placement, groupClustersInfo, spec.Replicas)
 }
 

--- a/test/e2e/suites/base/federatedresourcequota_test.go
+++ b/test/e2e/suites/base/federatedresourcequota_test.go
@@ -579,18 +579,6 @@ var _ = framework.SerialDescribe("Multi-Components: FederatedResourceQuota enfor
 
 				flinkDeploymentObj.SetNamespace(flinkDeploymentNamespace)
 				flinkDeploymentObj.SetName(flinkDeploymentName)
-				err = unstructured.SetNestedField(flinkDeploymentObj.Object, int64(3), "spec", "jobManager", "replicas")
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				err = unstructured.SetNestedField(flinkDeploymentObj.Object, map[string]interface{}{
-					"cpu":    int64(2),
-					"memory": "50Mi",
-				}, "spec", "jobManager", "resource")
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				err = unstructured.SetNestedField(flinkDeploymentObj.Object, map[string]interface{}{
-					"cpu":    int64(1),
-					"memory": "100Mi",
-				}, "spec", "taskManager", "resource")
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 				flinkDeploymentGVR = schema.GroupVersionResource{
 					Group:    flinkDeploymentObj.GroupVersionKind().Group,
@@ -641,9 +629,12 @@ var _ = framework.SerialDescribe("Multi-Components: FederatedResourceQuota enfor
 		ginkgo.It("FederatedResourceQuota usage should be calculated correctly", func() {
 			framework.WaitFederatedResourceQuotaFitWith(karmadaClient, frqNamespace, frqName, func(frq *policyv1alpha1.FederatedResourceQuota) bool {
 				expectedUsed := corev1.ResourceList{
-					"cpu":    resource.MustParse("7"),
-					"memory": resource.MustParse("250Mi"),
+					"cpu":    resource.MustParse("150m"),
+					"memory": resource.MustParse("200m"),
 				}
+				ginkgo.GinkgoLogr.Info("FederatedResourceQuota OverallUsed",
+					"cpu", frq.Status.OverallUsed.Cpu().String(),
+					"memory", frq.Status.OverallUsed.Memory().String())
 				return frq.Status.OverallUsed != nil && frq.Status.OverallUsed.Cpu().Equal(*expectedUsed.Cpu()) &&
 					frq.Status.OverallUsed.Memory().Equal(*expectedUsed.Memory())
 			})

--- a/test/e2e/suites/base/manifest/flinkdeployment-cr.yaml
+++ b/test/e2e/suites/base/manifest/flinkdeployment-cr.yaml
@@ -16,10 +16,10 @@ spec:
   jobManager:
     replicas: 1
     resource:
-      cpu: 1
+      cpu: 0.05
       memory: 100m
   serviceAccount: flink
   taskManager:
     resource:
-      cpu: 1
+      cpu: 0.1
       memory: 100m

--- a/test/e2e/suites/base/schedule_multi_template_test.go
+++ b/test/e2e/suites/base/schedule_multi_template_test.go
@@ -200,8 +200,8 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 				gomega.Expect(jobManagerComponent).ShouldNot(gomega.BeNil(), "jobmanager component should exist")
 				gomega.Expect(taskManagerComponent).ShouldNot(gomega.BeNil(), "taskmanager component should exist")
 				// Verify the detailed content of components (including ReplicaRequirements and resource values)
-				verifyComponentResources(jobManagerComponent, 1, "1", "100m")
-				verifyComponentResources(taskManagerComponent, 1, "1", "100m")
+				verifyComponentResources(jobManagerComponent, 1, "50m", "100m")
+				verifyComponentResources(taskManagerComponent, 1, "100m", "100m")
 			})
 
 			var targetClusterName string


### PR DESCRIPTION
Cherry pick of #7554 on release-1.16.
#7554: the scheduler process multiple templates in the
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-scheduler`: fixed the issue when cluster resources are insufficient, multiple template resources can still be scheduled.
```