### PR TITLE
update wrong memory format in the flinkdeployment-cr.yaml

### DIFF
--- a/test/e2e/suites/base/federatedresourcequota_test.go
+++ b/test/e2e/suites/base/federatedresourcequota_test.go
@@ -641,7 +641,7 @@ var _ = framework.SerialDescribe("Multi-Components: FederatedResourceQuota enfor
 			framework.WaitFederatedResourceQuotaFitWith(karmadaClient, frqNamespace, frqName, func(frq *policyv1alpha1.FederatedResourceQuota) bool {
 				expectedUsed := corev1.ResourceList{
 					"cpu":    resource.MustParse("150m"),
-					"memory": resource.MustParse("200m"),
+					"memory": resource.MustParse("200Mi"),
 				}
 				ginkgo.GinkgoLogr.Info("FederatedResourceQuota OverallUsed",
 					"cpu", frq.Status.OverallUsed.Cpu().String(),

--- a/test/e2e/suites/base/manifest/flinkdeployment-cr.yaml
+++ b/test/e2e/suites/base/manifest/flinkdeployment-cr.yaml
@@ -17,9 +17,9 @@ spec:
     replicas: 1
     resource:
       cpu: 0.05
-      memory: 100m
+      memory: 100Mi
   serviceAccount: flink
   taskManager:
     resource:
       cpu: 0.1
-      memory: 100m
+      memory: 100Mi

--- a/test/e2e/suites/base/schedule_multi_template_test.go
+++ b/test/e2e/suites/base/schedule_multi_template_test.go
@@ -65,15 +65,19 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 		return nil
 	}
 
-	// Helper function to verify component resource requirements
+	// Helper function to verify component resource requirements.
+	// Uses Cmp for quantity comparison to avoid mismatches caused by different
+	// internal representations (e.g. DecimalSI vs BinarySI) for equal values.
 	verifyComponentResources := func(component *workv1alpha2.Component, expectedReplicas int32, expectedCPU, expectedMemory string) {
 		gomega.Expect(component).ShouldNot(gomega.BeNil())
 		gomega.Expect(component.Replicas).Should(gomega.Equal(expectedReplicas))
 		gomega.Expect(component.ReplicaRequirements).ShouldNot(gomega.BeNil())
-		gomega.Expect(component.ReplicaRequirements.ResourceRequest).Should(gomega.Equal(corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(expectedCPU),
-			corev1.ResourceMemory: resource.MustParse(expectedMemory),
-		}))
+		actualCPU := component.ReplicaRequirements.ResourceRequest[corev1.ResourceCPU]
+		actualMemory := component.ReplicaRequirements.ResourceRequest[corev1.ResourceMemory]
+		gomega.Expect(actualCPU.Cmp(resource.MustParse(expectedCPU))).Should(gomega.Equal(0),
+			"CPU mismatch: got %s, expected %s", actualCPU.String(), expectedCPU)
+		gomega.Expect(actualMemory.Cmp(resource.MustParse(expectedMemory))).Should(gomega.Equal(0),
+			"Memory mismatch: got %s, expected %s", actualMemory.String(), expectedMemory)
 	}
 
 	ginkgo.Context("FlinkDeployment scheduling", func() {
@@ -202,8 +206,8 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 				gomega.Expect(jobManagerComponent).ShouldNot(gomega.BeNil(), "jobmanager component should exist")
 				gomega.Expect(taskManagerComponent).ShouldNot(gomega.BeNil(), "taskmanager component should exist")
 				// Verify the detailed content of components (including ReplicaRequirements and resource values)
-				verifyComponentResources(jobManagerComponent, 1, "50m", "100m")
-				verifyComponentResources(taskManagerComponent, 1, "100m", "100m")
+				verifyComponentResources(jobManagerComponent, 1, "50m", "100Mi")
+				verifyComponentResources(taskManagerComponent, 1, "100m", "100Mi")
 			})
 
 			var targetClusterName string


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

The `flinkdeployment-cr.yaml` use 100m (milli-bytes) of memory. As noted, memory should be specified in realistic units like Mi (e.g., 100Mi / 100M) rather than milli-bytes (m), which represent fractional bytes and are not meaningful for memory in Kubernetes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

