### PR TITLE
feat(helm): add extraCommandArgs support to remaining components

### DIFF
--- a/charts/karmada/templates/_helpers.tpl
+++ b/charts/karmada/templates/_helpers.tpl
@@ -644,6 +644,79 @@ If none are set, outputs nothing.
 {{- end }}
 {{- end -}}
 
+{{- define "karmada.scheduler.extraCommandArgs" -}}
+{{- if .Values.scheduler.extraCommandArgs }}
+{{- range $key, $value := .Values.scheduler.extraCommandArgs }}
+- --{{ $key }}={{ $value }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "karmada.descheduler.extraCommandArgs" -}}
+{{- if .Values.descheduler.extraCommandArgs }}
+{{- range $key, $value := .Values.descheduler.extraCommandArgs }}
+- --{{ $key }}={{ $value }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "karmada.schedulerEstimator.extraCommandArgs" -}}
+{{- if .Values.schedulerEstimator.extraCommandArgs }}
+{{- range $key, $value := .Values.schedulerEstimator.extraCommandArgs }}
+- --{{ $key }}={{ $value }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "karmada.webhook.extraCommandArgs" -}}
+{{- if .Values.webhook.extraCommandArgs }}
+{{- range $key, $value := .Values.webhook.extraCommandArgs }}
+- --{{ $key }}={{ $value }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "karmada.agent.extraCommandArgs" -}}
+{{- if .Values.agent.extraCommandArgs }}
+{{- range $key, $value := .Values.agent.extraCommandArgs }}
+- --{{ $key }}={{ $value }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "karmada.aggregatedApiServer.extraCommandArgs" -}}
+{{- if .Values.aggregatedApiServer.extraCommandArgs }}
+{{- range $key, $value := .Values.aggregatedApiServer.extraCommandArgs }}
+- --{{ $key }}={{ $value }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "karmada.apiServer.extraCommandArgs" -}}
+{{- if .Values.apiServer.extraCommandArgs }}
+{{- range $key, $value := .Values.apiServer.extraCommandArgs }}
+- --{{ $key }}={{ $value }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "karmada.metricsAdapter.extraCommandArgs" -}}
+{{- if .Values.metricsAdapter.extraCommandArgs }}
+{{- range $key, $value := .Values.metricsAdapter.extraCommandArgs }}
+- --{{ $key }}={{ $value }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "karmada.search.extraCommandArgs" -}}
+{{- if .Values.search.extraCommandArgs }}
+{{- range $key, $value := .Values.search.extraCommandArgs }}
+- --{{ $key }}={{ $value }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+
 {{- define "karmada.initContainer.waitEtcd" -}}
 - name: wait
   image: {{ include "karmada.cfssl.image" . }}

--- a/charts/karmada/templates/karmada-agent.yaml
+++ b/charts/karmada/templates/karmada-agent.yaml
@@ -115,6 +115,7 @@ spec:
             - --metrics-bind-address=$(POD_IP):8080
             - --health-probe-bind-address=$(POD_IP):10357
             - --v={{ .Values.agent.logVerbosity }}
+            {{- include "karmada.agent.extraCommandArgs" . | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/karmada/templates/karmada-aggregated-apiserver.yaml
+++ b/charts/karmada/templates/karmada-aggregated-apiserver.yaml
@@ -71,6 +71,7 @@ spec:
             - --tls-min-version=VersionTLS13
             - --v={{ .Values.aggregatedApiServer.logVerbosity }}
             - --bind-address=$(POD_IP)
+            {{- include "karmada.aggregatedApiServer.extraCommandArgs" . | nindent 12 }}
           resources:
             {{- toYaml .Values.aggregatedApiServer.resources | nindent 12 }}
           readinessProbe:

--- a/charts/karmada/templates/karmada-apiserver.yaml
+++ b/charts/karmada/templates/karmada-apiserver.yaml
@@ -106,6 +106,7 @@ spec:
             - --oidc-username-prefix={{ .usernamePrefix }}
             {{- end }}
             {{- end }}
+            {{- include "karmada.apiServer.extraCommandArgs" . | nindent 12 }}
           ports:
             - name: http
               containerPort: 5443

--- a/charts/karmada/templates/karmada-descheduler.yaml
+++ b/charts/karmada/templates/karmada-descheduler.yaml
@@ -59,6 +59,7 @@ spec:
             - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
             - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
             - --v={{ .Values.descheduler.logVerbosity }}
+            {{- include "karmada.descheduler.extraCommandArgs" . | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/karmada/templates/karmada-metrics-adapter.yaml
+++ b/charts/karmada/templates/karmada-metrics-adapter.yaml
@@ -57,6 +57,7 @@ spec:
             - --tls-min-version=VersionTLS13
             - --v={{ .Values.metricsAdapter.logVerbosity }}
             - --bind-address=$(POD_IP)
+            {{- include "karmada.metricsAdapter.extraCommandArgs" . | nindent 12 }}
           resources:
             {{- toYaml .Values.metricsAdapter.resources | nindent 12 }}
           readinessProbe:

--- a/charts/karmada/templates/karmada-scheduler-estimator.yaml
+++ b/charts/karmada/templates/karmada-scheduler-estimator.yaml
@@ -64,6 +64,7 @@ spec:
             {{- with (include "karmada.schedulerEstimator.featureGates" $) }}
             - {{ . }}
             {{- end }}
+            {{- include "karmada.schedulerEstimator.extraCommandArgs" $ | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -65,6 +65,7 @@ spec:
             {{- with (include "karmada.scheduler.featureGates" .) }}
             - {{ . }}
             {{- end }}
+            {{- include "karmada.scheduler.extraCommandArgs" . | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/karmada/templates/karmada-search.yaml
+++ b/charts/karmada/templates/karmada-search.yaml
@@ -84,6 +84,7 @@ spec:
             - --tls-min-version=VersionTLS13
             - --v={{ .Values.search.logVerbosity }}
             - --bind-address=$(POD_IP)
+            {{- include "karmada.search.extraCommandArgs" . | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /livez

--- a/charts/karmada/templates/karmada-webhook.yaml
+++ b/charts/karmada/templates/karmada-webhook.yaml
@@ -61,6 +61,7 @@ spec:
             {{- with (include "karmada.webhook.featureGates" .) }}
             - {{ . }}
             {{- end }}
+            {{- include "karmada.webhook.extraCommandArgs" . | nindent 12 }}
           ports:
             - containerPort: 8443
             - containerPort: 8080

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -249,6 +249,11 @@ scheduler:
   enableSchedulerEstimator: false
   ## @param scheduler.featureGates A set of key=value pairs that describe feature gates for karmada-scheduler
   featureGates: {}
+  ## @param scheduler.extraCommandArgs A set of key=value pairs that describe extra command line arguments for the scheduler.
+  ## They are rendered as --key=value after built-in and dedicated flags.
+  ## Duplicate single-value flags will override earlier values (last value wins).
+  ## Multi-value flags (like --feature-gates or --controllers) may not behave as simple overrides.
+  extraCommandArgs: {}
 
 ## webhook config
 webhook:
@@ -311,6 +316,11 @@ webhook:
   priorityClassName: "system-node-critical"
   ## @param webhook.featureGates A set of key=value pairs that describe feature gates for karmada-webhook
   featureGates: {}
+  ## @param webhook.extraCommandArgs A set of key=value pairs that describe extra command line arguments for the webhook.
+  ## They are rendered as --key=value after built-in and dedicated flags.
+  ## Duplicate single-value flags will override earlier values (last value wins).
+  ## Multi-value flags (like --feature-gates or --controllers) may not behave as simple overrides.
+  extraCommandArgs: {}
 
 ## controller manager config
 controllerManager:
@@ -493,6 +503,11 @@ apiServer:
       key: "encryption-config.yaml"
     ## @param apiServer.encryptionAtRest.configFile path where the encryption config file will be mounted in the container
     configFile: "/etc/karmada/encryption/encryption-config.yaml"
+  ## @param apiServer.extraCommandArgs A set of key=value pairs that describe extra command line arguments for the apiServer.
+  ## They are rendered as --key=value after built-in and dedicated flags.
+  ## Duplicate single-value flags will override earlier values (last value wins).
+  ## Multi-value flags (like --feature-gates or --controllers) may not behave as simple overrides.
+  extraCommandArgs: {}
 
 ## karmada aggregated apiserver config
 aggregatedApiServer:
@@ -555,6 +570,11 @@ aggregatedApiServer:
   podDisruptionBudget: *podDisruptionBudget
   ## @param aggregatedApiServer.priorityClassName the priority class name for the karmada-aggregated-apiserver.
   priorityClassName: "system-node-critical"
+  ## @param aggregatedApiServer.extraCommandArgs A set of key=value pairs that describe extra command line arguments for the aggregatedApiServer.
+  ## They are rendered as --key=value after built-in and dedicated flags.
+  ## Duplicate single-value flags will override earlier values (last value wins).
+  ## Multi-value flags (like --feature-gates or --controllers) may not behave as simple overrides.
+  extraCommandArgs: {}
 
 ## karmada metrics adapter config
 metricsAdapter:
@@ -617,6 +637,11 @@ metricsAdapter:
   podDisruptionBudget: *podDisruptionBudget
   ## @param metricsAadpter.priorityClassName the priority class name for the karmada-mertics-adapter
   priorityClassName: "system-node-critical"
+  ## @param metricsAdapter.extraCommandArgs A set of key=value pairs that describe extra command line arguments for the metricsAdapter.
+  ## They are rendered as --key=value after built-in and dedicated flags.
+  ## Duplicate single-value flags will override earlier values (last value wins).
+  ## Multi-value flags (like --feature-gates or --controllers) may not behave as simple overrides.
+  extraCommandArgs: {}
 
 ## kubernetes controller manager config
 kubeControllerManager:
@@ -853,6 +878,11 @@ agent:
   podDisruptionBudget: *podDisruptionBudget
   ## @param agent.priorityClassName the priority class name for the karmada-agent
   priorityClassName: "system-node-critical"
+  ## @param agent.extraCommandArgs A set of key=value pairs that describe extra command line arguments for the agent.
+  ## They are rendered as --key=value after built-in and dedicated flags.
+  ## Duplicate single-value flags will override earlier values (last value wins).
+  ## Multi-value flags (like --feature-gates or --controllers) may not behave as simple overrides.
+  extraCommandArgs: {}
 
 ## karmada scheduler estimator
 schedulerEstimator:
@@ -939,6 +969,11 @@ schedulerEstimator:
   featureGates: {}
   ## @param schedulerEstimator.priorityClassName the priority class name for the scheduler-estimator
   priorityClassName: "system-node-critical"
+  ## @param schedulerEstimator.extraCommandArgs A set of key=value pairs that describe extra command line arguments for the schedulerEstimator.
+  ## They are rendered as --key=value after built-in and dedicated flags.
+  ## Duplicate single-value flags will override earlier values (last value wins).
+  ## Multi-value flags (like --feature-gates or --controllers) may not behave as simple overrides.
+  extraCommandArgs: {}
 
 ## descheduler config
 descheduler:
@@ -1001,6 +1036,11 @@ descheduler:
   podDisruptionBudget: *podDisruptionBudget
   ## @param descheduler.priorityClassName the priority class name for the descheduler
   priorityClassName: "system-node-critical"
+  ## @param descheduler.extraCommandArgs A set of key=value pairs that describe extra command line arguments for the descheduler.
+  ## They are rendered as --key=value after built-in and dedicated flags.
+  ## Duplicate single-value flags will override earlier values (last value wins).
+  ## Multi-value flags (like --feature-gates or --controllers) may not behave as simple overrides.
+  extraCommandArgs: {}
 
 ## karmada-search config
 search:
@@ -1065,3 +1105,8 @@ search:
   podDisruptionBudget: *podDisruptionBudget
   ## @param search.priorityClassName the priority class name for the karmada-search
   priorityClassName: "system-node-critical"
+  ## @param search.extraCommandArgs A set of key=value pairs that describe extra command line arguments for the search.
+  ## They are rendered as --key=value after built-in and dedicated flags.
+  ## Duplicate single-value flags will override earlier values (last value wins).
+  ## Multi-value flags (like --feature-gates or --controllers) may not behave as simple overrides.
+  extraCommandArgs: {}


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

This PR adds `extraCommandArgs` support to all remaining Helm chart components:

- `karmada-scheduler`
- `karmada-descheduler`
- `karmada-scheduler-estimator`
- `karmada-webhook`
- `karmada-agent`
- `karmada-aggregated-apiserver`
- `karmada-apiserver`
- `karmada-metrics-adapter`
- `karmada-search`

Each component now exposes:

```yaml
extraCommandArgs: {}
```

Arguments are rendered as:

```yaml
- --<key>=<value>
```

and are appended after built-in and dedicated flags. This matches the existing `controllerManager` behavior and intentionally allows `extraCommandArgs` to act as the final override layer for single-value flags.

Documentation has also been added to `values.yaml` describing the precedence behavior and noting that some multi-value flags may not behave as simple overrides.

## Which issue(s) this PR fixes

Fixes #7626

## Special notes for your reviewer

Validation performed:

```bash
helm lint charts/karmada
helm template charts/karmada >/dev/null
```

Additionally, rendering was verified with sample `extraCommandArgs` values (including `schedulerEstimator`) to ensure `--key=value` arguments are correctly appended to manifests.
