### PR TITLE
karmadactl: validate --etcd-pvc-size to avoid panic on invalid value

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -237,8 +238,13 @@ func (i *CommandInitOption) validateLocalEtcd(parentCommand string) error {
 		return fmt.Errorf("for data security,when etcd storage mode is hostPath,etcd-replicas can only be 1")
 	}
 
-	if i.EtcdStorageMode == etcdStorageModePVC && i.StorageClassesName == "" {
-		return fmt.Errorf("when etcd storage mode is PVC, storageClassesName is not empty. See '%s init --help'", parentCommand)
+	if i.EtcdStorageMode == etcdStorageModePVC {
+		if i.StorageClassesName == "" {
+			return fmt.Errorf("when etcd storage mode is PVC, storageClassesName is not empty. See '%s init --help'", parentCommand)
+		}
+		if _, err := resource.ParseQuantity(i.EtcdPersistentVolumeSize); err != nil {
+			return fmt.Errorf("invalid etcd-pvc-size %q: %w. See '%s init --help'", i.EtcdPersistentVolumeSize, err, parentCommand)
+		}
 	}
 
 	if i.WaitComponentReadyTimeout < 0 {

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
@@ -135,6 +135,32 @@ func TestCommandInitOption_Validate(t *testing.T) {
 			errorMsg: "CommandInitOption.Validate() does not return err when StorageClassesName is empty",
 		},
 		{
+			name: "Invalid EtcdPersistentVolumeSize",
+			opt: CommandInitOption{
+				KarmadaAPIServerAdvertiseAddress: "192.0.2.1",
+				EtcdStorageMode:                  etcdStorageModePVC,
+				StorageClassesName:               "fast",
+				EtcdReplicas:                     1,
+				EtcdPersistentVolumeSize:         "abc",
+				ImagePullPolicy:                  string(corev1.PullIfNotPresent),
+			},
+			wantErr:  true,
+			errorMsg: "CommandInitOption.Validate() does not return err when etcd-pvc-size is not a valid quantity",
+		},
+		{
+			name: "Valid EtcdPersistentVolumeSize",
+			opt: CommandInitOption{
+				KarmadaAPIServerAdvertiseAddress: "192.0.2.1",
+				EtcdStorageMode:                  etcdStorageModePVC,
+				StorageClassesName:               "fast",
+				EtcdReplicas:                     1,
+				EtcdPersistentVolumeSize:         "5Gi",
+				ImagePullPolicy:                  string(corev1.PullIfNotPresent),
+			},
+			wantErr:  false,
+			errorMsg: "CommandInitOption.Validate() returns err when etcd-pvc-size is a valid quantity",
+		},
+		{
 			name: "Invalid EtcdStorageMode",
 			opt: CommandInitOption{
 				KarmadaAPIServerAdvertiseAddress: "192.0.2.1",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`karmadactl init` panics when `--etcd-pvc-size` is given an invalid quantity, because the value is passed to `resource.MustParse` in `etcdVolume()` without any validation. This PR validates `--etcd-pvc-size` with `resource.ParseQuantity` in `validateLocalEtcd` (PVC mode) so the command returns a clear validation error instead of panicking.

**Which issue(s) this PR fixes**:
Fixes #7646

**Special notes for your reviewer**:

Added regression tests (`Invalid_EtcdPersistentVolumeSize`, `Valid_EtcdPersistentVolumeSize`) to `TestCommandInitOption_Validate`. Reproduced the panic before the fix (`cannot parse 'abc': quantities must match the regular expression ...`); after the fix `init` returns a descriptive error. `gofmt`, `go vet`, `go build`, and the package tests all pass.

**Does this PR introduce a user-facing change?**:

```release-note
`karmadactl`: Fixed the issue that `init` panics when `--etcd-pvc-size` is set to an invalid value.
```
