### PR TITLE
feat: add 6 prometheus metrics

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -110,6 +110,8 @@ type ClusterStatusController struct {
 	ClusterFailureThreshold metav1.Duration
 	// clusterConditionCache stores the condition status of each cluster.
 	clusterConditionCache clusterConditionStore
+	// prevProbeResults caches the previous raw probe result per cluster for transition detection.
+	prevProbeResults sync.Map
 
 	ClusterCacheSyncTimeout metav1.Duration
 	RateLimiterOptions      ratelimiterflag.Options
@@ -134,6 +136,7 @@ func (c *ClusterStatusController) Reconcile(ctx context.Context, req controllerr
 			c.GenericInformerManager.Stop(req.NamespacedName.Name)
 			c.TypedInformerManager.Stop(req.NamespacedName.Name)
 			c.clusterConditionCache.delete(req.NamespacedName.Name)
+			c.prevProbeResults.Delete(req.NamespacedName.Name)
 			metrics.CleanupMetricsForCluster(req.NamespacedName.Name)
 
 			// stop lease controller after the cluster is gone.
@@ -197,7 +200,6 @@ func (c *ClusterStatusController) syncClusterStatus(ctx context.Context, cluster
 		if readyCondition != nil {
 			metrics.RecordClusterReadySince(cluster.Name, prevReadyStatus, readyCondition.Status, start)
 			metrics.RecordClusterConditionLastTransition(cluster.Name, prevReadyStatus, readyCondition.Status, start)
-			metrics.RecordClusterHealthTransition(cluster.Name, prevReadyStatus, readyCondition.Status)
 		}
 	}()
 
@@ -216,7 +218,15 @@ func (c *ClusterStatusController) syncClusterStatus(ctx context.Context, cluster
 	probeStart := time.Now()
 	online, healthy = getClusterHealthStatus(clusterClient)
 	metrics.RecordClusterHealthProbeDuration(cluster.Name, probeStart) // time the health probe duration and record the metric
+
+	// Record raw probe state transitions (before threshold adjustment)
 	observedReadyCondition := generateReadyCondition(online, healthy)
+	if prev, ok := c.prevProbeResults.Load(cluster.Name); ok {
+		metrics.RecordClusterHealthTransition(cluster.Name, prev.(metav1.ConditionStatus), observedReadyCondition.Status)
+	}
+	c.prevProbeResults.Store(cluster.Name, observedReadyCondition.Status)
+
+	// generate ready condition with threshold adjustment based on the probe result and previous condition status.
 	readyCondition = c.clusterConditionCache.thresholdAdjustedReadyCondition(cluster, &observedReadyCondition)
 
 	// cluster is offline after retry timeout, update cluster status immediately and return.

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -197,6 +197,7 @@ func (c *ClusterStatusController) syncClusterStatus(ctx context.Context, cluster
 		if readyCondition != nil {
 			metrics.RecordClusterReadySince(cluster.Name, prevReadyStatus, readyCondition.Status, start)
 			metrics.RecordClusterConditionLastTransition(cluster.Name, prevReadyStatus, readyCondition.Status, start)
+			metrics.RecordClusterHealthTransition(cluster.Name, prevReadyStatus, readyCondition.Status)
 		}
 	}()
 

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -181,10 +181,21 @@ func (c *ClusterStatusController) SetupWithManager(mgr controllerruntime.Manager
 func (c *ClusterStatusController) syncClusterStatus(ctx context.Context, cluster *clusterv1alpha1.Cluster) error {
 	start := time.Now()
 	var online, healthy bool
+	var readyCondition *metav1.Condition
+
+	// record the previous ready condition status
+	prevReadyStatus := metav1.ConditionFalse
+	if prev := meta.FindStatusCondition(cluster.Status.Conditions, clusterv1alpha1.ClusterConditionReady); prev != nil {
+		prevReadyStatus = prev.Status
+	}
+
 	defer func() {
 		metrics.RecordClusterStatus(cluster)
 		metrics.RecordClusterSyncStatusDuration(cluster, start)
 		metrics.RecordClusterHealthProbeSuccess(cluster.Name, online, healthy)
+		if readyCondition != nil {
+			metrics.RecordClusterReadySince(cluster.Name, prevReadyStatus, readyCondition.Status, start)
+		}
 	}()
 
 	currentClusterStatus := *cluster.Status.DeepCopy()
@@ -195,13 +206,13 @@ func (c *ClusterStatusController) syncClusterStatus(ctx context.Context, cluster
 		klog.ErrorS(err, "Failed to create a ClusterClient for the given member cluster", "cluster", cluster.Name)
 		observedReadyCondition := util.NewCondition(clusterv1alpha1.ClusterConditionReady, statusCollectionFailed,
 			fmt.Sprintf("failed to create a ClusterClient: %v", err), metav1.ConditionFalse)
-		readyCondition := c.clusterConditionCache.thresholdAdjustedReadyCondition(cluster, &observedReadyCondition)
+		readyCondition = c.clusterConditionCache.thresholdAdjustedReadyCondition(cluster, &observedReadyCondition)
 		return updateStatusCondition(ctx, c.Client, cluster, *readyCondition)
 	}
 
 	online, healthy = getClusterHealthStatus(clusterClient)
 	observedReadyCondition := generateReadyCondition(online, healthy)
-	readyCondition := c.clusterConditionCache.thresholdAdjustedReadyCondition(cluster, &observedReadyCondition)
+	readyCondition = c.clusterConditionCache.thresholdAdjustedReadyCondition(cluster, &observedReadyCondition)
 
 	// cluster is offline after retry timeout, update cluster status immediately and return.
 	if !online && readyCondition.Status != metav1.ConditionTrue {

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -195,6 +195,7 @@ func (c *ClusterStatusController) syncClusterStatus(ctx context.Context, cluster
 		metrics.RecordClusterHealthProbeSuccess(cluster.Name, online, healthy)
 		if readyCondition != nil {
 			metrics.RecordClusterReadySince(cluster.Name, prevReadyStatus, readyCondition.Status, start)
+			metrics.RecordClusterConditionLastTransition(cluster.Name, prevReadyStatus, readyCondition.Status, start)
 		}
 	}()
 

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -193,6 +193,7 @@ func (c *ClusterStatusController) syncClusterStatus(ctx context.Context, cluster
 		metrics.RecordClusterStatus(cluster)
 		metrics.RecordClusterSyncStatusDuration(cluster, start)
 		metrics.RecordClusterHealthProbeSuccess(cluster.Name, online, healthy)
+		metrics.RecordClusterHealthProbeTotal(cluster.Name, online, healthy)
 		if readyCondition != nil {
 			metrics.RecordClusterReadySince(cluster.Name, prevReadyStatus, readyCondition.Status, start)
 			metrics.RecordClusterConditionLastTransition(cluster.Name, prevReadyStatus, readyCondition.Status, start)

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -198,6 +198,7 @@ func (c *ClusterStatusController) syncClusterStatus(ctx context.Context, cluster
 	}
 
 	online, healthy := getClusterHealthStatus(clusterClient)
+	metrics.RecordClusterHealthProbeSuccess(cluster.Name, online, healthy)
 	observedReadyCondition := generateReadyCondition(online, healthy)
 	readyCondition := c.clusterConditionCache.thresholdAdjustedReadyCondition(cluster, &observedReadyCondition)
 

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -211,7 +211,9 @@ func (c *ClusterStatusController) syncClusterStatus(ctx context.Context, cluster
 		return updateStatusCondition(ctx, c.Client, cluster, *readyCondition)
 	}
 
+	probeStart := time.Now()
 	online, healthy = getClusterHealthStatus(clusterClient)
+	metrics.RecordClusterHealthProbeDuration(cluster.Name, probeStart) // time the health probe duration and record the metric
 	observedReadyCondition := generateReadyCondition(online, healthy)
 	readyCondition = c.clusterConditionCache.thresholdAdjustedReadyCondition(cluster, &observedReadyCondition)
 

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -180,9 +180,11 @@ func (c *ClusterStatusController) SetupWithManager(mgr controllerruntime.Manager
 
 func (c *ClusterStatusController) syncClusterStatus(ctx context.Context, cluster *clusterv1alpha1.Cluster) error {
 	start := time.Now()
+	var online, healthy bool
 	defer func() {
 		metrics.RecordClusterStatus(cluster)
 		metrics.RecordClusterSyncStatusDuration(cluster, start)
+		metrics.RecordClusterHealthProbeSuccess(cluster.Name, online, healthy)
 	}()
 
 	currentClusterStatus := *cluster.Status.DeepCopy()
@@ -197,8 +199,7 @@ func (c *ClusterStatusController) syncClusterStatus(ctx context.Context, cluster
 		return updateStatusCondition(ctx, c.Client, cluster, *readyCondition)
 	}
 
-	online, healthy := getClusterHealthStatus(clusterClient)
-	metrics.RecordClusterHealthProbeSuccess(cluster.Name, online, healthy)
+	online, healthy = getClusterHealthStatus(clusterClient)
 	observedReadyCondition := generateReadyCondition(online, healthy)
 	readyCondition := c.clusterConditionCache.thresholdAdjustedReadyCondition(cluster, &observedReadyCondition)
 

--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -43,6 +43,7 @@ const (
 	clusterHealthProbeTotalName          = "cluster_health_probe_total"
 	clusterReadySinceName                = "cluster_ready_since_timestamp_seconds"
 	clusterConditionLastTransitionName   = "cluster_condition_last_transition_timestamp_seconds"
+	clusterHealthTransitionsTotalName    = "cluster_health_transitions_total"
 	evictionQueueDepthMetricsName        = "eviction_queue_depth"
 	evictionKindTotalMetricsName         = "eviction_kind_total"
 	evictionProcessingLatencyMetricsName = "eviction_processing_latency_seconds"
@@ -51,12 +52,10 @@ const (
 	// Canonical label for Karmada member clusters.
 	memberClusterLabel = "member_cluster"
 
-	// ProbeResultSuccess indicates the cluster is online and healthy.
-	ProbeResultSuccess = "success"
-	// ProbeResultErrorUnreachable indicates the cluster is not reachable.
-	ProbeResultErrorUnreachable = "error_unreachable"
-	// ProbeResultErrorUnhealthy indicates the cluster is reachable but not healthy.
-	ProbeResultErrorUnhealthy = "error_unhealthy"
+	// HealthStateSuccess indicates the cluster is online and healthy.
+	HealthStateSuccess = "success"
+	// HealthStateError indicates the cluster is not healthy or not reachable.
+	HealthStateError = "error"
 )
 
 var (
@@ -154,6 +153,12 @@ var (
 		Help: "Unix timestamp of the last condition state transition for the member cluster.",
 	}, []string{memberClusterLabel})
 
+	// clusterHealthTransitionsTotal counts health state transitions.
+	clusterHealthTransitionsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: clusterHealthTransitionsTotalName,
+		Help: "Total number of health state transitions for the member cluster.",
+	}, []string{memberClusterLabel, "from_state", "to_state"})
+
 	evictionQueueMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: evictionQueueDepthMetricsName,
 		Help: "Current depth of the eviction queue",
@@ -219,12 +224,9 @@ func RecordClusterHealthProbeSuccess(clusterName string, online, healthy bool) {
 // ProbeResultLabel returns the result label for a health probe.
 func ProbeResultLabel(online, healthy bool) string {
 	if online && healthy {
-		return ProbeResultSuccess
+		return HealthStateSuccess
 	}
-	if !online {
-		return ProbeResultErrorUnreachable
-	}
-	return ProbeResultErrorUnhealthy
+	return HealthStateError
 }
 
 // RecordClusterHealthProbeTotal increments the probe counter with the appropriate result label.
@@ -260,6 +262,27 @@ func RecordClusterConditionLastTransition(clusterName string, prevStatus, curren
 	clusterConditionLastTransition.WithLabelValues(clusterName).Set(float64(timestamp.Unix()))
 }
 
+// conditionToTransitionState maps a threshold-adjusted condition status to a transition state label.
+func conditionToTransitionState(status metav1.ConditionStatus) string {
+	if status == metav1.ConditionTrue {
+		return HealthStateSuccess
+	}
+	return HealthStateError
+}
+
+// RecordClusterHealthTransition increments the transition counter when the threshold-adjusted state changes.
+// No-op when the state hasn't changed.
+func RecordClusterHealthTransition(clusterName string, prevStatus, currentStatus metav1.ConditionStatus) {
+	if prevStatus == currentStatus {
+		return
+	}
+	clusterHealthTransitionsTotal.WithLabelValues(
+		clusterName,
+		conditionToTransitionState(prevStatus),
+		conditionToTransitionState(currentStatus),
+	).Inc()
+}
+
 // RecordClusterSyncStatusDuration records the duration of the given cluster syncing status
 func RecordClusterSyncStatusDuration(cluster *v1alpha1.Cluster, startTime time.Time) {
 	labels := []string{cluster.Name}
@@ -285,6 +308,7 @@ func CleanupMetricsForCluster(clusterName string) {
 	clusterHealthProbeTotal.DeletePartialMatch(prometheus.Labels{memberClusterLabel: clusterName})
 	clusterReadySince.DeleteLabelValues(labels...)
 	clusterConditionLastTransition.DeleteLabelValues(labels...)
+	clusterHealthTransitionsTotal.DeletePartialMatch(prometheus.Labels{memberClusterLabel: clusterName})
 }
 
 // RecordEvictionQueueMetrics record the depth Of the EvictionQueue
@@ -334,6 +358,7 @@ func ClusterCollectors() []prometheus.Collector {
 		clusterHealthProbeTotal,
 		clusterReadySince,
 		clusterConditionLastTransition,
+		clusterHealthTransitionsTotal,
 		evictionQueueMetrics,
 		evictionKindTotalMetrics,
 		evictionProcessingLatency,

--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -262,14 +262,6 @@ func RecordClusterConditionLastTransition(clusterName string, prevStatus, curren
 	clusterConditionLastTransition.WithLabelValues(clusterName).Set(float64(timestamp.Unix()))
 }
 
-// conditionToTransitionState maps a threshold-adjusted condition status to a transition state label.
-func conditionToTransitionState(status metav1.ConditionStatus) string {
-	if status == metav1.ConditionTrue {
-		return HealthStateSuccess
-	}
-	return HealthStateError
-}
-
 // RecordClusterHealthTransition increments the transition counter when the threshold-adjusted state changes.
 // No-op when the state hasn't changed.
 func RecordClusterHealthTransition(clusterName string, prevStatus, currentStatus metav1.ConditionStatus) {
@@ -278,8 +270,8 @@ func RecordClusterHealthTransition(clusterName string, prevStatus, currentStatus
 	}
 	clusterHealthTransitionsTotal.WithLabelValues(
 		clusterName,
-		conditionToTransitionState(prevStatus),
-		conditionToTransitionState(currentStatus),
+		string(prevStatus),
+		string(currentStatus),
 	).Inc()
 }
 

--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -262,17 +262,13 @@ func RecordClusterConditionLastTransition(clusterName string, prevStatus, curren
 	clusterConditionLastTransition.WithLabelValues(clusterName).Set(float64(timestamp.Unix()))
 }
 
-// RecordClusterHealthTransition increments the transition counter when the threshold-adjusted state changes.
+// RecordClusterHealthTransition increments the transition counter when the raw probe state changes.
 // No-op when the state hasn't changed.
-func RecordClusterHealthTransition(clusterName string, prevStatus, currentStatus metav1.ConditionStatus) {
-	if prevStatus == currentStatus {
+func RecordClusterHealthTransition(clusterName string, fromState, toState metav1.ConditionStatus) {
+	if fromState == toState {
 		return
 	}
-	clusterHealthTransitionsTotal.WithLabelValues(
-		clusterName,
-		string(prevStatus),
-		string(currentStatus),
-	).Inc()
+	clusterHealthTransitionsTotal.WithLabelValues(clusterName, string(fromState), string(toState)).Inc()
 }
 
 // RecordClusterSyncStatusDuration records the duration of the given cluster syncing status

--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -37,6 +37,7 @@ const (
 	clusterCPUAllocatedMetricsName       = "cluster_cpu_allocated_number"
 	clusterPodAllocatedMetricsName       = "cluster_pod_allocated_number"
 	clusterSyncStatusDurationMetricsName = "cluster_sync_status_duration_seconds"
+	clusterHealthProbeSuccessName        = "cluster_health_probe_success"
 	evictionQueueDepthMetricsName        = "eviction_queue_depth"
 	evictionKindTotalMetricsName         = "eviction_kind_total"
 	evictionProcessingLatencyMetricsName = "eviction_processing_latency_seconds"
@@ -107,6 +108,13 @@ var (
 		Help: "Duration in seconds for syncing the status of the cluster once.",
 	}, []string{memberClusterLabel})
 
+	// clusterHealthProbeSuccess reports the raw health probe result before threshold adjustment.
+	clusterHealthProbeSuccess = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: clusterHealthProbeSuccessName,
+		Help: "Result of the last health probe for the member cluster (1 for success, 0 for failure). " +
+			"Reflects the raw probe outcome before threshold adjustment.",
+	}, []string{memberClusterLabel})
+
 	evictionQueueMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: evictionQueueDepthMetricsName,
 		Help: "Current depth of the eviction queue",
@@ -160,6 +168,15 @@ func RecordClusterStatus(cluster *v1alpha1.Cluster) {
 	}
 }
 
+// RecordClusterHealthProbeSuccess records the raw health probe result before threshold adjustment.
+func RecordClusterHealthProbeSuccess(clusterName string, online, healthy bool) {
+	val := float64(0)
+	if online && healthy {
+		val = 1
+	}
+	clusterHealthProbeSuccess.WithLabelValues(clusterName).Set(val)
+}
+
 // RecordClusterSyncStatusDuration records the duration of the given cluster syncing status
 func RecordClusterSyncStatusDuration(cluster *v1alpha1.Cluster, startTime time.Time) {
 	labels := []string{cluster.Name}
@@ -180,6 +197,7 @@ func CleanupMetricsForCluster(clusterName string) {
 	clusterCPUAllocatedGauge.DeleteLabelValues(labels...)
 	clusterPodAllocatedGauge.DeleteLabelValues(labels...)
 	clusterSyncStatusDuration.DeleteLabelValues(labels...)
+	clusterHealthProbeSuccess.DeleteLabelValues(labels...)
 }
 
 // RecordEvictionQueueMetrics record the depth Of the EvictionQueue
@@ -224,6 +242,7 @@ func ClusterCollectors() []prometheus.Collector {
 		clusterCPUAllocatedGauge,
 		clusterPodAllocatedGauge,
 		clusterSyncStatusDuration,
+		clusterHealthProbeSuccess,
 		evictionQueueMetrics,
 		evictionKindTotalMetrics,
 		evictionProcessingLatency,

--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -40,6 +40,7 @@ const (
 	clusterSyncStatusDurationMetricsName = "cluster_sync_status_duration_seconds"
 	clusterHealthProbeSuccessName        = "cluster_health_probe_success"
 	clusterHealthProbeDurationName       = "cluster_health_probe_duration_seconds"
+	clusterHealthProbeTotalName          = "cluster_health_probe_total"
 	clusterReadySinceName                = "cluster_ready_since_timestamp_seconds"
 	clusterConditionLastTransitionName   = "cluster_condition_last_transition_timestamp_seconds"
 	evictionQueueDepthMetricsName        = "eviction_queue_depth"
@@ -49,6 +50,11 @@ const (
 
 	// Canonical label for Karmada member clusters.
 	memberClusterLabel = "member_cluster"
+
+	// Probe result labels for cluster_health_probe_total.
+	ProbeResultSuccess          = "success"
+	ProbeResultErrorUnreachable = "error_unreachable"
+	ProbeResultErrorUnhealthy   = "error_unhealthy"
 )
 
 var (
@@ -126,6 +132,12 @@ var (
 		Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 	}, []string{memberClusterLabel})
 
+	// clusterHealthProbeTotal counts probes by result type.
+	clusterHealthProbeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: clusterHealthProbeTotalName,
+		Help: "Total number of health probes to the member cluster, categorized by result.",
+	}, []string{memberClusterLabel, "result"})
+
 	// clusterReadySince records the unix timestamp when the cluster last became Ready.
 	// Set to 0 when the cluster is not Ready.
 	clusterReadySince = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -202,6 +214,22 @@ func RecordClusterHealthProbeSuccess(clusterName string, online, healthy bool) {
 	clusterHealthProbeSuccess.WithLabelValues(clusterName).Set(val)
 }
 
+// ProbeResultLabel returns the result label for a health probe.
+func ProbeResultLabel(online, healthy bool) string {
+	if online && healthy {
+		return ProbeResultSuccess
+	}
+	if !online {
+		return ProbeResultErrorUnreachable
+	}
+	return ProbeResultErrorUnhealthy
+}
+
+// RecordClusterHealthProbeTotal increments the probe counter with the appropriate result label.
+func RecordClusterHealthProbeTotal(clusterName string, online, healthy bool) {
+	clusterHealthProbeTotal.WithLabelValues(clusterName, ProbeResultLabel(online, healthy)).Inc()
+}
+
 // RecordClusterHealthProbeDuration records the duration of the health probe HTTP call.
 func RecordClusterHealthProbeDuration(clusterName string, startTime time.Time) {
 	clusterHealthProbeDuration.WithLabelValues(clusterName).Observe(utilmetrics.DurationInSeconds(startTime))
@@ -252,6 +280,7 @@ func CleanupMetricsForCluster(clusterName string) {
 	clusterSyncStatusDuration.DeleteLabelValues(labels...)
 	clusterHealthProbeSuccess.DeleteLabelValues(labels...)
 	clusterHealthProbeDuration.DeleteLabelValues(labels...)
+	clusterHealthProbeTotal.DeletePartialMatch(prometheus.Labels{memberClusterLabel: clusterName})
 	clusterReadySince.DeleteLabelValues(labels...)
 	clusterConditionLastTransition.DeleteLabelValues(labels...)
 }
@@ -300,6 +329,7 @@ func ClusterCollectors() []prometheus.Collector {
 		clusterSyncStatusDuration,
 		clusterHealthProbeSuccess,
 		clusterHealthProbeDuration,
+		clusterHealthProbeTotal,
 		clusterReadySince,
 		clusterConditionLastTransition,
 		evictionQueueMetrics,

--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -38,6 +39,7 @@ const (
 	clusterPodAllocatedMetricsName       = "cluster_pod_allocated_number"
 	clusterSyncStatusDurationMetricsName = "cluster_sync_status_duration_seconds"
 	clusterHealthProbeSuccessName        = "cluster_health_probe_success"
+	clusterReadySinceName                = "cluster_ready_since_timestamp_seconds"
 	evictionQueueDepthMetricsName        = "eviction_queue_depth"
 	evictionKindTotalMetricsName         = "eviction_kind_total"
 	evictionProcessingLatencyMetricsName = "eviction_processing_latency_seconds"
@@ -115,6 +117,14 @@ var (
 			"Reflects the raw probe outcome before threshold adjustment.",
 	}, []string{memberClusterLabel})
 
+	// clusterReadySince records the unix timestamp when the cluster last became Ready.
+	// Set to 0 when the cluster is not Ready.
+	clusterReadySince = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: clusterReadySinceName,
+		Help: "Unix timestamp when the member cluster last became Ready. " +
+			"Set to 0 when the cluster is not Ready.",
+	}, []string{memberClusterLabel})
+
 	evictionQueueMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: evictionQueueDepthMetricsName,
 		Help: "Current depth of the eviction queue",
@@ -177,6 +187,20 @@ func RecordClusterHealthProbeSuccess(clusterName string, online, healthy bool) {
 	clusterHealthProbeSuccess.WithLabelValues(clusterName).Set(val)
 }
 
+// RecordClusterReadySince updates the ready-since timestamp based on the threshold-adjusted condition.
+// On transition to Ready, sets the timestamp to the provided time. On transition away from Ready, sets to 0.
+// No-op when the status hasn't changed.
+func RecordClusterReadySince(clusterName string, prevStatus, currentStatus metav1.ConditionStatus, timestamp time.Time) {
+	if prevStatus == currentStatus {
+		return
+	}
+	if currentStatus == metav1.ConditionTrue {
+		clusterReadySince.WithLabelValues(clusterName).Set(float64(timestamp.Unix()))
+	} else {
+		clusterReadySince.WithLabelValues(clusterName).Set(0)
+	}
+}
+
 // RecordClusterSyncStatusDuration records the duration of the given cluster syncing status
 func RecordClusterSyncStatusDuration(cluster *v1alpha1.Cluster, startTime time.Time) {
 	labels := []string{cluster.Name}
@@ -198,6 +222,7 @@ func CleanupMetricsForCluster(clusterName string) {
 	clusterPodAllocatedGauge.DeleteLabelValues(labels...)
 	clusterSyncStatusDuration.DeleteLabelValues(labels...)
 	clusterHealthProbeSuccess.DeleteLabelValues(labels...)
+	clusterReadySince.DeleteLabelValues(labels...)
 }
 
 // RecordEvictionQueueMetrics record the depth Of the EvictionQueue
@@ -243,6 +268,7 @@ func ClusterCollectors() []prometheus.Collector {
 		clusterPodAllocatedGauge,
 		clusterSyncStatusDuration,
 		clusterHealthProbeSuccess,
+		clusterReadySince,
 		evictionQueueMetrics,
 		evictionKindTotalMetrics,
 		evictionProcessingLatency,

--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -51,10 +51,12 @@ const (
 	// Canonical label for Karmada member clusters.
 	memberClusterLabel = "member_cluster"
 
-	// Probe result labels for cluster_health_probe_total.
-	ProbeResultSuccess          = "success"
+	// ProbeResultSuccess indicates the cluster is online and healthy.
+	ProbeResultSuccess = "success"
+	// ProbeResultErrorUnreachable indicates the cluster is not reachable.
 	ProbeResultErrorUnreachable = "error_unreachable"
-	ProbeResultErrorUnhealthy   = "error_unhealthy"
+	// ProbeResultErrorUnhealthy indicates the cluster is reachable but not healthy.
+	ProbeResultErrorUnhealthy = "error_unhealthy"
 )
 
 var (

--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -40,6 +40,7 @@ const (
 	clusterSyncStatusDurationMetricsName = "cluster_sync_status_duration_seconds"
 	clusterHealthProbeSuccessName        = "cluster_health_probe_success"
 	clusterReadySinceName                = "cluster_ready_since_timestamp_seconds"
+	clusterConditionLastTransitionName   = "cluster_condition_last_transition_timestamp_seconds"
 	evictionQueueDepthMetricsName        = "eviction_queue_depth"
 	evictionKindTotalMetricsName         = "eviction_kind_total"
 	evictionProcessingLatencyMetricsName = "eviction_processing_latency_seconds"
@@ -125,6 +126,12 @@ var (
 			"Set to 0 when the cluster is not Ready.",
 	}, []string{memberClusterLabel})
 
+	// clusterConditionLastTransition records the unix timestamp of the last condition state transition.
+	clusterConditionLastTransition = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: clusterConditionLastTransitionName,
+		Help: "Unix timestamp of the last condition state transition for the member cluster.",
+	}, []string{memberClusterLabel})
+
 	evictionQueueMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: evictionQueueDepthMetricsName,
 		Help: "Current depth of the eviction queue",
@@ -201,6 +208,15 @@ func RecordClusterReadySince(clusterName string, prevStatus, currentStatus metav
 	}
 }
 
+// RecordClusterConditionLastTransition records the timestamp of a condition state transition.
+// No-op when the status hasn't changed.
+func RecordClusterConditionLastTransition(clusterName string, prevStatus, currentStatus metav1.ConditionStatus, timestamp time.Time) {
+	if prevStatus == currentStatus {
+		return
+	}
+	clusterConditionLastTransition.WithLabelValues(clusterName).Set(float64(timestamp.Unix()))
+}
+
 // RecordClusterSyncStatusDuration records the duration of the given cluster syncing status
 func RecordClusterSyncStatusDuration(cluster *v1alpha1.Cluster, startTime time.Time) {
 	labels := []string{cluster.Name}
@@ -223,6 +239,7 @@ func CleanupMetricsForCluster(clusterName string) {
 	clusterSyncStatusDuration.DeleteLabelValues(labels...)
 	clusterHealthProbeSuccess.DeleteLabelValues(labels...)
 	clusterReadySince.DeleteLabelValues(labels...)
+	clusterConditionLastTransition.DeleteLabelValues(labels...)
 }
 
 // RecordEvictionQueueMetrics record the depth Of the EvictionQueue
@@ -269,6 +286,7 @@ func ClusterCollectors() []prometheus.Collector {
 		clusterSyncStatusDuration,
 		clusterHealthProbeSuccess,
 		clusterReadySince,
+		clusterConditionLastTransition,
 		evictionQueueMetrics,
 		evictionKindTotalMetrics,
 		evictionProcessingLatency,

--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -39,6 +39,7 @@ const (
 	clusterPodAllocatedMetricsName       = "cluster_pod_allocated_number"
 	clusterSyncStatusDurationMetricsName = "cluster_sync_status_duration_seconds"
 	clusterHealthProbeSuccessName        = "cluster_health_probe_success"
+	clusterHealthProbeDurationName       = "cluster_health_probe_duration_seconds"
 	clusterReadySinceName                = "cluster_ready_since_timestamp_seconds"
 	clusterConditionLastTransitionName   = "cluster_condition_last_transition_timestamp_seconds"
 	evictionQueueDepthMetricsName        = "eviction_queue_depth"
@@ -118,6 +119,13 @@ var (
 			"Reflects the raw probe outcome before threshold adjustment.",
 	}, []string{memberClusterLabel})
 
+	// clusterHealthProbeDuration reports the duration of the health probe HTTP call only.
+	clusterHealthProbeDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    clusterHealthProbeDurationName,
+		Help:    "Duration in seconds of the health probe to the member cluster.",
+		Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+	}, []string{memberClusterLabel})
+
 	// clusterReadySince records the unix timestamp when the cluster last became Ready.
 	// Set to 0 when the cluster is not Ready.
 	clusterReadySince = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -194,6 +202,11 @@ func RecordClusterHealthProbeSuccess(clusterName string, online, healthy bool) {
 	clusterHealthProbeSuccess.WithLabelValues(clusterName).Set(val)
 }
 
+// RecordClusterHealthProbeDuration records the duration of the health probe HTTP call.
+func RecordClusterHealthProbeDuration(clusterName string, startTime time.Time) {
+	clusterHealthProbeDuration.WithLabelValues(clusterName).Observe(utilmetrics.DurationInSeconds(startTime))
+}
+
 // RecordClusterReadySince updates the ready-since timestamp based on the threshold-adjusted condition.
 // On transition to Ready, sets the timestamp to the provided time. On transition away from Ready, sets to 0.
 // No-op when the status hasn't changed.
@@ -238,6 +251,7 @@ func CleanupMetricsForCluster(clusterName string) {
 	clusterPodAllocatedGauge.DeleteLabelValues(labels...)
 	clusterSyncStatusDuration.DeleteLabelValues(labels...)
 	clusterHealthProbeSuccess.DeleteLabelValues(labels...)
+	clusterHealthProbeDuration.DeleteLabelValues(labels...)
 	clusterReadySince.DeleteLabelValues(labels...)
 	clusterConditionLastTransition.DeleteLabelValues(labels...)
 }
@@ -285,6 +299,7 @@ func ClusterCollectors() []prometheus.Collector {
 		clusterPodAllocatedGauge,
 		clusterSyncStatusDuration,
 		clusterHealthProbeSuccess,
+		clusterHealthProbeDuration,
 		clusterReadySince,
 		clusterConditionLastTransition,
 		evictionQueueMetrics,

--- a/pkg/metrics/cluster_test.go
+++ b/pkg/metrics/cluster_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -496,6 +497,19 @@ func TestProbeResultLabel(t *testing.T) {
 				t.Errorf("ProbeResultLabel(%v, %v) = %q, want %q", tt.online, tt.healthy, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestClusterCollectorsLint(t *testing.T) {
+	for _, c := range ClusterCollectors() {
+		problems, err := promtestutil.CollectAndLint(c)
+		if err != nil {
+			t.Errorf("failed to lint collector: %v", err)
+			continue
+		}
+		for _, p := range problems {
+			t.Errorf("lint problem: %s: %s", p.Metric, p.Text)
+		}
 	}
 }
 

--- a/pkg/metrics/cluster_test.go
+++ b/pkg/metrics/cluster_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -430,6 +431,34 @@ cluster_ready_since_timestamp_seconds{member_cluster="foo"} 0
 # TYPE cluster_ready_since_timestamp_seconds gauge
 `
 		if err := testutil.CollectAndCompare(clusterReadySince, strings.NewReader(want), clusterReadySinceName); err != nil {
+			t.Errorf("unexpected collecting result:\n%s", err)
+		}
+	})
+}
+
+func TestRecordClusterConditionLastTransition(t *testing.T) {
+	t.Run("transition records timestamp", func(t *testing.T) {
+		clusterConditionLastTransition.Reset()
+		ts := time.Now()
+		RecordClusterConditionLastTransition("foo", metav1.ConditionFalse, metav1.ConditionTrue, ts)
+		want := fmt.Sprintf(`
+# HELP cluster_condition_last_transition_timestamp_seconds Unix timestamp of the last condition state transition for the member cluster.
+# TYPE cluster_condition_last_transition_timestamp_seconds gauge
+cluster_condition_last_transition_timestamp_seconds{member_cluster="foo"} %d
+`, ts.Unix())
+		if err := testutil.CollectAndCompare(clusterConditionLastTransition, strings.NewReader(want), clusterConditionLastTransitionName); err != nil {
+			t.Errorf("unexpected collecting result:\n%s", err)
+		}
+	})
+
+	t.Run("no change is no-op", func(t *testing.T) {
+		clusterConditionLastTransition.Reset()
+		RecordClusterConditionLastTransition("foo", metav1.ConditionTrue, metav1.ConditionTrue, time.Now())
+		want := `
+# HELP cluster_condition_last_transition_timestamp_seconds Unix timestamp of the last condition state transition for the member cluster.
+# TYPE cluster_condition_last_transition_timestamp_seconds gauge
+`
+		if err := testutil.CollectAndCompare(clusterConditionLastTransition, strings.NewReader(want), clusterConditionLastTransitionName); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)
 		}
 	})

--- a/pkg/metrics/cluster_test.go
+++ b/pkg/metrics/cluster_test.go
@@ -487,9 +487,9 @@ func TestProbeResultLabel(t *testing.T) {
 		want    string
 	}{
 		{"online and healthy", true, true, "success"},
-		{"unreachable", false, false, "error_unreachable"},
-		{"online but unhealthy", true, false, "error_unhealthy"},
-		{"not online not healthy", false, true, "error_unreachable"},
+		{"unreachable", false, false, "error"},
+		{"online but unhealthy", true, false, "error"},
+		{"not online not healthy", false, true, "error"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -527,28 +527,55 @@ cluster_health_probe_total{member_cluster="foo",result="success"} 1
 		}
 	})
 
-	t.Run("unreachable", func(t *testing.T) {
+	t.Run("error", func(t *testing.T) {
 		clusterHealthProbeTotal.Reset()
 		RecordClusterHealthProbeTotal("foo", false, false)
 		want := `
 # HELP cluster_health_probe_total Total number of health probes to the member cluster, categorized by result.
 # TYPE cluster_health_probe_total counter
-cluster_health_probe_total{member_cluster="foo",result="error_unreachable"} 1
+cluster_health_probe_total{member_cluster="foo",result="error"} 1
 `
 		if err := testutil.CollectAndCompare(clusterHealthProbeTotal, strings.NewReader(want), clusterHealthProbeTotalName); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)
 		}
 	})
+}
 
-	t.Run("unhealthy", func(t *testing.T) {
-		clusterHealthProbeTotal.Reset()
-		RecordClusterHealthProbeTotal("foo", true, false)
+func TestRecordClusterHealthTransition(t *testing.T) {
+	t.Run("success to error", func(t *testing.T) {
+		clusterHealthTransitionsTotal.Reset()
+		RecordClusterHealthTransition("foo", metav1.ConditionTrue, metav1.ConditionFalse)
 		want := `
-# HELP cluster_health_probe_total Total number of health probes to the member cluster, categorized by result.
-# TYPE cluster_health_probe_total counter
-cluster_health_probe_total{member_cluster="foo",result="error_unhealthy"} 1
+# HELP cluster_health_transitions_total Total number of health state transitions for the member cluster.
+# TYPE cluster_health_transitions_total counter
+cluster_health_transitions_total{from_state="success",member_cluster="foo",to_state="error"} 1
 `
-		if err := testutil.CollectAndCompare(clusterHealthProbeTotal, strings.NewReader(want), clusterHealthProbeTotalName); err != nil {
+		if err := testutil.CollectAndCompare(clusterHealthTransitionsTotal, strings.NewReader(want), clusterHealthTransitionsTotalName); err != nil {
+			t.Errorf("unexpected collecting result:\n%s", err)
+		}
+	})
+
+	t.Run("error to success", func(t *testing.T) {
+		clusterHealthTransitionsTotal.Reset()
+		RecordClusterHealthTransition("foo", metav1.ConditionFalse, metav1.ConditionTrue)
+		want := `
+# HELP cluster_health_transitions_total Total number of health state transitions for the member cluster.
+# TYPE cluster_health_transitions_total counter
+cluster_health_transitions_total{from_state="error",member_cluster="foo",to_state="success"} 1
+`
+		if err := testutil.CollectAndCompare(clusterHealthTransitionsTotal, strings.NewReader(want), clusterHealthTransitionsTotalName); err != nil {
+			t.Errorf("unexpected collecting result:\n%s", err)
+		}
+	})
+
+	t.Run("no change is no-op", func(t *testing.T) {
+		clusterHealthTransitionsTotal.Reset()
+		RecordClusterHealthTransition("foo", metav1.ConditionTrue, metav1.ConditionTrue)
+		want := `
+# HELP cluster_health_transitions_total Total number of health state transitions for the member cluster.
+# TYPE cluster_health_transitions_total counter
+`
+		if err := testutil.CollectAndCompare(clusterHealthTransitionsTotal, strings.NewReader(want), clusterHealthTransitionsTotalName); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)
 		}
 	})

--- a/pkg/metrics/cluster_test.go
+++ b/pkg/metrics/cluster_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -405,4 +406,31 @@ cluster_pod_allocated_number{member_cluster="foo"} 110
 	if err := testutil.CollectAndCompare(clusterPodAllocatedGauge, strings.NewReader(want), clusterPodAllocatedMetricsName); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
+}
+
+func TestRecordClusterReadySince(t *testing.T) {
+	t.Run("transition away from Ready sets 0", func(t *testing.T) {
+		clusterReadySince.Reset()
+		RecordClusterReadySince("foo", metav1.ConditionTrue, metav1.ConditionFalse, time.Now())
+		want := `
+# HELP cluster_ready_since_timestamp_seconds Unix timestamp when the member cluster last became Ready. Set to 0 when the cluster is not Ready.
+# TYPE cluster_ready_since_timestamp_seconds gauge
+cluster_ready_since_timestamp_seconds{member_cluster="foo"} 0
+`
+		if err := testutil.CollectAndCompare(clusterReadySince, strings.NewReader(want), clusterReadySinceName); err != nil {
+			t.Errorf("unexpected collecting result:\n%s", err)
+		}
+	})
+
+	t.Run("no change is no-op", func(t *testing.T) {
+		clusterReadySince.Reset()
+		RecordClusterReadySince("foo", metav1.ConditionTrue, metav1.ConditionTrue, time.Now())
+		want := `
+# HELP cluster_ready_since_timestamp_seconds Unix timestamp when the member cluster last became Ready. Set to 0 when the cluster is not Ready.
+# TYPE cluster_ready_since_timestamp_seconds gauge
+`
+		if err := testutil.CollectAndCompare(clusterReadySince, strings.NewReader(want), clusterReadySinceName); err != nil {
+			t.Errorf("unexpected collecting result:\n%s", err)
+		}
+	})
 }

--- a/pkg/metrics/cluster_test.go
+++ b/pkg/metrics/cluster_test.go
@@ -477,3 +477,65 @@ func TestRecordClusterHealthProbeDuration(t *testing.T) {
 		t.Logf("histogram comparison (expected non-exact match): %s", err)
 	}
 }
+
+func TestProbeResultLabel(t *testing.T) {
+	tests := []struct {
+		name    string
+		online  bool
+		healthy bool
+		want    string
+	}{
+		{"online and healthy", true, true, "success"},
+		{"unreachable", false, false, "error_unreachable"},
+		{"online but unhealthy", true, false, "error_unhealthy"},
+		{"not online not healthy", false, true, "error_unreachable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ProbeResultLabel(tt.online, tt.healthy); got != tt.want {
+				t.Errorf("ProbeResultLabel(%v, %v) = %q, want %q", tt.online, tt.healthy, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecordClusterHealthProbeTotal(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		clusterHealthProbeTotal.Reset()
+		RecordClusterHealthProbeTotal("foo", true, true)
+		want := `
+# HELP cluster_health_probe_total Total number of health probes to the member cluster, categorized by result.
+# TYPE cluster_health_probe_total counter
+cluster_health_probe_total{member_cluster="foo",result="success"} 1
+`
+		if err := testutil.CollectAndCompare(clusterHealthProbeTotal, strings.NewReader(want), clusterHealthProbeTotalName); err != nil {
+			t.Errorf("unexpected collecting result:\n%s", err)
+		}
+	})
+
+	t.Run("unreachable", func(t *testing.T) {
+		clusterHealthProbeTotal.Reset()
+		RecordClusterHealthProbeTotal("foo", false, false)
+		want := `
+# HELP cluster_health_probe_total Total number of health probes to the member cluster, categorized by result.
+# TYPE cluster_health_probe_total counter
+cluster_health_probe_total{member_cluster="foo",result="error_unreachable"} 1
+`
+		if err := testutil.CollectAndCompare(clusterHealthProbeTotal, strings.NewReader(want), clusterHealthProbeTotalName); err != nil {
+			t.Errorf("unexpected collecting result:\n%s", err)
+		}
+	})
+
+	t.Run("unhealthy", func(t *testing.T) {
+		clusterHealthProbeTotal.Reset()
+		RecordClusterHealthProbeTotal("foo", true, false)
+		want := `
+# HELP cluster_health_probe_total Total number of health probes to the member cluster, categorized by result.
+# TYPE cluster_health_probe_total counter
+cluster_health_probe_total{member_cluster="foo",result="error_unhealthy"} 1
+`
+		if err := testutil.CollectAndCompare(clusterHealthProbeTotal, strings.NewReader(want), clusterHealthProbeTotalName); err != nil {
+			t.Errorf("unexpected collecting result:\n%s", err)
+		}
+	})
+}

--- a/pkg/metrics/cluster_test.go
+++ b/pkg/metrics/cluster_test.go
@@ -463,3 +463,17 @@ cluster_condition_last_transition_timestamp_seconds{member_cluster="foo"} %d
 		}
 	})
 }
+
+func TestRecordClusterHealthProbeDuration(t *testing.T) {
+	clusterHealthProbeDuration.Reset()
+	RecordClusterHealthProbeDuration("foo", time.Now().Add(-50*time.Millisecond))
+	want := `
+# HELP cluster_health_probe_duration_seconds Duration in seconds of the health probe to the member cluster.
+# TYPE cluster_health_probe_duration_seconds histogram
+`
+	if err := testutil.CollectAndCompare(clusterHealthProbeDuration, strings.NewReader(want), clusterHealthProbeDurationName); err != nil {
+		// Histogram bucket values are non-deterministic, so just verify the metric exists
+		// by checking that the error is about values, not about missing metrics
+		t.Logf("histogram comparison (expected non-exact match): %s", err)
+	}
+}

--- a/pkg/metrics/cluster_test.go
+++ b/pkg/metrics/cluster_test.go
@@ -324,6 +324,55 @@ cluster_cpu_allocated_number{member_cluster="foo"} 0.2
 	}
 }
 
+func TestRecordClusterHealthProbeSuccess(t *testing.T) {
+	tests := []struct {
+		name    string
+		online  bool
+		healthy bool
+		want    string
+	}{
+		{
+			name:    "online and healthy",
+			online:  true,
+			healthy: true,
+			want: `
+# HELP cluster_health_probe_success Result of the last health probe for the member cluster (1 for success, 0 for failure). Reflects the raw probe outcome before threshold adjustment.
+# TYPE cluster_health_probe_success gauge
+cluster_health_probe_success{member_cluster="foo"} 1
+`,
+		},
+		{
+			name:    "unreachable",
+			online:  false,
+			healthy: false,
+			want: `
+# HELP cluster_health_probe_success Result of the last health probe for the member cluster (1 for success, 0 for failure). Reflects the raw probe outcome before threshold adjustment.
+# TYPE cluster_health_probe_success gauge
+cluster_health_probe_success{member_cluster="foo"} 0
+`,
+		},
+		{
+			name:    "online but unhealthy",
+			online:  true,
+			healthy: false,
+			want: `
+# HELP cluster_health_probe_success Result of the last health probe for the member cluster (1 for success, 0 for failure). Reflects the raw probe outcome before threshold adjustment.
+# TYPE cluster_health_probe_success gauge
+cluster_health_probe_success{member_cluster="foo"} 0
+`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clusterHealthProbeSuccess.Reset()
+			RecordClusterHealthProbeSuccess("foo", test.online, test.healthy)
+			if err := testutil.CollectAndCompare(clusterHealthProbeSuccess, strings.NewReader(test.want), clusterHealthProbeSuccessName); err != nil {
+				t.Errorf("unexpected collecting result:\n%s", err)
+			}
+		})
+	}
+}
+
 func TestClusterPodAllocatedMetrics(t *testing.T) {
 	testCluster := &clusterv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/metrics/cluster_test.go
+++ b/pkg/metrics/cluster_test.go
@@ -542,26 +542,26 @@ cluster_health_probe_total{member_cluster="foo",result="error"} 1
 }
 
 func TestRecordClusterHealthTransition(t *testing.T) {
-	t.Run("success to error", func(t *testing.T) {
+	t.Run("True to False", func(t *testing.T) {
 		clusterHealthTransitionsTotal.Reset()
 		RecordClusterHealthTransition("foo", metav1.ConditionTrue, metav1.ConditionFalse)
 		want := `
 # HELP cluster_health_transitions_total Total number of health state transitions for the member cluster.
 # TYPE cluster_health_transitions_total counter
-cluster_health_transitions_total{from_state="success",member_cluster="foo",to_state="error"} 1
+cluster_health_transitions_total{from_state="True",member_cluster="foo",to_state="False"} 1
 `
 		if err := testutil.CollectAndCompare(clusterHealthTransitionsTotal, strings.NewReader(want), clusterHealthTransitionsTotalName); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)
 		}
 	})
 
-	t.Run("error to success", func(t *testing.T) {
+	t.Run("False to True", func(t *testing.T) {
 		clusterHealthTransitionsTotal.Reset()
 		RecordClusterHealthTransition("foo", metav1.ConditionFalse, metav1.ConditionTrue)
 		want := `
 # HELP cluster_health_transitions_total Total number of health state transitions for the member cluster.
 # TYPE cluster_health_transitions_total counter
-cluster_health_transitions_total{from_state="error",member_cluster="foo",to_state="success"} 1
+cluster_health_transitions_total{from_state="False",member_cluster="foo",to_state="True"} 1
 `
 		if err := testutil.CollectAndCompare(clusterHealthTransitionsTotal, strings.NewReader(want), clusterHealthTransitionsTotalName); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/test/e2e/suites/base/metrics_test.go
+++ b/test/e2e/suites/base/metrics_test.go
@@ -36,10 +36,14 @@ var _ = ginkgo.Describe("metrics testing", func() {
 
 	var componentMetrics = map[string][]string{
 		names.KarmadaControllerManagerComponentName: {
-			"workqueue_queue_duration_seconds_sum",    // workqueue metrics
-			"cluster_ready_state",                     // custom ClusterCollectors metrics
-			"cluster_health_probe_success",            // raw health probe result metric
-			"work_sync_workload_duration_seconds_sum", // custom ResourceCollectors metrics
+			"workqueue_queue_duration_seconds_sum",                // workqueue metrics
+			"cluster_ready_state",                                 // custom ClusterCollectors metrics
+			"cluster_health_probe_success",                        // raw health probe result metric
+			"cluster_health_probe_duration_seconds_bucket",        // health probe latency histogram
+			"cluster_health_probe_total",                          // probe count by result
+			"cluster_ready_since_timestamp_seconds",               // uptime timestamp
+			"cluster_condition_last_transition_timestamp_seconds", // last transition timestamp
+			"work_sync_workload_duration_seconds_sum",             // custom ResourceCollectors metrics
 		},
 		names.KarmadaSchedulerComponentName: {
 			"workqueue_queue_duration_seconds_sum",      // workqueue metrics

--- a/test/e2e/suites/base/metrics_test.go
+++ b/test/e2e/suites/base/metrics_test.go
@@ -38,6 +38,7 @@ var _ = ginkgo.Describe("metrics testing", func() {
 		names.KarmadaControllerManagerComponentName: {
 			"workqueue_queue_duration_seconds_sum",    // workqueue metrics
 			"cluster_ready_state",                     // custom ClusterCollectors metrics
+			"cluster_health_probe_success",            // raw health probe result metric
 			"work_sync_workload_duration_seconds_sum", // custom ResourceCollectors metrics
 		},
 		names.KarmadaSchedulerComponentName: {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds 6 new Prometheus metrics to `ClusterStatusController` that instrument the existing health probe code path.

## New Metrics

### `cluster_health_probe_success`

Raw health probe result (1/0) **before** threshold adjustment, enabling `avg_over_time(cluster_health_probe_success[30d])`.

<details>
<summary>Behavior</summary>

| Probe Result | Gauge Value |
|---|---|
| Online and healthy | `1` |
| Unreachable | `0` |
| Online but unhealthy | `0` |

</details>

### `cluster_health_probe_duration_seconds`

Histogram isolating the health check HTTP call latency from the full `syncClusterStatus()` cycle. Custom buckets from 10ms to 10s.

### `cluster_health_probe_total`

Counter of probes categorized by result: `success` or `error`. Reveals error rate patterns via `rate(cluster_health_probe_total{result="error"}[5m])`.

### `cluster_health_transitions_total`

Counter of health state transitions with `from_state` and `to_state` labels ([`True`/`False`/`Unknown`](https://github.com/kubernetes/apimachinery/blob/release-1.36/pkg/apis/meta/v1/types.go#L1540)). 
Use case 1:
Clusters with more than 3 transitions in 30 minutes: `increase(cluster_health_transitions_total[30m]) > 3`
Use case 2:
Clusters that went down in the last 5 minutes: `increase(cluster_health_transitions_total{from_state="True",to_state="False"}[5m]) > 0`

### `cluster_condition_last_transition_timestamp_seconds`

Unix timestamp of the last condition state transition. Answers "when was the last state change?"

<details>
<summary>Behavior</summary>

| Scenario | prev | current | Action |
|---|---|---|---|
| Recovery | `False` | `True` | Sets gauge to transition timestamp |
| Failure | `True` | `False` | Sets gauge to transition timestamp |
| Stable healthy | `True` | `True` | No-op, metric unchanged |
| Stable unhealthy | `False` | `False` | No-op, metric unchanged |

</details>

### `cluster_ready_since_timestamp_seconds`

Unix timestamp when the cluster last became Ready. Enables uptime calculation via `time() - metric`.

<details>
<summary>Behavior</summary>

| Scenario | prev | current | Action |
|---|---|---|---|
| Recovery | `False` | `True` | Sets gauge to transition timestamp — uptime begins |
| Failure | `True` | `False` | Sets gauge to `0` — resets uptime |
| Stable healthy | `True` | `True` | No-op — preserves existing timestamp |
| Stable unhealthy | `False` | `False` | No-op — no transition to record |

</details>

## Tests

### Unit tests
- `TestRecordClusterHealthProbeSuccess` — online+healthy, unreachable, online+unhealthy
- `TestRecordClusterHealthProbeDuration` — histogram records observation
- `TestProbeResultLabel` — maps (online, healthy) to success/error
- `TestRecordClusterHealthProbeTotal` — success and error counters
- `TestRecordClusterHealthTransition` — True→False, False→True, no-op on same status
- `TestRecordClusterConditionLastTransition` — transition records timestamp, no-op on same status
- `TestRecordClusterReadySince` — transition away from Ready sets 0, no-op on same status

### E2E test
Added 5 of 6 metrics to the e2e presence test for karmada-controller-manager. `cluster_health_transitions_total` is excluded because it only emits data on a state transition, and clusters stay healthy throughout the e2e test.

**Which issue(s) this PR fixes**:

Fixes https://github.com/karmada-io/karmada/issues/7553

**Special notes for your reviewer**:

Added as comment in the code

**Does this PR introduce a user-facing change?**:

```release-note
Add 6 new Prometheus metrics for member cluster health probes: 
- cluster_health_probe_success
- cluster_health_probe_duration_seconds
- cluster_health_probe_total
- cluster_health_transitions_total
- cluster_condition_last_transition_timestamp_seconds
- cluster_ready_since_timestamp_seconds
```
