### PR TITLE
Fix fatal exit when Cluster API REST config creation fails

### DIFF
--- a/pkg/clusterdiscovery/clusterapi/clusterapi.go
+++ b/pkg/clusterdiscovery/clusterapi/clusterapi.go
@@ -207,7 +207,8 @@ func (d *ClusterDetector) joinClusterAPICluster(clusterWideKey keys.ClusterWideK
 
 	clusterRestConfig, err := apiclient.RestConfig("", kubeconfigPath)
 	if err != nil {
-		klog.Fatalf("Failed to get cluster-api management cluster rest config. kubeconfig: %s, err: %v", kubeconfigPath, err)
+		klog.Errorf("Failed to get cluster-api management cluster rest config. kubeconfig: %s, err: %v", kubeconfigPath, err)
+		return err
 	}
 	opts := join.CommandJoinOption{
 		DryRun:           false,


### PR DESCRIPTION
**What this PR does / why we need it**:

The `joinClusterAPICluster` function currently invokes `klog.Fatalf` when `apiclient.RestConfig` fails to create a REST configuration for a Cluster API cluster.

Using `klog.Fatalf` causes the entire controller-manager process to terminate via `os.Exit(255)`, making failures in REST configuration creation non-recoverable. This behavior is inconsistent with the surrounding code path, which propagates errors to callers for handling and retry.

This PR replaces the fatal log with an error log and returns the error to the caller. As a result, failures are propagated through the existing error-handling flow instead of terminating the controller-manager process. This improves resiliency and allows transient failures affecting a single cluster to be handled without impacting the entire component.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

* Verified that the fatal log call is still present in `upstream/master`.

* Validated the change by running:

  ```bash
  go test ./pkg/clusterdiscovery/clusterapi/...
  ```

* The affected package currently does not contain unit tests (`[no test files]`).

* The change is intentionally minimal and limited to error handling behavior.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
