### PR TITLE
test: add unit tests for untested functions in pkg/util/helper

### DIFF
--- a/pkg/util/helper/binding_test.go
+++ b/pkg/util/helper/binding_test.go
@@ -1828,3 +1828,349 @@ func TestObtainClustersWithPurgeModeDirectly(t *testing.T) {
 		})
 	}
 }
+
+func TestGetWeightSum(t *testing.T) {
+	tests := []struct {
+		name     string
+		list     ClusterWeightInfoList
+		expected int64
+	}{
+		{
+			name:     "empty list",
+			list:     ClusterWeightInfoList{},
+			expected: 0,
+		},
+		{
+			name: "single cluster",
+			list: ClusterWeightInfoList{
+				{ClusterName: "cluster1", Weight: 5},
+			},
+			expected: 5,
+		},
+		{
+			name: "multiple clusters",
+			list: ClusterWeightInfoList{
+				{ClusterName: "cluster1", Weight: 1},
+				{ClusterName: "cluster2", Weight: 2},
+				{ClusterName: "cluster3", Weight: 3},
+			},
+			expected: 6,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.list.GetWeightSum()
+			if got != tt.expected {
+				t.Errorf("GetWeightSum() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewDispenser(t *testing.T) {
+	tests := []struct {
+		name        string
+		numReplicas int32
+		init        []workv1alpha2.TargetCluster
+		uuid        types.UID
+	}{
+		{
+			name:        "nil init",
+			numReplicas: 5,
+			init:        nil,
+			uuid:        "",
+		},
+		{
+			name:        "with initial assignment",
+			numReplicas: 10,
+			init: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 3},
+				{Name: "cluster2", Replicas: 7},
+			},
+			uuid: "4858ca61-3ff8-4095-8267-f3d059d8074c",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDispenser(tt.numReplicas, tt.init, tt.uuid)
+			if d == nil {
+				t.Fatal("NewDispenser() returned nil")
+			}
+			if d.NumReplicas != tt.numReplicas {
+				t.Errorf("NumReplicas = %v, want %v", d.NumReplicas, tt.numReplicas)
+			}
+			if len(d.Result) != len(tt.init) {
+				t.Errorf("Result length = %v, want %v", len(d.Result), len(tt.init))
+			}
+			if len(tt.init) > 0 {
+				if !reflect.DeepEqual(d.Result, tt.init) {
+					t.Errorf("Result = %v, want %v", d.Result, tt.init)
+				}
+				d.Result[0].Replicas = 999
+				if tt.init[0].Replicas == 999 {
+					t.Error("NewDispenser() should make a copy of init, not reference it")
+				}
+			}
+		})
+	}
+}
+
+func TestDone(t *testing.T) {
+	tests := []struct {
+		name        string
+		numReplicas int32
+		result      []workv1alpha2.TargetCluster
+		expected    bool
+	}{
+		{
+			name:        "done: zero replicas with non-empty result",
+			numReplicas: 0,
+			result:      []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: 3}},
+			expected:    true,
+		},
+		{
+			name:        "not done: non-zero replicas",
+			numReplicas: 5,
+			result:      []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: 3}},
+			expected:    false,
+		},
+		{
+			name:        "not done: zero replicas but empty result",
+			numReplicas: 0,
+			result:      []workv1alpha2.TargetCluster{},
+			expected:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Dispenser{
+				NumReplicas: tt.numReplicas,
+				Result:      tt.result,
+			}
+			if got := d.Done(); got != tt.expected {
+				t.Errorf("Done() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetStaticWeightInfoListByTargetClusters(t *testing.T) {
+	tests := []struct {
+		name      string
+		tcs       []workv1alpha2.TargetCluster
+		scheduled []workv1alpha2.TargetCluster
+		expected  ClusterWeightInfoList
+	}{
+		{
+			name:      "empty target clusters",
+			tcs:       []workv1alpha2.TargetCluster{},
+			scheduled: []workv1alpha2.TargetCluster{},
+			expected:  ClusterWeightInfoList{},
+		},
+		{
+			name: "no scheduled clusters",
+			tcs: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 2},
+				{Name: "cluster2", Replicas: 3},
+			},
+			scheduled: []workv1alpha2.TargetCluster{},
+			expected: ClusterWeightInfoList{
+				{ClusterName: "cluster1", Weight: 2, LastReplicas: 0},
+				{ClusterName: "cluster2", Weight: 3, LastReplicas: 0},
+			},
+		},
+		{
+			name: "with matching scheduled clusters",
+			tcs: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 2},
+				{Name: "cluster2", Replicas: 3},
+			},
+			scheduled: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 5},
+			},
+			expected: ClusterWeightInfoList{
+				{ClusterName: "cluster1", Weight: 2, LastReplicas: 5},
+				{ClusterName: "cluster2", Weight: 3, LastReplicas: 0},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetStaticWeightInfoListByTargetClusters(tt.tcs, tt.scheduled)
+			if len(got) != len(tt.expected) {
+				t.Errorf("length = %v, want %v", len(got), len(tt.expected))
+				return
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Errorf("index %d: got %+v, want %+v", i, got[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIsBindingScheduled(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   *workv1alpha2.ResourceBindingStatus
+		expected bool
+	}{
+		{
+			name: "scheduled true",
+			status: &workv1alpha2.ResourceBindingStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   workv1alpha2.Scheduled,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "scheduled false",
+			status: &workv1alpha2.ResourceBindingStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   workv1alpha2.Scheduled,
+						Status: metav1.ConditionFalse,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "no conditions",
+			status:   &workv1alpha2.ResourceBindingStatus{},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsBindingScheduled(tt.status)
+			if got != tt.expected {
+				t.Errorf("IsBindingScheduled() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConstructObjectReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		rs       policyv1alpha1.ResourceSelector
+		expected workv1alpha2.ObjectReference
+	}{
+		{
+			name: "full resource selector",
+			rs: policyv1alpha1.ResourceSelector{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Namespace:  "default",
+				Name:       "my-app",
+			},
+			expected: workv1alpha2.ObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Namespace:  "default",
+				Name:       "my-app",
+			},
+		},
+		{
+			name: "cluster scoped resource",
+			rs: policyv1alpha1.ResourceSelector{
+				APIVersion: "v1",
+				Kind:       "Node",
+				Name:       "node1",
+			},
+			expected: workv1alpha2.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Node",
+				Name:       "node1",
+			},
+		},
+		{
+			name:     "empty resource selector",
+			rs:       policyv1alpha1.ResourceSelector{},
+			expected: workv1alpha2.ObjectReference{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConstructObjectReference(tt.rs)
+			if got != tt.expected {
+				t.Errorf("ConstructObjectReference() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateNodeClaimByPodSpec(t *testing.T) {
+	tests := []struct {
+		name     string
+		podSpec  *corev1.PodSpec
+		expected *workv1alpha2.NodeClaim
+	}{
+		{
+			name:     "empty pod spec returns nil",
+			podSpec:  &corev1.PodSpec{},
+			expected: nil,
+		},
+		{
+			name: "with node selector",
+			podSpec: &corev1.PodSpec{
+				NodeSelector: map[string]string{"disktype": "ssd"},
+			},
+			expected: &workv1alpha2.NodeClaim{
+				NodeSelector: map[string]string{"disktype": "ssd"},
+			},
+		},
+		{
+			name: "with tolerations",
+			podSpec: &corev1.PodSpec{
+				Tolerations: []corev1.Toleration{
+					{Key: "key1", Operator: corev1.TolerationOpExists},
+				},
+			},
+			expected: &workv1alpha2.NodeClaim{
+				Tolerations: []corev1.Toleration{
+					{Key: "key1", Operator: corev1.TolerationOpExists},
+				},
+			},
+		},
+		{
+			name: "with node affinity",
+			podSpec: &corev1.PodSpec{
+				Affinity: &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{MatchFields: []corev1.NodeSelectorRequirement{
+									{Key: "foo", Operator: corev1.NodeSelectorOpExists},
+								}},
+							},
+						},
+					},
+				},
+			},
+			expected: &workv1alpha2.NodeClaim{
+				HardNodeAffinity: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{MatchFields: []corev1.NodeSelectorRequirement{
+							{Key: "foo", Operator: corev1.NodeSelectorOpExists},
+						}},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateNodeClaimByPodSpec(tt.podSpec)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("GenerateNodeClaimByPodSpec() = %+v, want %+v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Add unit tests for functions in `pkg/util/helper/binding.go` 
that lacked test coverage:

- `GetWeightSum` - tests empty list, single cluster, multiple clusters
- `NewDispenser` - tests nil init, with initial assignment, verifies deep copy
- `Done` - tests zero replicas with result, non-zero replicas, empty result
- `GetStaticWeightInfoListByTargetClusters` - tests empty clusters, no scheduled, with matching scheduled
- `IsBindingScheduled` - tests scheduled true, scheduled false, no conditions
- `ConstructObjectReference` - tests full selector, cluster scoped, empty selector
- `GenerateNodeClaimByPodSpec` - tests empty spec, node selector, tolerations, node affinity

**Which issue(s) this PR fixes**:
Fixes #7605 

**Special notes for your reviewer**:
All existing tests pass with the new additions:
ok github.com/karmada-io/karmada/pkg/util/helper 1.336s

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```