### PR TITLE
fix: update cached scale target when scale target reference changes

### DIFF
--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_handler.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_handler.go
@@ -74,7 +74,12 @@ func (c *CronHandler) CronFHPAScaleTargetRefUpdates(cronFHPAKey string, scaleTar
 		return false
 	}
 
-	return !equality.Semantic.DeepEqual(origTarget, scaleTarget)
+	if !equality.Semantic.DeepEqual(origTarget, scaleTarget) {
+		c.cronFHPAScaleTargetMap[cronFHPAKey] = scaleTarget
+		return true
+	}
+
+	return false
 }
 
 // AddCronExecutorIfNotExist creates the executor for CronFederatedHPA if not exist

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_handler_test.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_handler_test.go
@@ -98,6 +98,37 @@ func TestCronFHPAScaleTargetRefUpdates(t *testing.T) {
 	}
 }
 
+func TestCronFHPAScaleTargetRefUpdates_BugReproduction(t *testing.T) {
+	handler := NewCronHandler(fake.NewClientBuilder().Build(), record.NewFakeRecorder(100))
+	cronFHPAKey := "default/test-cronhpa"
+
+	target1 := autoscalingv2.CrossVersionObjectReference{
+		Kind:       "Deployment",
+		Name:       "test-deployment-1",
+		APIVersion: "apps/v1",
+	}
+	target2 := autoscalingv2.CrossVersionObjectReference{
+		Kind:       "Deployment",
+		Name:       "test-deployment-2",
+		APIVersion: "apps/v1",
+	}
+
+	// 1. Initial target setting. The map is empty.
+	// This should return false because it's the initial target and not an "update" from a previous target.
+	updated := handler.CronFHPAScaleTargetRefUpdates(cronFHPAKey, target1)
+	assert.False(t, updated, "Initial target setting should return false")
+
+	// 2. Update to a new scale target.
+	// This should return true because target2 is different from target1.
+	updated = handler.CronFHPAScaleTargetRefUpdates(cronFHPAKey, target2)
+	assert.True(t, updated, "Update to a new scale target should return true")
+
+	// 3. Call again with the same updated target.
+	// This should return false because the target hasn't changed since the last call.
+	updated = handler.CronFHPAScaleTargetRefUpdates(cronFHPAKey, target2)
+	assert.False(t, updated, "Calling again with the same target should return false")
+}
+
 func TestAddCronExecutorIfNotExist(t *testing.T) {
 	handler := NewCronHandler(fake.NewClientBuilder().Build(), record.NewFakeRecorder(100))
 


### PR DESCRIPTION
fixes #7622 
What does this PR do?

This PR updates CronFHPAScaleTargetRefUpdates() to refresh the cached scale target reference when a target change is detected.

Without updating the cached value, subsequent calls continue comparing against the stale target reference and repeatedly report the same change.

Changes

* Update the cached scale target reference when a new target is detected.
* Add a regression test covering repeated calls with the same updated target reference.

