### PR TITLE
fix: correct APIService invalid-data error message

### DIFF
--- a/operator/pkg/tasks/init/karmadaresource.go
+++ b/operator/pkg/tasks/init/karmadaresource.go
@@ -206,7 +206,7 @@ func runWebhookConfiguration(r workflow.RunData) error {
 func runAPIService(r workflow.RunData) error {
 	data, ok := r.(InitData)
 	if !ok {
-		return errors.New("webhookConfiguration task invoked with an invalid data struct")
+		return errors.New("APIService task invoked with an invalid data struct")
 	}
 
 	config := data.ControlplaneConfig()


### PR DESCRIPTION
## Summary
- correct the `runAPIService` invalid-data type assertion error message
- replace the copied `webhookConfiguration task` text with `APIService task`

Closes #7592.

## Testing
- `go test ./operator/pkg/tasks/init/...` could not be run in this environment because the `go` toolchain is not installed
- `git diff --check`
