### PR TITLE
fix: close outFile before returning on copy error in Unpack and DeCompress

### DIFF
--- a/operator/pkg/util/util.go
+++ b/operator/pkg/util/util.go
@@ -153,9 +153,12 @@ func Unpack(file, targetPath string) error {
 				return err
 			}
 			if err := ioCopyN(outFile, tr); err != nil {
+				outFile.Close()
 				return err
 			}
-			outFile.Close()
+			if err := outFile.Close(); err != nil {
+				return err
+			}
 		default:
 			fmt.Printf("unknown type: %v in %s\n", header.Typeflag, header.Name)
 		}

--- a/pkg/karmadactl/cmdinit/utils/util.go
+++ b/pkg/karmadactl/cmdinit/utils/util.go
@@ -121,9 +121,12 @@ func DeCompress(file, targetPath string) error {
 				return err
 			}
 			if err := ioCopyN(outFile, tr); err != nil {
+				outFile.Close()
 				return err
 			}
-			outFile.Close()
+			if err := outFile.Close(); err != nil {
+				return err
+			}
 		default:
 			fmt.Printf("unknown type: %v in %s\n", header.Typeflag, header.Name)
 		}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

`Unpack` in `operator/pkg/util` and `DeCompress` in `pkg/karmadactl/cmdinit/utils` both open a file per tar entry inside a loop. When `ioCopyN` returns an error, the function returns without closing the open `*os.File`, leaking the file descriptor.

The successful `outFile.Close()` was also discarding its return value. On NFS and similar filesystems, write errors only surface at close time, so a failed write could return success with a truncated file.

## Which issue(s) this PR fixes

None (self-found)

## Special notes for your reviewer

Both functions have the same bug; `Unpack` is in `operator/` and `DeCompress` in `karmadactl/cmdinit/utils/`.

## Does this PR introduce a user-facing change?

No.