### PR TITLE
test: add unit tests for sortServicePortStatus and sortServiceLoadBalancerIngress

### DIFF
--- a/pkg/util/helper/service_test.go
+++ b/pkg/util/helper/service_test.go
@@ -174,3 +174,172 @@ func TestDedupeAndSortServiceLoadBalancerIngress(t *testing.T) {
 		})
 	}
 }
+func TestSortServicePortStatus(t *testing.T) {
+	errA := new(string)
+	*errA = "error-a"
+	errB := new(string)
+	*errB = "error-b"
+
+	tests := []struct {
+		name  string
+		ports []corev1.PortStatus
+		want  []corev1.PortStatus
+	}{
+		{
+			name: "sort by port number ascending",
+			ports: []corev1.PortStatus{
+				{Port: 443, Protocol: corev1.ProtocolTCP},
+				{Port: 80, Protocol: corev1.ProtocolTCP},
+			},
+			want: []corev1.PortStatus{
+				{Port: 80, Protocol: corev1.ProtocolTCP},
+				{Port: 443, Protocol: corev1.ProtocolTCP},
+			},
+		},
+		{
+			name: "same port, sort by protocol",
+			ports: []corev1.PortStatus{
+				{Port: 80, Protocol: corev1.ProtocolUDP},
+				{Port: 80, Protocol: corev1.ProtocolTCP},
+			},
+			want: []corev1.PortStatus{
+				{Port: 80, Protocol: corev1.ProtocolTCP},
+				{Port: 80, Protocol: corev1.ProtocolUDP},
+			},
+		},
+		{
+			name: "same port and protocol, nil error sorts before non-nil",
+			ports: []corev1.PortStatus{
+				{Port: 80, Protocol: corev1.ProtocolTCP, Error: errA},
+				{Port: 80, Protocol: corev1.ProtocolTCP},
+			},
+			want: []corev1.PortStatus{
+				{Port: 80, Protocol: corev1.ProtocolTCP},
+				{Port: 80, Protocol: corev1.ProtocolTCP, Error: errA},
+			},
+		},
+		{
+			name: "same port and protocol, both non-nil error sorts by error string",
+			ports: []corev1.PortStatus{
+				{Port: 80, Protocol: corev1.ProtocolTCP, Error: errB},
+				{Port: 80, Protocol: corev1.ProtocolTCP, Error: errA},
+			},
+			want: []corev1.PortStatus{
+				{Port: 80, Protocol: corev1.ProtocolTCP, Error: errA},
+				{Port: 80, Protocol: corev1.ProtocolTCP, Error: errB},
+			},
+		},
+		{
+			name:  "empty slice",
+			ports: []corev1.PortStatus{},
+			want:  []corev1.PortStatus{},
+		},
+		{
+			name: "single element unchanged",
+			ports: []corev1.PortStatus{
+				{Port: 80, Protocol: corev1.ProtocolTCP},
+			},
+			want: []corev1.PortStatus{
+				{Port: 80, Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortServicePortStatus(tt.ports)
+			assert.Equal(t, tt.want, tt.ports)
+		})
+	}
+}
+
+func TestSortServiceLoadBalancerIngress(t *testing.T) {
+	proxyMode := corev1.LoadBalancerIPModeProxy
+	vipMode := corev1.LoadBalancerIPModeVIP
+
+	tests := []struct {
+		name      string
+		ingresses []corev1.LoadBalancerIngress
+		want      []corev1.LoadBalancerIngress
+	}{
+		{
+			name: "sort by hostname ascending",
+			ingresses: []corev1.LoadBalancerIngress{
+				{Hostname: "beta.example.com"},
+				{Hostname: "alpha.example.com"},
+			},
+			want: []corev1.LoadBalancerIngress{
+				{Hostname: "alpha.example.com"},
+				{Hostname: "beta.example.com"},
+			},
+		},
+		{
+			name: "hostname sorts before ip",
+			ingresses: []corev1.LoadBalancerIngress{
+				{IP: "1.1.1.1"},
+				{Hostname: "alpha.example.com"},
+			},
+			want: []corev1.LoadBalancerIngress{
+				{Hostname: "alpha.example.com"},
+				{IP: "1.1.1.1"},
+			},
+		},
+		{
+			name: "sort by ip ascending when no hostname",
+			ingresses: []corev1.LoadBalancerIngress{
+				{IP: "2.2.2.2"},
+				{IP: "1.1.1.1"},
+			},
+			want: []corev1.LoadBalancerIngress{
+				{IP: "1.1.1.1"},
+				{IP: "2.2.2.2"},
+			},
+		},
+		{
+			name: "same hostname and ip, non-nil ipmode sorts before nil",
+			ingresses: []corev1.LoadBalancerIngress{
+				{IP: "1.1.1.1"},
+				{IP: "1.1.1.1", IPMode: &vipMode},
+			},
+			want: []corev1.LoadBalancerIngress{
+				{IP: "1.1.1.1", IPMode: &vipMode},
+				{IP: "1.1.1.1"},
+			},
+		},
+		{
+			name: "same hostname and ip, sort by ipmode string",
+			ingresses: []corev1.LoadBalancerIngress{
+				{IP: "1.1.1.1", IPMode: &vipMode},
+				{IP: "1.1.1.1", IPMode: &proxyMode},
+			},
+			want: []corev1.LoadBalancerIngress{
+				{IP: "1.1.1.1", IPMode: &proxyMode},
+				{IP: "1.1.1.1", IPMode: &vipMode},
+			},
+		},
+		{
+			name:      "empty slice",
+			ingresses: []corev1.LoadBalancerIngress{},
+			want:      []corev1.LoadBalancerIngress{},
+		},
+		{
+			name: "single element unchanged",
+			ingresses: []corev1.LoadBalancerIngress{
+				{Hostname: "alpha.example.com"},
+			},
+			want: []corev1.LoadBalancerIngress{
+				{Hostname: "alpha.example.com"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for range 1000 { // eliminate randomness in sorting
+				sortServiceLoadBalancerIngress(tt.ingresses)
+				pass := assert.Equalf(t, tt.want, tt.ingresses, "sortServiceLoadBalancerIngress(%v)", tt.ingresses)
+				if !pass {
+					break
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it:**
Add unit tests for unexported helper functions in `pkg/util/helper/service.go` that lacked test coverage:
- `sortServicePortStatus`
- `sortServiceLoadBalancerIngress`

**Which issue(s) this PR fixes:**
Fixes: #7657 

**Special notes for your reviewer:**
All existing tests pass with the new additions:
ok github.com/karmada-io/karmada/pkg/util/helper

**Does this PR introduce a user-facing change?:**
NONE