### PR TITLE
clusterdiscovery: replace klog.Fatalf with klog.Errorf in joinClusterAPICluster

### DIFF
--- a/pkg/clusterdiscovery/clusterapi/clusterapi.go
+++ b/pkg/clusterdiscovery/clusterapi/clusterapi.go
@@ -207,7 +207,8 @@ func (d *ClusterDetector) joinClusterAPICluster(clusterWideKey keys.ClusterWideK
 
 	clusterRestConfig, err := apiclient.RestConfig("", kubeconfigPath)
 	if err != nil {
-		klog.Fatalf("Failed to get cluster-api management cluster rest config. kubeconfig: %s, err: %v", kubeconfigPath, err)
+		klog.Errorf("Failed to build rest config for cluster-api cluster(%s) from kubeconfig %s: %v", clusterWideKey.Name, kubeconfigPath, err)
+		return err
 	}
 	opts := join.CommandJoinOption{
 		DryRun:           false,


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`joinClusterAPICluster` calls `klog.Fatalf` when `apiclient.RestConfig`
fails to build the REST config for a cluster-api managed cluster.
`klog.Fatalf` calls `os.Exit(1)`, which terminates the entire
`karmada-controller-manager` process. This is too aggressive — the error
is potentially transient (e.g. temporary network issue) and the reconcile
loop should retry it via exponential backoff instead of crashing.

This PR replaces `klog.Fatalf` with `klog.Errorf` and adds `return err`
so the async worker re-queues the item with backoff, consistent with the
error handling pattern used throughout the rest of this function.

**Which issue(s) this PR fixes**:
Fixes #7636

**Special notes for your reviewer**:
- The identical `klog.Fatalf` in `controllermanager.go` (startup path) is correct and left unchanged.
- Only the reconcile path inside `joinClusterAPICluster` is affected.

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-controller-manager`: Fixed the issue that a transient REST config
error during cluster-api cluster join caused the entire controller-manager
process to exit instead of retrying.