### PR TITLE
perf(luavm): cache compiled Lua FunctionProto in RunScript to avoid r…

### DIFF
--- a/pkg/resourceinterpreter/customized/declarative/configurable.go
+++ b/pkg/resourceinterpreter/customized/declarative/configurable.go
@@ -193,9 +193,9 @@ func (c *ConfigurableInterpreter) GetDependencies(object *unstructured.Unstructu
 	klog.V(4).Infof("Running operation %s for object: %v %s/%s with configurable interpreter.",
 		configv1alpha1.InterpreterOperationInterpretDependency, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	refs := sets.New[configv1alpha1.DependentObjectReference]()
-	for _, luaScript := range scripts {
+	for i, luaScript := range scripts {
 		var references []configv1alpha1.DependentObjectReference
-		references, err = c.luaVM.GetDependencies(object, luaScript)
+		references, err = c.luaVM.GetDependencies(object, luaScript, i)
 		if err != nil {
 			klog.Errorf("Failed to get DependentObjectReferences from object: %v %s/%s, error: %v",
 				object.GroupVersionKind(), object.GetNamespace(), object.GetName(), err)

--- a/pkg/resourceinterpreter/customized/declarative/luavm/lua.go
+++ b/pkg/resourceinterpreter/customized/declarative/luavm/lua.go
@@ -60,8 +60,8 @@ func New(useOpenLibs bool, poolSize int) *VM {
 	return vm
 }
 
-// compileScript parses and compiles the Lua script into a FunctionProto, caching the result to avoid redundant compilation.
-func (vm *VM) compileScript(script string) (*lua.FunctionProto, error) {
+// loadOrCompileScript returns a cached FunctionProto for script, compiling it on first use.
+func (vm *VM) loadOrCompileScript(script string) (*lua.FunctionProto, error) {
 	if value, ok := vm.funcCache.Load(script); ok {
 		return value.(*lua.FunctionProto), nil
 	}
@@ -110,7 +110,7 @@ func (vm *VM) RunScript(script string, fnName string, nRets int, args ...any) ([
 	defer cancel()
 	l.SetContext(ctx)
 
-	proto, err := vm.compileScript(script)
+	proto, err := vm.loadOrCompileScript(script)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resourceinterpreter/customized/declarative/luavm/lua.go
+++ b/pkg/resourceinterpreter/customized/declarative/luavm/lua.go
@@ -21,9 +21,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
+	"sync"
 	"time"
 
 	lua "github.com/yuin/gopher-lua"
+	"github.com/yuin/gopher-lua/parse"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
@@ -40,6 +43,8 @@ type VM struct {
 	// UseOpenLibs flag to enable open libraries. Libraries are disabled by default while running, but enabled during testing to allow the use of print statements.
 	UseOpenLibs bool
 	Pool        *fixedpool.FixedPool
+	// TODO(user): Implement a garbage collection or eviction policy for funcCache to prevent memory leaks if scripts are updated or dynamically generated.
+	funcCache sync.Map // map[string]*lua.FunctionProto
 }
 
 // New creates a manager for lua VM
@@ -53,6 +58,26 @@ func New(useOpenLibs bool, poolSize int) *VM {
 		func(a any) { a.(*lua.LState).Close() },
 		poolSize)
 	return vm
+}
+
+// compileScript parses and compiles the Lua script into a FunctionProto, caching the result to avoid redundant compilation.
+func (vm *VM) compileScript(script string) (*lua.FunctionProto, error) {
+	if value, ok := vm.funcCache.Load(script); ok {
+		return value.(*lua.FunctionProto), nil
+	}
+
+	chunk, err := parse.Parse(strings.NewReader(script), "<string>")
+	if err != nil {
+		return nil, err
+	}
+
+	proto, err := lua.Compile(chunk, "<string>")
+	if err != nil {
+		return nil, err
+	}
+
+	vm.funcCache.Store(script, proto)
+	return proto, nil
 }
 
 // NewLuaState creates a new lua state.
@@ -85,8 +110,14 @@ func (vm *VM) RunScript(script string, fnName string, nRets int, args ...any) ([
 	defer cancel()
 	l.SetContext(ctx)
 
-	err = l.DoString(script)
+	proto, err := vm.compileScript(script)
 	if err != nil {
+		return nil, err
+	}
+
+	chunkFn := l.NewFunctionFromProto(proto)
+	l.Push(chunkFn)
+	if err := l.PCall(0, lua.MultRet, nil); err != nil {
 		return nil, err
 	}
 

--- a/pkg/resourceinterpreter/customized/declarative/luavm/lua.go
+++ b/pkg/resourceinterpreter/customized/declarative/luavm/lua.go
@@ -29,6 +29,7 @@ import (
 	"github.com/yuin/gopher-lua/parse"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	luajson "layeh.com/gopher-json"
 
@@ -38,13 +39,24 @@ import (
 	lualifted "github.com/karmada-io/karmada/pkg/util/lifted/lua"
 )
 
+// ScriptCacheKey identifies a Lua interpreter script slot for cache lookups.
+type ScriptCacheKey struct {
+	GVK             schema.GroupVersionKind
+	Operation       configv1alpha1.InterpreterOperation
+	DependencyIndex int
+}
+
+type scriptCacheEntry struct {
+	script string
+	proto  *lua.FunctionProto
+}
+
 // VM Defines a struct that implements the luaVM.
 type VM struct {
 	// UseOpenLibs flag to enable open libraries. Libraries are disabled by default while running, but enabled during testing to allow the use of print statements.
 	UseOpenLibs bool
 	Pool        *fixedpool.FixedPool
-	// TODO(user): Implement a garbage collection or eviction policy for funcCache to prevent memory leaks if scripts are updated or dynamically generated.
-	funcCache sync.Map // map[string]*lua.FunctionProto
+	funcCache   sync.Map // map[ScriptCacheKey]*scriptCacheEntry
 }
 
 // New creates a manager for lua VM
@@ -60,10 +72,14 @@ func New(useOpenLibs bool, poolSize int) *VM {
 	return vm
 }
 
-// loadOrCompileScript returns a cached FunctionProto for script, compiling it on first use.
-func (vm *VM) loadOrCompileScript(script string) (*lua.FunctionProto, error) {
-	if value, ok := vm.funcCache.Load(script); ok {
-		return value.(*lua.FunctionProto), nil
+// loadOrCompileScript returns a cached FunctionProto for the given key and script,
+// compiling it on first use or when the script content changes.
+func (vm *VM) loadOrCompileScript(key ScriptCacheKey, script string) (*lua.FunctionProto, error) {
+	if value, ok := vm.funcCache.Load(key); ok {
+		entry := value.(*scriptCacheEntry)
+		if entry.script == script {
+			return entry.proto, nil
+		}
 	}
 
 	chunk, err := parse.Parse(strings.NewReader(script), "<string>")
@@ -76,7 +92,7 @@ func (vm *VM) loadOrCompileScript(script string) (*lua.FunctionProto, error) {
 		return nil, err
 	}
 
-	vm.funcCache.Store(script, proto)
+	vm.funcCache.Store(key, &scriptCacheEntry{script: script, proto: proto})
 	return proto, nil
 }
 
@@ -96,7 +112,7 @@ func (vm *VM) NewLuaState() (*lua.LState, error) {
 }
 
 // RunScript got a lua vm from pool, and execute script with given arguments.
-func (vm *VM) RunScript(script string, fnName string, nRets int, args ...any) ([]lua.LValue, error) {
+func (vm *VM) RunScript(key ScriptCacheKey, script string, fnName string, nRets int, args ...any) ([]lua.LValue, error) {
 	a, err := vm.Pool.Get()
 	if err != nil {
 		return nil, err
@@ -110,7 +126,7 @@ func (vm *VM) RunScript(script string, fnName string, nRets int, args ...any) ([
 	defer cancel()
 	l.SetContext(ctx)
 
-	proto, err := vm.loadOrCompileScript(script)
+	proto, err := vm.loadOrCompileScript(key, script)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +174,8 @@ func (vm *VM) RunScript(script string, fnName string, nRets int, args ...any) ([
 
 // GetReplicas returns the desired replicas of the object as well as the requirements of each replica by lua script.
 func (vm *VM) GetReplicas(obj *unstructured.Unstructured, script string) (replica int32, requires *workv1alpha2.ReplicaRequirements, err error) {
-	results, err := vm.RunScript(script, "GetReplicas", 2, obj)
+	key := ScriptCacheKey{GVK: obj.GroupVersionKind(), Operation: configv1alpha1.InterpreterOperationInterpretReplica}
+	results, err := vm.RunScript(key, script, "GetReplicas", 2, obj)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -187,7 +204,8 @@ func (vm *VM) GetReplicas(obj *unstructured.Unstructured, script string) (replic
 
 // GetComponents returns the desired components of the object by executing a Lua script.
 func (vm *VM) GetComponents(obj *unstructured.Unstructured, script string) ([]workv1alpha2.Component, error) {
-	results, err := vm.RunScript(script, "GetComponents", 1, obj)
+	key := ScriptCacheKey{GVK: obj.GroupVersionKind(), Operation: configv1alpha1.InterpreterOperationInterpretComponent}
+	results, err := vm.RunScript(key, script, "GetComponents", 1, obj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run 'GetComponents' script: %w", err)
 	}
@@ -214,7 +232,8 @@ func (vm *VM) GetComponents(obj *unstructured.Unstructured, script string) ([]wo
 
 // ReviseReplica revises the replica of the given object by lua.
 func (vm *VM) ReviseReplica(object *unstructured.Unstructured, replica int64, script string) (*unstructured.Unstructured, error) {
-	results, err := vm.RunScript(script, "ReviseReplica", 1, object, replica)
+	key := ScriptCacheKey{GVK: object.GroupVersionKind(), Operation: configv1alpha1.InterpreterOperationReviseReplica}
+	results, err := vm.RunScript(key, script, "ReviseReplica", 1, object, replica)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +306,8 @@ func (vm *VM) setLib(l *lua.LState) error {
 
 // Retain returns the objects that based on the "desired" object but with values retained from the "observed" object by lua.
 func (vm *VM) Retain(desired *unstructured.Unstructured, observed *unstructured.Unstructured, script string) (retained *unstructured.Unstructured, err error) {
-	results, err := vm.RunScript(script, "Retain", 1, desired, observed)
+	key := ScriptCacheKey{GVK: desired.GroupVersionKind(), Operation: configv1alpha1.InterpreterOperationRetain}
+	results, err := vm.RunScript(key, script, "Retain", 1, desired, observed)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +326,8 @@ func (vm *VM) Retain(desired *unstructured.Unstructured, observed *unstructured.
 
 // AggregateStatus returns the objects that based on the 'object' but with status aggregated by lua.
 func (vm *VM) AggregateStatus(object *unstructured.Unstructured, items []workv1alpha2.AggregatedStatusItem, script string) (*unstructured.Unstructured, error) {
-	results, err := vm.RunScript(script, "AggregateStatus", 1, object, items)
+	key := ScriptCacheKey{GVK: object.GroupVersionKind(), Operation: configv1alpha1.InterpreterOperationAggregateStatus}
+	results, err := vm.RunScript(key, script, "AggregateStatus", 1, object, items)
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +346,8 @@ func (vm *VM) AggregateStatus(object *unstructured.Unstructured, items []workv1a
 
 // InterpretHealth returns the health state of the object by lua.
 func (vm *VM) InterpretHealth(object *unstructured.Unstructured, script string) (bool, error) {
-	results, err := vm.RunScript(script, "InterpretHealth", 1, object)
+	key := ScriptCacheKey{GVK: object.GroupVersionKind(), Operation: configv1alpha1.InterpreterOperationInterpretHealth}
+	results, err := vm.RunScript(key, script, "InterpretHealth", 1, object)
 	if err != nil {
 		return false, err
 	}
@@ -340,7 +362,8 @@ func (vm *VM) InterpretHealth(object *unstructured.Unstructured, script string) 
 
 // ReflectStatus returns the status of the object by lua.
 func (vm *VM) ReflectStatus(object *unstructured.Unstructured, script string) (status *runtime.RawExtension, err error) {
-	results, err := vm.RunScript(script, "ReflectStatus", 1, object)
+	key := ScriptCacheKey{GVK: object.GroupVersionKind(), Operation: configv1alpha1.InterpreterOperationInterpretStatus}
+	results, err := vm.RunScript(key, script, "ReflectStatus", 1, object)
 	if err != nil {
 		return nil, err
 	}
@@ -356,8 +379,13 @@ func (vm *VM) ReflectStatus(object *unstructured.Unstructured, script string) (s
 }
 
 // GetDependencies returns the dependent resources of the given object by lua.
-func (vm *VM) GetDependencies(object *unstructured.Unstructured, script string) (dependencies []configv1alpha1.DependentObjectReference, err error) {
-	results, err := vm.RunScript(script, "GetDependencies", 1, object)
+func (vm *VM) GetDependencies(object *unstructured.Unstructured, script string, dependencyIndex int) (dependencies []configv1alpha1.DependentObjectReference, err error) {
+	key := ScriptCacheKey{
+		GVK:             object.GroupVersionKind(),
+		Operation:       configv1alpha1.InterpreterOperationInterpretDependency,
+		DependencyIndex: dependencyIndex,
+	}
+	results, err := vm.RunScript(key, script, "GetDependencies", 1, object)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resourceinterpreter/customized/declarative/luavm/lua_test.go
+++ b/pkg/resourceinterpreter/customized/declarative/luavm/lua_test.go
@@ -206,7 +206,7 @@ func TestCompileScriptCaching(t *testing.T) {
 	}
 
 	count := 0
-	vm.funcCache.Range(func(key, value any) bool {
+	vm.funcCache.Range(func(_, _ any) bool {
 		count++
 		return true
 	})
@@ -250,7 +250,7 @@ func TestRunScriptCaching(t *testing.T) {
 	}
 
 	count := 0
-	vm.funcCache.Range(func(key, value any) bool {
+	vm.funcCache.Range(func(_, _ any) bool {
 		count++
 		return true
 	})

--- a/pkg/resourceinterpreter/customized/declarative/luavm/lua_test.go
+++ b/pkg/resourceinterpreter/customized/declarative/luavm/lua_test.go
@@ -187,16 +187,16 @@ end`,
 	}
 }
 
-func TestCompileScriptCaching(t *testing.T) {
+func TestLoadOrCompileScriptCaching(t *testing.T) {
 	vm := New(false, 1)
 	script := `function TestFunc(obj) return 42 end`
 
-	proto1, err := vm.compileScript(script)
+	proto1, err := vm.loadOrCompileScript(script)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	proto2, err := vm.compileScript(script)
+	proto2, err := vm.loadOrCompileScript(script)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/resourceinterpreter/customized/declarative/luavm/lua_test.go
+++ b/pkg/resourceinterpreter/customized/declarative/luavm/lua_test.go
@@ -190,13 +190,17 @@ end`,
 func TestLoadOrCompileScriptCaching(t *testing.T) {
 	vm := New(false, 1)
 	script := `function TestFunc(obj) return 42 end`
+	key := ScriptCacheKey{
+		GVK:       schema.GroupVersionKind{Group: "test", Version: "v1", Kind: "Test"},
+		Operation: configv1alpha1.InterpreterOperationInterpretHealth,
+	}
 
-	proto1, err := vm.loadOrCompileScript(script)
+	proto1, err := vm.loadOrCompileScript(key, script)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	proto2, err := vm.loadOrCompileScript(script)
+	proto2, err := vm.loadOrCompileScript(key, script)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,11 +219,60 @@ func TestLoadOrCompileScriptCaching(t *testing.T) {
 	}
 }
 
+func TestLoadOrCompileScriptRecompileOnChange(t *testing.T) {
+	vm := New(false, 1)
+	key := ScriptCacheKey{
+		GVK:       schema.GroupVersionKind{Group: "test", Version: "v1", Kind: "Test"},
+		Operation: configv1alpha1.InterpreterOperationInterpretHealth,
+	}
+	scriptV1 := `function TestFunc(obj) return 42 end`
+	scriptV2 := `function TestFunc(obj) return 43 end`
+
+	proto1, err := vm.loadOrCompileScript(key, scriptV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proto2, err := vm.loadOrCompileScript(key, scriptV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if proto1 == proto2 {
+		t.Fatalf("expected a new proto after script change")
+	}
+
+	entry, ok := vm.funcCache.Load(key)
+	if !ok {
+		t.Fatal("expected cache entry to exist")
+	}
+	cached := entry.(*scriptCacheEntry)
+	if cached.script != scriptV2 {
+		t.Fatalf("expected cached script to be updated, got %q", cached.script)
+	}
+	if cached.proto != proto2 {
+		t.Fatalf("expected cached proto to match latest compile")
+	}
+
+	count := 0
+	vm.funcCache.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	if count != 1 {
+		t.Fatalf("expected 1 entry in funcCache after script update, got %d", count)
+	}
+}
+
 func TestRunScriptCaching(t *testing.T) {
 	vm := New(false, 1)
 	script := `function TestFunc() return 42 end`
+	key := ScriptCacheKey{
+		GVK:       schema.GroupVersionKind{Group: "test", Version: "v1", Kind: "Test"},
+		Operation: configv1alpha1.InterpreterOperationInterpretHealth,
+	}
 
-	results1, err := vm.RunScript(script, "TestFunc", 1)
+	results1, err := vm.RunScript(key, script, "TestFunc", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,7 +287,7 @@ func TestRunScriptCaching(t *testing.T) {
 		t.Fatalf("expected 42, got %v", value1)
 	}
 
-	results2, err := vm.RunScript(script, "TestFunc", 1)
+	results2, err := vm.RunScript(key, script, "TestFunc", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -901,7 +954,7 @@ func TestGetDeployPodDependencies(t *testing.T) {
 	vm := New(false, 1)
 
 	for _, tt := range tests {
-		res, err := vm.GetDependencies(tt.curObj, tt.luaScript)
+		res, err := vm.GetDependencies(tt.curObj, tt.luaScript, 0)
 		if err != nil {
 			t.Errorf("GetDependencies err %v", err)
 		}

--- a/pkg/resourceinterpreter/customized/declarative/luavm/lua_test.go
+++ b/pkg/resourceinterpreter/customized/declarative/luavm/lua_test.go
@@ -187,6 +187,78 @@ end`,
 	}
 }
 
+func TestCompileScriptCaching(t *testing.T) {
+	vm := New(false, 1)
+	script := `function TestFunc(obj) return 42 end`
+
+	proto1, err := vm.compileScript(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proto2, err := vm.compileScript(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if proto1 != proto2 {
+		t.Fatalf("expected cached proto pointer to be reused")
+	}
+
+	count := 0
+	vm.funcCache.Range(func(key, value any) bool {
+		count++
+		return true
+	})
+	if count != 1 {
+		t.Fatalf("expected 1 entry in funcCache, got %d", count)
+	}
+}
+
+func TestRunScriptCaching(t *testing.T) {
+	vm := New(false, 1)
+	script := `function TestFunc() return 42 end`
+
+	results1, err := vm.RunScript(script, "TestFunc", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results1) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results1))
+	}
+	value1, ok := results1[0].(lua.LNumber)
+	if !ok {
+		t.Fatalf("expected lua.LNumber, got %T", results1[0])
+	}
+	if value1 != 42 {
+		t.Fatalf("expected 42, got %v", value1)
+	}
+
+	results2, err := vm.RunScript(script, "TestFunc", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results2) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results2))
+	}
+	value2, ok := results2[0].(lua.LNumber)
+	if !ok {
+		t.Fatalf("expected lua.LNumber, got %T", results2[0])
+	}
+	if value2 != 42 {
+		t.Fatalf("expected 42, got %v", value2)
+	}
+
+	count := 0
+	vm.funcCache.Range(func(key, value any) bool {
+		count++
+		return true
+	})
+	if count != 1 {
+		t.Fatalf("expected 1 entry in funcCache after repeated RunScript calls, got %d", count)
+	}
+}
+
 // MockMultiPodTemplateWorkload simulates a CRD with multiple pod templates,
 // mirroring the structure of a real-world Kubernetes object.
 type MockMultiPodTemplateWorkload struct {

--- a/pkg/resourceinterpreter/default/thirdparty/thirdparty.go
+++ b/pkg/resourceinterpreter/default/thirdparty/thirdparty.go
@@ -179,9 +179,9 @@ func (p *ConfigurableInterpreter) GetDependencies(object *unstructured.Unstructu
 	klog.V(4).Infof("Running operation %s for object: %v %s/%s with thirdparty configurable interpreter.",
 		configv1alpha1.InterpreterOperationInterpretDependency, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	refs := sets.New[configv1alpha1.DependentObjectReference]()
-	for _, luaScript := range scripts {
+	for i, luaScript := range scripts {
 		var references []configv1alpha1.DependentObjectReference
-		references, err = p.luaVM.GetDependencies(object, luaScript)
+		references, err = p.luaVM.GetDependencies(object, luaScript, i)
 		if err != nil {
 			klog.Errorf("Failed to get DependentObjectReferences from object: %v %s/%s, error: %v",
 				object.GroupVersionKind(), object.GetNamespace(), object.GetName(), err)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Cache compiled Lua `FunctionProto` in the VM to avoid redundant parse+compile on every `RunScript` call.

`RunScript` is called on every status event through `ReflectStatus`, `InterpretHealth`, `AggregateStatus`, etc. In large fleets this causes continuous unnecessary allocation and GC pressure. Since scripts are immutable, recompiling every time is pure waste.

Fixes #
This fix caches compiled protos using `sync.Map` keyed by script content and reuses via `NewFunctionFromProto` + `PCall`. Behavior remains identical.

**Which issue(s) this PR fixes**:

Fixes #7597
Part of #7596

**Does this PR introduce a user-facing change?**:
```release-note
karmada-controller-manager`/`karmada-agent`: Optimized Lua script execution in the resource interpreter by caching compiled FunctionProto, improving performance for customized resource interpretation.
```
