### PR TITLE
karmadactl: validate --cert-external-ip to avoid silently using 127.0…

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -320,6 +320,13 @@ func (i *CommandInitOption) Validate(parentCommand string) error {
 			return fmt.Errorf("karmada apiserver advertise address is not valid")
 		}
 	}
+	if i.ExternalIP != "" {
+		for ip := range strings.SplitSeq(i.ExternalIP, ",") {
+			if net.ParseIP(ip) == nil {
+				return fmt.Errorf("cert-external-ip %q is not a valid IP address", ip)
+			}
+		}
+	}
 	if (i.CaCertFile != "") != (i.CaKeyFile != "") {
 		return fmt.Errorf("ca-cert-file and ca-key-file must be used together")
 	}

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
@@ -85,6 +85,39 @@ func TestCommandInitOption_Validate(t *testing.T) {
 			errorMsg: "CommandInitOption.Validate() does not return err when KarmadaAPIServerAdvertiseAddress is wrong",
 		},
 		{
+			name: "Invalid cert-external-ip",
+			opt: CommandInitOption{
+				ExternalIP:      "192.168.1.300",
+				EtcdStorageMode: etcdStorageModeEmptyDir,
+				ImagePullPolicy: string(corev1.PullIfNotPresent),
+			},
+			wantErr:  true,
+			errorMsg: "CommandInitOption.Validate() does not return err when cert-external-ip is not a valid IP",
+		},
+		{
+			name: "cert-external-ip with spaces is rejected",
+			opt: CommandInitOption{
+				// A space after the comma is not tolerated by net.ParseIP, which is
+				// how the value is consumed during cert generation, so it must be
+				// rejected here rather than silently becoming 127.0.0.1.
+				ExternalIP:      "192.0.2.1, 192.0.2.2",
+				EtcdStorageMode: etcdStorageModeEmptyDir,
+				ImagePullPolicy: string(corev1.PullIfNotPresent),
+			},
+			wantErr:  true,
+			errorMsg: "CommandInitOption.Validate() does not return err when cert-external-ip contains a space",
+		},
+		{
+			name: "Valid cert-external-ip",
+			opt: CommandInitOption{
+				ExternalIP:      "192.0.2.1,192.0.2.2",
+				EtcdStorageMode: etcdStorageModeEmptyDir,
+				ImagePullPolicy: string(corev1.PullIfNotPresent),
+			},
+			wantErr:  false,
+			errorMsg: "CommandInitOption.Validate() returns err when cert-external-ip is a valid IP list",
+		},
+		{
 			name: "Empty EtcdHostDataPath",
 			opt: CommandInitOption{
 				KarmadaAPIServerAdvertiseAddress: "192.0.2.1",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`karmadactl init` accepts the `--cert-external-ip` flag but never validates it. The value is passed to `utils.FlagsIP` -> `utils.StringToNetIP`, which silently falls back to `127.0.0.1` for any value it can't parse as an IP. So an invalid `--cert-external-ip` slips through and the certificate ends up signed for `127.0.0.1` instead of the address the user asked for, which surfaces later as confusing TLS errors.

This PR validates `--cert-external-ip` in `Validate()` (splitting on comma and parsing each entry with `netutils.ParseIPSloppy`), the same way `--karmada-apiserver-advertise-address` is already validated, and returns a clear error on invalid input.

**Which issue(s) this PR fixes**:
Fixes #7655

**Special notes for your reviewer**:

Added regression tests (`Invalid cert-external-ip`, `Valid cert-external-ip`) to `TestCommandInitOption_Validate`. The validation splits exactly the way `FlagsIP` consumes the value, so anything that passes validation is guaranteed to produce real IPs in the cert SANs. `gofmt`, `go vet`, `go build`, the package tests, and the import-aliases check all pass.

**Does this PR introduce a user-facing change?**:

```release-note
`karmadactl`: Fixed the issue that `init` silently uses `127.0.0.1` when `--cert-external-ip` is set to an invalid value.
```

