### PR TITLE
[release-1.17] eliminate Node.js 20 depreated actions warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: '23.4'
-          # Use the automatic token, so that this task can be run in the forked repo.
-          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: verify codegen
         run: hack/verify-codegen.sh
       - name: verify crdgen
@@ -96,7 +89,7 @@ jobs:
         # Prevent running from the forked repository that doesn't need to upload coverage.
         # In addition, running on the forked repository would fail as missing the necessary secret.
         if: ${{ github.repository == 'karmada-io/karmada' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           # Even though token upload token is not required for public repos,
           # but adding a token might increase successful uploads as per:

--- a/hack/update-estimator-protobuf.sh
+++ b/hack/update-estimator-protobuf.sh
@@ -24,10 +24,78 @@ DEFAULT_GOPATH=$(go env GOPATH | awk -F ':' '{print $1}')
 export GOPATH=${DEFAULT_GOPATH}
 export PATH=$PATH:$GOPATH/bin
 
+PROTOC_VERSION="23.4"
+PROTOC_TAG="v${PROTOC_VERSION}"
+PROTOC_DIR="${KARMADA_ROOT}/_tmp/protoc"
+
 GO111MODULE=on go install golang.org/x/tools/cmd/goimports
 GO111MODULE=on go install k8s.io/code-generator/cmd/go-to-protobuf
 GO111MODULE=on go install github.com/gogo/protobuf/protoc-gen-gogo
 GO111MODULE=on go install github.com/vektra/mockery/v3
+
+setup_protoc() {
+  # If the pinned protoc already exists and matches, reuse it.
+  if [[ -x "${PROTOC_DIR}/bin/protoc" ]]; then
+    if [[ "$("${PROTOC_DIR}/bin/protoc" --version 2>/dev/null)" == "libprotoc ${PROTOC_VERSION}"* ]]; then
+      export PATH="${PROTOC_DIR}/bin:${PATH}"
+      return 0
+    fi
+    # Version mismatch; remove stale binary and re-download below.
+    rm -rf "${PROTOC_DIR}"
+  fi
+
+  # If system protoc already matches, keep using it (no download needed).
+  if command -v protoc >/dev/null 2>&1; then
+    if [[ "$(protoc --version 2>/dev/null)" == "libprotoc ${PROTOC_VERSION}"* ]]; then
+      return 0
+    fi
+  fi
+
+  rm -rf "${PROTOC_DIR}"
+  mkdir -p "${PROTOC_DIR}"
+
+  local os arch zip_name url tmp_zip
+  os="$(uname | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+
+  # Map host OS/arch to the suffixes used by protobuf release assets.
+  # Note: protobuf releases use "osx" (not "darwin") and "aarch_64" (not "aarch64").
+  case "${os}" in
+    linux) os="linux" ;;
+    darwin) os="osx" ;;
+    *) echo "Unsupported OS for protoc download: ${os}" >&2; exit 1 ;;
+  esac
+
+  case "${arch}" in
+    x86_64|amd64) arch="x86_64" ;;
+    aarch64|arm64) arch="aarch_64" ;;
+    *) echo "Unsupported arch for protoc download: ${arch}" >&2; exit 1 ;;
+  esac
+
+  zip_name="protoc-${PROTOC_VERSION}-${os}-${arch}.zip"
+
+  url="https://github.com/protocolbuffers/protobuf/releases/download/${PROTOC_TAG}/${zip_name}"
+  tmp_zip="${KARMADA_ROOT}/_tmp/${zip_name}"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -sSLf -o "${tmp_zip}" "${url}"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "${tmp_zip}" "${url}"
+  else
+    echo "Neither curl nor wget is available to download protoc" >&2
+    exit 1
+  fi
+
+  if ! command -v unzip >/dev/null 2>&1; then
+    echo "unzip is required to install protoc ${PROTOC_VERSION}" >&2
+    exit 1
+  fi
+
+  unzip -q "${tmp_zip}" -d "${PROTOC_DIR}"
+  rm -f "${tmp_zip}"
+
+  export PATH="${PROTOC_DIR}/bin:${PATH}"
+}
 
 # Make dummy GOPATH for go-to-protobuf to generate the files to repo root.
 # It is useful for case that karmada repo not in the real GOPATH.
@@ -38,6 +106,8 @@ cleanup() {
 trap "cleanup" EXIT SIGINT
 
 cleanup
+
+setup_protoc
 
 source "${KARMADA_ROOT}"/hack/util.sh
 util:create_gopath_tree "${KARMADA_ROOT}" "${go_path}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Ref to https://github.com/karmada-io/karmada/pull/7561#issuecomment-4581395274, we need to update the action `codecov/codecov-action` version and remove the unused action `arduino/setup-protoc` to eliminate `Node.js 20 deprecated` warning.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

