### PR TITLE
Fix metricsadapter: sort GetMetricBySelector results for deterministic output

### DIFF
--- a/pkg/metricsadapter/provider/custommetrics.go
+++ b/pkg/metricsadapter/provider/custommetrics.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 
@@ -142,7 +143,6 @@ func (c *CustomMetricsProvider) GetMetricBySelector(ctx context.Context, namespa
 		if !ok {
 			break
 		}
-		// TODO(chaunceyjiang) The MetricValue items need to be sorted.
 		for _, metric := range metrics.Items {
 			// metrics is unique in one cluster, but it may exist in multiple clusters.
 			// for this situation, we need to add the value of all clusters.
@@ -155,6 +155,9 @@ func (c *CustomMetricsProvider) GetMetricBySelector(ctx context.Context, namespa
 	for _, metric := range sameMetrics {
 		metricValueList.Items = append(metricValueList.Items, metric)
 	}
+	sort.Slice(metricValueList.Items, func(i, j int) bool {
+		return metricValueList.Items[i].DescribedObject.Name < metricValueList.Items[j].DescribedObject.Name
+	})
 	if len(metricValueList.Items) == 0 {
 		return nil, provider.NewMetricNotFoundError(info.GroupResource, info.Metric)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`GetMetricBySelector` aggregates custom metrics from member clusters into a
map (`sameMetrics`) and then iterates the map to build the response Items slice.
Go map iteration order is non-deterministic, so every call returns metrics in a
different order. This can cause inconsistent behavior in HPA controllers that
consume the custom metrics API and compare metric lists across calls.

This PR sorts the Items slice by `DescribedObject.Name` before returning,
producing a stable and predictable response. Resolves the existing TODO left
by @chaunceyjiang.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- Addresses the TODO comment in `GetMetricBySelector`:
  `// TODO(chaunceyjiang) The MetricValue items need to be sorted.`
- The sort key is `DescribedObject.Name`, which uniquely identifies a metric
  target within a namespace.
- No existing test file for this package; the change is a single `sort.Slice`
  call with no logic branching.

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-metrics-adapter`: Fixed the issue that `GetMetricBySelector` returned
custom metrics in non-deterministic order when aggregating results from multiple
member clusters.