### PR TITLE
Test(webhook): add verify empty placement does not panic in propagation policies

### DIFF
--- a/pkg/webhook/clusterpropagationpolicy/mutating_test.go
+++ b/pkg/webhook/clusterpropagationpolicy/mutating_test.go
@@ -207,3 +207,48 @@ func TestMutatingAdmission_Handle_FullCoverage(t *testing.T) {
 		t.Errorf("Handle() got.Allowed = false, want true")
 	}
 }
+
+func TestMutatingAdmission_Handle_EmptyPlacement(t *testing.T) {
+	// Use a cluster-scoped policy to verify empty placement handling.
+	policyName := "test-cp-policy"
+
+	// Build a create admission request, which is the path that adds defaults.
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+		},
+	}
+
+	// Create a policy without Spec.Placement. Placement is optional, so this
+	// produces an empty Placement value rather than a nil pointer.
+	cpPolicy := &policyv1alpha1.ClusterPropagationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+		},
+		Spec: policyv1alpha1.PropagationSpec{
+			ResourceSelectors: []policyv1alpha1.ResourceSelector{
+				{
+					Namespace:  "",
+					Kind:       util.ServiceImportKind,
+					APIVersion: mcsv1alpha1.GroupVersion.String(),
+				},
+			},
+		},
+	}
+
+	// Store the original object in the admission request for patch generation.
+	raw, err := json.Marshal(cpPolicy)
+	if err != nil {
+		t.Fatalf("Failed to marshal cluster propagation policy: %v", err)
+	}
+	req.Object.Raw = raw
+
+	// Use the fake decoder to pass the policy directly into the webhook.
+	mutatingHandler := NewMutatingHandler(&fakeMutationDecoder{obj: cpPolicy})
+
+	// Empty placement is valid and should not block admission.
+	got := mutatingHandler.Handle(context.Background(), req)
+	if !got.Allowed {
+		t.Errorf("Handle() got.Allowed = false, want true")
+	}
+}

--- a/pkg/webhook/propagationpolicy/mutating_test.go
+++ b/pkg/webhook/propagationpolicy/mutating_test.go
@@ -213,3 +213,51 @@ func TestMutatingAdmission_Handle_FullCoverage(t *testing.T) {
 		t.Errorf("Handle() got.Allowed = false, want true")
 	}
 }
+
+func TestMutatingAdmission_Handle_EmptyPlacement(t *testing.T) {
+	// Use a namespaced PropagationPolicy to verify empty placement handling.
+	policyName := "test-propagation-policy"
+	namespace := "test-namespace"
+
+	// Build a create admission request, which is the path that adds defaults.
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Namespace: namespace,
+			Operation: admissionv1.Create,
+		},
+	}
+
+	// Create a policy without Spec.Placement. Placement is optional, so this
+	// produces an empty Placement value rather than a nil pointer.
+	pp := &policyv1alpha1.PropagationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+		},
+		Spec: policyv1alpha1.PropagationSpec{
+			// Keep the selector namespace empty so the webhook can default it.
+			ResourceSelectors: []policyv1alpha1.ResourceSelector{
+				{
+					Namespace:  "",
+					Kind:       util.ServiceImportKind,
+					APIVersion: mcsv1alpha1.GroupVersion.String(),
+				},
+			},
+		},
+	}
+
+	// Store the original object in the admission request for patch generation.
+	raw, err := json.Marshal(pp)
+	if err != nil {
+		t.Fatalf("Failed to marshal propagation policy: %v", err)
+	}
+	req.Object.Raw = raw
+
+	// Use the fake decoder to pass the policy directly into the webhook.
+	mutatingHandler := NewMutatingHandler(&fakeMutationDecoder{obj: pp})
+
+	// Empty placement is valid and should not block admission.
+	got := mutatingHandler.Handle(context.Background(), req)
+	if !got.Allowed {
+		t.Errorf("Handle() got.Allowed = false, want true")
+	}
+}


### PR DESCRIPTION

**What type of PR is this?**
 /kind bug

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**: 
These PRs provide regression test cases for the `PropagationPolicy` and `ClusterPropagationPolicy` mutating webhooks in case `spec.placement` is missing.

`spec.placement` is an optional field with value type, and therefore, if it is not provided, it is decoded into an empty `Placement` value. These new test cases illustrate such behavior.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #7638

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
The reported panic scenario assumes `spec.placement` is a pointer. In the current API, `PropagationSpec.Placement` is a value field:
Because of that, omitting `spec.placement` decodes to an empty `Placement` value, not `nil`. This PR keeps the production webhook logic unchanged and adds focused tests to document and protect the expected behavior for both namespaced and cluster-scoped propagation policies.

Tested with:

```bash
go test ./pkg/webhook/propagationpolicy
go test ./pkg/webhook/clusterpropagationpolicy
```
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**: 
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->


