### PR TITLE
Add warning comments to the UpdateStatus function

### DIFF
--- a/pkg/util/helper/status.go
+++ b/pkg/util/helper/status.go
@@ -36,6 +36,19 @@ import (
 // Note: changes to any sub-resource other than status will be ignored.
 // Changes to the status sub-resource will only be applied if the object
 // already exist.
+//
+// WARNING: This helper fetches the object via the client's cache (an informer),
+// which may be stale. The desired status produced by MutateFn is compared
+// (DeepEqual) against this possibly-stale cached object, and the update is
+// skipped when they are equal. If the cache lags behind the API server, a
+// needed update can be silently skipped.
+//
+// Because of the above, callers MUST ensure the problem can eventually
+// converge even if a single update is skipped. In particular, a caller MUST
+// NOT filter out (ignore) reconcile events without also having a periodic
+// reconcile, otherwise a skipped update may never be retried and the status
+// stays stale forever.
+// See https://github.com/karmada-io/karmada/issues/6858 for the background.
 func UpdateStatus(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
 	key := client.ObjectKeyFromObject(obj)
 	if err := c.Get(ctx, key, obj); err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR adds comments to the [UpdateStatus](https://github.com/karmada-io/karmada/blob/5b6c89cd672d59baea1120c266b278dde28d377f/pkg/util/helper/status.go#L39) helper in `pkg/util/helper/status.go`, clarifying its behavior when updating the status sub-resource. 

**Which issue(s) this PR fixes**:
Fixes #6858
Fixes #7077

**Special notes for your reviewer**:

The concrete problem originally reported in #6858 — status updates being effectively lost — was traced back to stale-cache conflicts when the execution controller syncs workloads to member clusters. That root cause has been addressed by #7106, which retries on conflict in syncToClusters, so the reported symptom no longer reproduces.

Regarding the broader concern about [helper.UpdateStatus](https://github.com/karmada-io/karmada/blob/5b6c89cd672d59baea1120c266b278dde28d377f/pkg/util/helper/status.go#L39) itself: it fetches the object from the (potentially stale) informer cache and skips the write when the mutated status DeepEquals the cached copy. In theory this can skip a needed update. After re-reviewing all current callers, we could not find a reliable, reproducible path where this leads to a permanently lost status update in the codebase as it stands today.

Given that, rather than reworking the helper's semantics (which risks regressions such as dropping optimistic concurrency), we've chosen to document the precondition.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

