### PR TITLE
Add e2e for single template assumption

### DIFF
--- a/test/e2e/suites/base/estimator_test.go
+++ b/test/e2e/suites/base/estimator_test.go
@@ -365,6 +365,14 @@ var _ = framework.SerialDescribe("[EstimatorAssumption] ResourceQuota plugin ass
 						strings.Contains(cond.Message, "no enough resource")
 				})
 		})
+
+		// At this point, 6 FlinkDeployments are in the assumption cache (6 × 150m = 900m assumed).
+		// A single-template Deployment requesting 200m CPU would push the total to 1100m,
+		// exceeding the 1000m ResourceQuota. This step verifies that the assumption cache also
+		// protects against over-scheduling of single-template workloads.
+		ginkgo.By("verifying a single-template Deployment requesting 200m CPU is also unschedulable due to assumed workloads", func() {
+			assertSingleTemplateDeploymentUnschedulable(quotaNamespace, targetCluster)
+		})
 	})
 })
 
@@ -497,5 +505,73 @@ var _ = framework.SerialDescribe("[EstimatorAssumption] NodeResource plugin assu
 			gomega.Expect(assumptionExhausted).Should(gomega.BeTrue(),
 				"expected assumption to exhaust cluster resources within %d FlinkDeployments", maxFlinkCount)
 		})
+
+		// At this point the assumption cache has consumed all available node CPU on member1.
+		// A single-template Deployment requesting 200m CPU should also fail to schedule,
+		// verifying that the assumption cache protects against over-scheduling of
+		// single-template workloads as well.
+		ginkgo.By("verifying a single-template Deployment requesting 200m CPU is also unschedulable due to assumed workloads", func() {
+			assertSingleTemplateDeploymentUnschedulable(testNamespace, targetCluster)
+		})
 	})
 })
+
+// assertSingleTemplateDeploymentUnschedulable creates a single-replica Deployment requesting
+// 200m CPU in the given namespace, propagates it to targetCluster, and asserts that the
+// ResourceBinding transitions to an unschedulable state because the assumption cache has
+// already exhausted the available resources.
+func assertSingleTemplateDeploymentUnschedulable(namespace, targetCluster string) {
+	const cpuRequest = "200m"
+
+	deployName := fmt.Sprintf("deploy-%s", rand.String(RandomStrLength))
+	deploy := helper.NewDeployment(namespace, deployName)
+	deploy.Spec.Replicas = ptr.To[int32](1)
+	deploy.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse(cpuRequest),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse(cpuRequest),
+		},
+	}
+	framework.CreateDeployment(kubeClient, deploy)
+	ginkgo.DeferCleanup(func() {
+		framework.RemoveDeployment(kubeClient, namespace, deployName)
+	})
+
+	pp := helper.NewPropagationPolicy(namespace, ppNamePrefix+rand.String(RandomStrLength),
+		[]policyv1alpha1.ResourceSelector{{
+			APIVersion: deploy.APIVersion,
+			Kind:       deploy.Kind,
+			Name:       deployName,
+		}},
+		policyv1alpha1.Placement{
+			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+				ClusterNames: []string{targetCluster},
+			},
+			SpreadConstraints: []policyv1alpha1.SpreadConstraint{
+				{
+					SpreadByField: policyv1alpha1.SpreadByFieldCluster,
+					MaxGroups:     1,
+					MinGroups:     1,
+				},
+			},
+			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceAggregated,
+			},
+		})
+	framework.CreatePropagationPolicy(karmadaClient, pp)
+	ginkgo.DeferCleanup(func() {
+		framework.RemovePropagationPolicy(karmadaClient, namespace, pp.Name)
+	})
+
+	bindingName := names.GenerateBindingName(util.DeploymentKind, deployName)
+	framework.WaitResourceBindingFitWith(karmadaClient, namespace, bindingName,
+		func(binding *workv1alpha2.ResourceBinding) bool {
+			cond := meta.FindStatusCondition(binding.Status.Conditions, workv1alpha2.Scheduled)
+			return cond != nil && cond.Status == metav1.ConditionFalse &&
+				cond.Reason == workv1alpha2.BindingReasonSchedulerError &&
+				strings.Contains(cond.Message, "no enough resource")
+		})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7481

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

We have used the previous multi-template test and directly added a test step to distribute the deployment resources. Because the previous assumptions are still valid, the scheduling result of insufficient resources is obtained when the deployment resources are directly distributed.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

