### PR TITLE
[Proposal]: Preserve Available Replicas in WorkloadRebalancer

### DIFF
--- a/docs/proposals/scheduling/ extend-workload-rebalancer/README.md
+++ b/docs/proposals/scheduling/ extend-workload-rebalancer/README.md
@@ -1,0 +1,720 @@
+---
+title: Extend WorkloadRebalancer with Strategy-based Rebalancing
+authors:
+  - "@zhy76"
+reviewers:
+  - TBD
+approvers:
+  - TBD
+
+creation-date: 2026-06-23
+---
+
+# Extend WorkloadRebalancer with Strategy-based Rebalancing
+
+## Summary
+
+In a multi-cluster environment, workload distribution may gradually drift away from the desired state as clusters recover
+from failures, capacity changes, new clusters are added, workloads scale out, or member cluster utilization changes. Karmada
+needs a set of composable rescheduling primitives that users or operation systems can invoke in different rebalancing
+scenarios.
+
+This proposal extends `WorkloadRebalancer` from a single "trigger Fresh scheduling" API into a strategy-based rebalancing
+execution framework. This proposal uses `Deployment` as the main example and defines several explicitly invokable
+primitives: full rescheduling, preserving ready replicas while rescheduling only the unavailable part, and a
+source-preserving safe migration framework.
+
+This proposal does not design automatic rebalancing decisions or cluster waterline algorithms. In this proposal,
+`WorkloadRebalancer` is only an execution-layer primitive: it receives an already selected workload and strategy, performs
+the corresponding rescheduling action, and records status.
+
+## Background
+
+Rescheduling is a broader problem. Typical scenarios include:
+
+- After a cluster recovers, users may want workloads to move back from temporary failover clusters.
+- Some member clusters may have insufficient resources or long-running pending replicas. Users may want to move only the
+  part that cannot run, without disturbing replicas that are already ready.
+- Some member clusters may stay highly utilized while other member clusters still have spare capacity. Users may want to
+  move selected workloads from high-waterline clusters to low-waterline clusters to improve resource distribution and future
+  scale-out capacity.
+- After a new cluster is added or an existing cluster is expanded, users may want workloads to use the new capacity.
+- During planned maintenance, cluster scale-in, or cross-cluster migration, users may want to bring up the target side
+  before reducing the source side.
+
+Karmada already supports active workload rebalance through `WorkloadRebalancer`. The existing behavior is close to a
+"Fresh schedule" command: the controller updates `ResourceBinding` or `ClusterResourceBinding`, and then the scheduler
+recomputes the assignment without preserving the previous distribution.
+
+This is a useful primitive, but production rescheduling often needs more than one execution behavior:
+
+- Some workloads only need to move unavailable replicas, while ready replicas should stay in their current member clusters.
+- Some workloads need source-preserving migration, where source replicas keep serving until target replicas are available.
+- Different workload types may need different safety checks, but they should still reuse the same rebalance API, status,
+  TTL, retry, and cancellation model.
+
+This proposal keeps `WorkloadRebalancer` as the user-facing entry point and adds a strategy layer under it.
+
+Therefore, the goal of this proposal is not to complete a full automatic rescheduling system, but to first provide the
+missing execution-layer primitives.
+
+## Motivation
+
+The existing `WorkloadRebalancer` can trigger Fresh scheduling by updating `ResourceBinding.spec.rescheduleTriggeredAt`.
+This is useful when users want Karmada to discard the old distribution and compute a new one.
+
+Beyond failure recovery, rescheduling is also an important way to improve multi-cluster resource efficiency. When some
+workloads stay in high-waterline member clusters while other eligible clusters still have spare capacity, the federation may
+see pending replicas, imbalanced utilization, and blocked scale-out. Therefore, Karmada needs reusable rescheduling
+primitives that users or higher-level systems can use to improve workload distribution across member clusters.
+
+However, not every rebalance should immediately discard the old distribution. For example, a propagated `Deployment` may
+already have ready replicas in `member1`, and only the unavailable replicas need to be rescheduled to other clusters. In
+another case, users may want to move replicas from `member1` to `member2`, while `member1` must continue serving until the
+target replicas become available.
+
+### Goals
+
+- Add an explicit strategy field to `WorkloadRebalancer`.
+- Keep the existing Fresh scheduling behavior as a strategy mode.
+- Add a `PreserveReady` mode for `Deployment`: keep ready replicas in their current member clusters and reschedule only the
+  unavailable part.
+- Define a safe migration strategy framework so source replicas can be preserved until target replicas become available.
+- Keep the common controller simple and allow new workload-specific rescheduling strategies to be added through executors.
+
+### Non-Goals
+
+- Do not design automatic rescheduling decisions or cluster waterline algorithms.
+- Do not define application-specific readiness, traffic switching, or data loading semantics.
+
+## Proposal
+
+Add `spec.strategy` to `WorkloadRebalancer`. The strategy describes how a selected workload should be rebalanced. This
+proposal defines two strategy families:
+
+| Strategy | Purpose |
+| --- | --- |
+| `Reschedule` | Re-enter Karmada scheduling. It can either recompute the whole assignment or preserve ready replicas and reschedule only the unavailable part. |
+| `SafeMigration` | Move replicas from one member cluster to another while preserving source replicas until the target side is available. |
+
+This proposal intentionally only defines these atomic execution capabilities. It does not define workload selection, target
+cluster selection, or execution frequency control. Users or platforms can build scenario-specific rescheduling systems on
+top of these primitives later.
+
+### User Stories
+
+#### Story 1: Full rebalance after cluster recovery
+
+A `Deployment` was moved away from `member1` during failover. After `member1` recovers, an administrator wants Karmada to
+recompute placement and use all eligible clusters again.
+
+The user creates a `WorkloadRebalancer` with `strategy.type=Reschedule` and `mode=Full`. This mode keeps the current
+`WorkloadRebalancer` behavior.
+
+#### Story 2: Preserve ready replicas and reschedule unavailable replicas
+
+A `Deployment` has 10 replicas distributed across two clusters. `member1` is assigned 6 replicas but only 4 are ready.
+`member2` is assigned 4 replicas and all are ready. The user wants to keep these 8 ready replicas and only reschedule the
+2 unavailable replicas.
+
+Example:
+
+```yaml
+apiVersion: apps.karmada.io/v1alpha1
+kind: WorkloadRebalancer
+metadata:
+  name: demo-deployment-preserve-ready
+spec:
+  workloads:
+    - apiVersion: apps/v1
+      kind: Deployment
+      namespace: default
+      name: nginx
+  strategy:
+    type: Reschedule
+    args:
+      mode: PreserveReady
+```
+
+For a 10-replica `Deployment`:
+
+| Cluster | Current assigned replicas | Ready | `PreserveReady` action |
+| --- | ---: | ---: | --- |
+| member1 | 6 | 4 | Keep 4 ready replicas and release 2 unavailable replicas. |
+| member2 | 4 | 4 | Keep 4 ready replicas. |
+
+The executor updates the binding so existing ready replicas keep their assignments. The scheduler then places the released
+replicas according to the current placement and cluster state.
+
+#### Story 3: Safely migrate from one member cluster to another
+
+A `Deployment` is currently distributed across multiple member clusters:
+
+| Cluster | Assigned replicas |
+| --- | ---: |
+| member1 | 5 |
+| member2 | 3 |
+| member3 | 2 |
+
+The user wants to move the replicas on `member1` to `member4`, while keeping `member2` and `member3` unchanged. The user
+creates a `SafeMigration` from `member1` to `member4`. The target side is brought up first, and the source side is reduced
+only after the target side becomes available.
+
+This strategy framework can express it as:
+
+```yaml
+strategy:
+  type: SafeMigration
+  args:
+    from: member1
+    to: member4
+    stableWindow: 60s
+    maxInFlightUnits: 1
+    noProgressTimeout: 1h
+```
+
+For `Deployment`, `from` and `to` represent one source member cluster and one target member cluster. Other clusters in the
+same binding are not affected by this `WorkloadRebalancer`.
+
+## Design Details
+
+### Overall Architecture
+
+`WorkloadRebalancer` remains the rescheduling command submitted by a user or higher-level system. The controller does not
+decide which workload should be moved or where it should be moved. It only executes the primitive action declared by
+`spec.strategy`.
+
+```mermaid
+flowchart LR
+  User["User / Automation"] --> WR["WorkloadRebalancer"]
+  WR --> C["WorkloadRebalancer Controller"]
+  C --> R["Reschedule Executor"]
+  C --> M["SafeMigration Executor"]
+  M --> U["Workload-specific Unit Executor"]
+  R --> RB["ResourceBinding / ClusterResourceBinding"]
+  U --> RB
+  RB --> S["karmada-scheduler"]
+  S --> RB
+  RB --> BC["binding-controller"]
+  BC --> W["Work"]
+  W --> Member["Member Cluster Workload"]
+  Member --> Status["Aggregated Status"]
+  Status --> C
+  C --> WRStatus["WorkloadRebalancer Status"]
+```
+
+Key boundaries:
+
+- `User / Automation`: decides whether to create a `WorkloadRebalancer`.
+- `WorkloadRebalancer Controller`: owns task lifecycle, status, retry, cancellation, TTL, and executor dispatch.
+- `Executor`: performs strategy-specific actions, such as patching bindings, waiting for target readiness, and judging
+  progress.
+- `Workload-specific Unit Executor`: splits `SafeMigration` into independently movable units and defines target-ready,
+  source-commit, and cancel semantics for that workload type. Different workloads may use different migration granularity,
+  such as replica batches, shards, partitions, or workload-owned subresources.
+- `karmada-scheduler`: still only computes scheduling results from bindings and placement. It does not run long-running
+  migration transactions.
+
+### API Changes
+
+Add the following fields to `WorkloadRebalancerSpec`:
+
+| Field | Strategy | Meaning |
+| --- | --- | --- |
+| `spec.cancel` | Common | Requests cancellation for an ongoing rebalance. |
+| `spec.ttlSecondsAfterFinished` | Common | Automatically cleans up only when all workloads finish successfully; failed, canceled, or no-progress-timeout objects are kept for troubleshooting. |
+| `strategy.type` | Common | Required. Strategy name. Valid values are `Reschedule` and `SafeMigration`. |
+| `strategy.args` | Common | Strategy parameters decoded and validated by the selected executor. |
+| `strategy.args.mode` | `Reschedule` | Rescheduling mode. Valid values are `Full` and `PreserveReady`; default is `PreserveReady` when unspecified, and `Full` must be specified explicitly. |
+| `strategy.args.from` | `SafeMigration` | Source member cluster for source-preserving migration. |
+| `strategy.args.to` | `SafeMigration` | Target member cluster for source-preserving migration. |
+| `strategy.args.stableWindow` | `SafeMigration` | Continuous stable time required after the target side satisfies readiness gates. It uses duration strings such as `60s`, `3m`, or `2h`. |
+| `strategy.args.maxInFlightUnits` | `SafeMigration` | Maximum number of migration units that can be progressed at the same time for one workload. For `Deployment`, this can represent concurrently migrated replica batches; for other workloads, the corresponding executor defines the unit. |
+| `strategy.args.noProgressTimeout` | Common | Applies to `Reschedule/PreserveReady` and `SafeMigration`. If no observable progress happens for this duration, the workload finishes with `NoProgressTimeout`. |
+
+API changes:
+
+```go
+type WorkloadRebalancerSpec struct {
+    // Workloads specifies workloads to rebalance.
+    Workloads []ObjectReference `json:"workloads"`
+
+    // Cancel requests cancellation for running workloads.
+    Cancel bool `json:"cancel,omitempty"`
+
+    // Strategy describes how the selected workloads should be rebalanced.
+    // It must be specified for the strategy-based rebalance semantics proposed here.
+    Strategy RebalanceStrategy `json:"strategy"`
+
+    // TTLSecondsAfterFinished limits successful finished WorkloadRebalancers.
+    // Failed, canceled, or no-progress-timeout objects should be kept for troubleshooting.
+    TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
+}
+
+type RebalanceStrategy struct {
+    // Type selects the executor.
+    // Valid values: Reschedule, SafeMigration.
+    Type RebalanceStrategyType `json:"type"`
+
+    // Args is decoded and validated by the selected executor.
+    Args runtime.RawExtension `json:"args,omitempty"`
+}
+```
+
+Example:
+
+```yaml
+apiVersion: apps.karmada.io/v1alpha1
+kind: WorkloadRebalancer
+metadata:
+  name: demo-deployment-migration
+spec:
+  workloads:
+    - apiVersion: apps/v1
+      kind: Deployment
+      namespace: default
+      name: nginx
+  cancel: false
+  ttlSecondsAfterFinished: 3600
+  strategy:
+    type: SafeMigration
+    args:
+      from: member-a
+      to: member-b
+      stableWindow: 3m
+      maxInFlightUnits: 1
+      noProgressTimeout: 1h
+```
+
+`Full` mode keeps the current `WorkloadRebalancer` behavior: update `ResourceBinding` or `ClusterResourceBinding`
+`spec.rescheduleTriggeredAt`, and then let the scheduler perform Fresh scheduling.
+
+`PreserveReady` mode reads ready replicas from binding aggregated status, sets each cluster's assigned replicas to its ready
+replica count, and lets the scheduler place the remaining replicas. If ready information cannot be observed, the workload
+fails with an explicit reason instead of falling back to full rescheduling.
+
+`SafeMigration` is source-preserving migration. For `Deployment`, a migration unit can be a replica batch moving from
+`from` to `to`. The executor first opens the target side for a unit, waits until the target unit stays available for
+`stableWindow`, and then commits the corresponding source unit. Concurrency is controlled by `maxInFlightUnits`, and
+stuck progress is detected by `noProgressTimeout`.
+
+`SafeMigration` has the following constraints:
+
+| Constraint | Description |
+| --- | --- |
+| `from` / `to` must be determined before the WR controller executes. | Missing `from` or `to` is treated as `InvalidStrategyArgs`. |
+| `from` / `to` cannot be changed after entering `Running`. | This avoids target drift during execution, which would make source/target object state hard to recover. |
+| Workload spec cannot be changed during migration. | This avoids changes to the unit list, replica count, placement, or readiness semantics while the executor is deciding which units have migrated or need rollback. |
+
+### Controller Framework
+
+The `WorkloadRebalancer` controller dispatches each observed workload to the corresponding executor based on
+`spec.strategy.type`.
+
+```text
+WorkloadRebalancer
+        |
+        v
+WorkloadRebalancer controller
+        |
+        +--> Reschedule executor
+        |       +--> Full
+        |       +--> PreserveReady
+        |
+        +--> SafeMigration executor
+                +--> workload-specific unit executor
+```
+
+The controller owns common lifecycle handling: workload lookup, status updates, retry, cancellation, timeout, and TTL after
+finished. Executors own strategy-specific binding changes and progress judgment.
+
+The main controller logic is:
+
+```go
+type StrategyExecutor interface {
+    // Reconcile advances one observed workload according to the selected strategy.
+    Reconcile(ctx context.Context, req StrategyRequest) (StrategyResult, error)
+}
+
+type StrategyRequest struct {
+    Rebalancer *WorkloadRebalancer
+    Observed   ObservedWorkload
+    Now        time.Time
+}
+
+type StrategyResult struct {
+    Observed     ObservedWorkload
+    RequeueAfter time.Duration
+}
+
+func (c *Controller) reconcile(ctx context.Context, name string) error {
+    wr := c.getWorkloadRebalancer(ctx, name)
+
+    // Ensure status.observedWorkloads matches spec.workloads.
+    observed := c.syncObservedWorkloads(wr.Spec.Workloads, wr.Status.ObservedWorkloads)
+
+    executor := c.executors[wr.Spec.Strategy.Type]
+    if executor == nil {
+        return c.markAllFailed(wr, observed, "UnsupportedStrategy")
+    }
+
+    var nextRequeue time.Duration
+    for i := range observed {
+        if observed[i].Result != "" {
+            continue
+        }
+
+        result, err := executor.Reconcile(ctx, StrategyRequest{
+            Rebalancer: wr,
+            Observed:   observed[i],
+            Now:        c.clock.Now(),
+        })
+        if err != nil {
+            return err
+        }
+
+        observed[i] = result.Observed
+        nextRequeue = minNonZero(nextRequeue, result.RequeueAfter)
+    }
+
+    c.patchStatus(ctx, wr, observed)
+
+    if allObservedWorkloadsFinished(observed) {
+        c.markFinishTime(ctx, wr)
+        return nil
+    }
+    return c.requeueAfter(name, nextRequeue)
+}
+```
+
+This main flow only handles common task state. It does not understand workload-specific semantics. How `PreserveReady`
+calculates ready deltas and how `SafeMigration` judges target availability are implemented by the corresponding executors.
+
+`SafeMigration` also needs a workload-specific unit executor. Safe migration is not a single patch action; it is a
+long-running transaction that opens target units, waits for readiness, and commits source units one by one. Different
+workloads may use different migration granularity. For `Deployment`, a unit can be a replica batch; for custom workloads, a
+unit can be a shard, partition, or subresource owned by that workload.
+
+The common controller does not need to understand these business units. It only requires the unit executor to answer four
+questions reliably:
+
+| Question | Purpose |
+| --- | --- |
+| What units belong to this migration? | Used to calculate `totalUnits` and avoid losing progress after controller restart. |
+| Which units have been committed? | Used to calculate `completedUnits`. |
+| Which units are waiting for readiness on the target side? | Used to enforce `maxInFlightUnits` and evaluate `stableWindow`. |
+| How should cancellation restore a safe state? | Used to enter `Canceling` after `spec.cancel=true` and eventually finish. |
+
+The suggested internal interface is below. It is an executor-internal contract and is not part of the `WorkloadRebalancer`
+API:
+
+```go
+type SafeMigrationExecutor struct {
+    UnitExecutors []SafeMigrationUnitExecutor
+}
+
+type SafeMigrationUnitExecutor interface {
+    // Match returns whether this executor can handle the workload under current args.
+    // The SafeMigration executor must ensure exactly one unit executor matches.
+    Match(ctx context.Context, req StrategyRequest) (bool, error)
+
+    // ListUnits reconstructs units from real Karmada/member objects on every reconcile.
+    // It must not depend on in-memory state.
+    ListUnits(ctx context.Context, req StrategyRequest) ([]MigrationUnit, error)
+
+    // EnsureTarget opens or keeps the target side for one unit.
+    EnsureTarget(ctx context.Context, req StrategyRequest, unit MigrationUnit) error
+
+    // CommitSource closes or reduces the source side after target ready and stable.
+    CommitSource(ctx context.Context, req StrategyRequest, unit MigrationUnit) error
+
+    // Cancel restores the workload to a safe state after spec.cancel=true.
+    // It returns true when cancellation has fully converged.
+    Cancel(ctx context.Context, req StrategyRequest) (bool, error)
+}
+
+type MigrationUnit struct {
+    // ID is stable across reconciliations and is used to identify the same unit after controller restart.
+    ID     string
+
+    // Ref is a human-readable reference for events and troubleshooting.
+    Ref    string
+
+    // Source and Target describe desired and observed states on both sides.
+    Source MigrationUnitState
+    Target MigrationUnitState
+
+    // Reason explains why this unit cannot progress or has failed.
+    Reason string
+}
+
+type MigrationUnitState struct {
+    // DesiredOpen means the executor expects this side to serve or hold the unit.
+    DesiredOpen bool
+
+    // ObservedOpen means the side is actually observed to hold the unit.
+    ObservedOpen bool
+
+    // Ready means the unit satisfies the workload-specific readiness gate on this side.
+    Ready bool
+
+    // ReadySince records when Ready became continuously true for stableWindow.
+    ReadySince *metav1.Time
+}
+```
+
+`MigrationUnit` is not fully persisted in status. On every reconcile, the executor reconstructs unit state from real objects
+and then writes aggregate progress:
+
+```text
+totalUnits = len(units)
+completedUnits = count(unit.Source.ObservedOpen == false &&
+                       unit.Target.ObservedOpen == true &&
+                       unit.Target.Ready == true)
+inFlightUnits = count(unit not completed &&
+                      (unit.Target.DesiredOpen || unit.Target.ObservedOpen))
+notStartedUnits = units - completedUnits - inFlightUnits
+```
+
+Here, `notStartedUnits` only means units whose migration has not started. It is not the Kubernetes Pod `Pending` phase. The
+relationship between these values is:
+
+- `totalUnits`: all units in this migration plan.
+- `completedUnits`: units that have been committed. The source side no longer holds them, and the target side holds them and
+  is ready.
+- `inFlightUnits`: units that are being migrated. The target side has been opened or is being opened, but source commit has
+  not finished.
+- `notStartedUnits`: units whose target side has not been opened yet. They can be progressed only when `maxInFlightUnits`
+  has free slots.
+
+This avoids relying on in-memory state after controller restart and avoids creating two sources of truth between `phase` and
+the actual object state.
+
+### Execution Flow
+
+Overall execution flow:
+
+```mermaid
+flowchart TD
+  A["Create / update WorkloadRebalancer"] --> B["Sync observedWorkloads"]
+  B --> Cancel{"spec.cancel?"}
+  Cancel -->|yes| X["Enter Canceling"]
+  Cancel -->|no| C{"strategy.type"}
+  C -->|Reschedule| D{"mode"}
+  D -->|Full| E["Write rescheduleTriggeredAt"]
+  D -->|PreserveReady| F["Patch binding to ready replicas"]
+  C -->|SafeMigration| G["Select unit executor"]
+  G --> G1["Open target units"]
+  E --> H["Wait scheduler / binding status"]
+  F --> H
+  G1 --> I["Wait target available and stable"]
+  I --> J["Commit source units"]
+  J --> H
+  H --> K{"finished?"}
+  K -->|yes| L["Update WR result"]
+  K -->|no| M["Requeue"]
+  X --> N{"SafeMigration?"}
+  N -->|yes| N1["Rollback to source first<br/>then clean target side"]
+  N -->|no| N2["Stop executor actions"]
+  N1 --> L
+  N2 --> L
+```
+
+#### `Reschedule/Full`
+
+1. Locate the `ResourceBinding` or `ClusterResourceBinding` for the referenced workload.
+2. Write `spec.rescheduleTriggeredAt`.
+3. Wait for the scheduler to complete and update binding status.
+4. Mark the observed workload `Successful` or `Failed`.
+
+The progress of `Full` only means whether the rescheduling action has completed. It does not mean the workload is ready:
+
+```text
+totalUnits = 1
+completedUnits = 0  // rescheduleTriggeredAt has been written, but the scheduler has not finished this schedule.
+completedUnits = 1  // binding.status.lastScheduledTime >= binding.spec.rescheduleTriggeredAt
+```
+
+#### `Reschedule/PreserveReady`
+
+1. Locate the binding for the referenced workload.
+2. Read current assigned replicas from `spec.clusters`.
+3. Read ready replicas from aggregated status.
+4. Set each cluster's assigned replicas to that cluster's ready replicas.
+5. Let the scheduler place the released unavailable replicas.
+6. Mark `Successful` after the unavailable part is scheduled and becomes ready.
+
+If ready replicas cannot be observed, this mode fails closed and does not fall back to `Full`.
+
+The progress of `PreserveReady` comes from ready delta recovery:
+
+```text
+desiredReplicas = workload desired replicas
+readyBefore = sum(ready replicas from binding aggregated status before patch)
+readyNow = sum(ready replicas from current binding aggregated status)
+
+totalUnits = desiredReplicas - readyBefore
+completedUnits = min(totalUnits, max(0, readyNow - readyBefore))
+```
+
+Therefore, `PreserveReady` can show how many released unavailable replicas have become ready again. It does not track
+individual Pods; it only relies on workload ready replicas in binding aggregated status.
+
+#### `SafeMigration`
+
+1. Validate `from`, `to`, and the referenced binding.
+2. Select exactly one matching workload-specific unit executor.
+3. The unit executor reconstructs the unit list from real objects and computes `totalUnits`, `completedUnits`, and
+   `inFlightUnits`.
+4. Within `maxInFlightUnits`, select units from `notStartedUnits` and open their target side.
+5. Wait for the target-side units to become available and satisfy `stableWindow`.
+6. Commit source-side cleanup or scale-down for stable units, then reconstruct unit state again and update progress.
+7. After all units are committed and the binding, Work objects, and aggregated status converge, mark the workload
+   `Successful`.
+
+If the target side does not become available, the source side is not reduced.
+
+### Status
+
+`status` continues to use the existing `observedWorkloads` array. Each workload shows its own phase, result, reason, and
+progress.
+
+| Field | Meaning |
+| --- | --- |
+| `status.observedGeneration` | The generation processed by the controller. |
+| `status.finishTime` | Time when all observed workloads entered a terminal state. |
+| `status.observedWorkloads[].workload` | The workload represented by this status entry. |
+| `status.observedWorkloads[].phase` | Current execution phase. Valid values are `Pending`, `Running`, `Canceling`, and `Completed`. |
+| `status.observedWorkloads[].result` | Filled only when `phase=Completed`. Valid values are `Successful` and `Failed`. |
+| `status.observedWorkloads[].reason` | Failure or cancellation reason. |
+| `status.observedWorkloads[].progress.totalUnits` | Total execution units. Unit meaning is strategy-defined: for `SafeMigration`, it can be replica batches or workload-specific units; for `Reschedule/PreserveReady`, it is the pending/unready replica delta that needs to be rescheduled and become ready; for `Reschedule/Full`, it is `1` scheduler rescheduling action. |
+| `status.observedWorkloads[].progress.completedUnits` | Completed execution units, in the same unit as `totalUnits`. |
+| `status.observedWorkloads[].progress.lastProgressTime` | Last time when observable progress happened. `noProgressTimeout` is calculated from this timestamp, and the controller can continue this judgment after restart. |
+
+Example 1: `SafeMigration` is running.
+
+```yaml
+status:
+  observedGeneration: 2
+  observedWorkloads:
+    - workload:
+        apiVersion: apps/v1
+        kind: Deployment
+        namespace: default
+        name: nginx
+      phase: Running
+      result: ""
+      reason: ""
+      progress:
+        totalUnits: 10
+        completedUnits: 4
+        lastProgressTime: "2026-06-17T09:30:00Z"
+```
+
+Example 2: `Reschedule/PreserveReady` has completed successfully. Two unavailable replicas were released and became ready
+again.
+
+```yaml
+status:
+  observedGeneration: 1
+  finishTime: "2026-06-17T10:00:00Z"
+  observedWorkloads:
+    - workload:
+        apiVersion: apps/v1
+        kind: Deployment
+        namespace: default
+        name: nginx
+      phase: Completed
+      result: Successful
+      reason: ""
+      progress:
+        totalUnits: 2
+        completedUnits: 2
+```
+
+Example 3: execution failed.
+
+```yaml
+status:
+  observedGeneration: 2
+  finishTime: "2026-06-17T10:00:00Z"
+  observedWorkloads:
+    - workload:
+        apiVersion: apps/v1
+        kind: Deployment
+        namespace: default
+        name: nginx
+      phase: Completed
+      result: Failed
+      reason: NoProgressTimeout
+      progress:
+        totalUnits: 10
+        completedUnits: 4
+        lastProgressTime: "2026-06-17T09:30:00Z"
+```
+
+Phase and result semantics:
+
+| Phase | Result | Meaning |
+| --- | --- | --- |
+| `Pending` | Empty | The workload has been accepted and is being validated or waiting to execute. |
+| `Running` | Empty | Execution has started and may have modified RB/CRB/Work/member objects. |
+| `Canceling` | Empty | The user has set `spec.cancel=true`, and the controller is restoring modified scheduling objects to a safe state. |
+| `Completed` | `Successful` | Execution completed successfully. |
+| `Completed` | `Failed` | Execution failed, was canceled, or timed out with no progress. See `reason` for details. |
+
+State machine:
+
+```mermaid
+stateDiagram-v2
+  [*] --> Pending: controller observes workload
+
+  Pending --> Running: validation passed
+  Pending --> Completed: validation failed
+  Pending --> Canceling: spec.cancel=true
+
+  Running --> Completed: succeeded
+  Running --> Completed: failed / no progress timeout
+  Running --> Canceling: spec.cancel=true
+
+  Canceling --> Completed: safe state restored after source-first rollback
+  Completed --> [*]
+```
+
+`Completed` is the only terminal phase. Successful execution uses `result=Successful`; validation failure, execution
+failure, no progress timeout, and user cancellation use `result=Failed`, with the exact cause represented by `reason`.
+
+## Test Plan
+
+- Unit test that `Reschedule/Full` still updates `rescheduleTriggeredAt`.
+- Unit test that `Reschedule/PreserveReady` preserves ready replicas and releases only unavailable replicas.
+- Unit test missing binding, missing ready status, and unsupported workload type.
+- Unit test invalid args finishing as `Completed/Failed/InvalidStrategyArgs`.
+- Unit test no progress timeout finishing as `Completed/Failed/NoProgressTimeout`.
+- Integration test `Reschedule/Full`: create a propagated `Deployment`, trigger `Full`, verify that the binding re-enters
+  Fresh scheduling, and verify scheduling completion status.
+- Integration test `Reschedule/PreserveReady`: create a propagated `Deployment` with unavailable replicas in one member
+  cluster, verify that ready replicas are preserved and only the unavailable part is rescheduled.
+- Integration test `SafeMigration`: create a `Deployment` distributed across multiple member clusters, migrate from
+  `member1` to `member4`, verify that source replicas are not reduced before target replicas are ready and stable, and
+  verify that replicas in other member clusters remain unchanged.
+- Integration test `SafeMigration` cancel: set `spec.cancel=true` during migration, verify phase enters `Canceling`, and
+  after safe state is restored, it becomes `Completed/Failed/CanceledByUser`.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Users expect source preservation but accidentally trigger full rescheduling. | New behavior must explicitly specify `strategy.type` and `mode`. |
+| Ready status is stale or cannot be observed. | `PreserveReady` fails closed and does not fall back to `Full`. |
+| Workload spec changes during `SafeMigration`, making units and readiness judgment ambiguous. | Reject high-risk spec changes after entering `Running`; users must cancel or wait for migration completion. |
+| Too much strategy logic makes the controller hard to maintain. | Keep the controller generic and move strategy-specific behavior into executors. |
+
+## Alternatives
+
+- **Add another migration CRD**: rejected because `WorkloadRebalancer` is already the user-facing entry point for workload
+  rebalance.
+- **Use workload annotations**: rejected because annotations do not provide a clear task lifecycle, per-workload result, TTL
+  cleanup, or retry status.
+- **Put safe migration into scheduler**: rejected because the scheduler should compute placement, while migration is a
+  long-running execution process that depends on workload readiness.

--- a/docs/proposals/scheduling/extend-workload-rebalancer/README.md
+++ b/docs/proposals/scheduling/extend-workload-rebalancer/README.md
@@ -1,0 +1,508 @@
+---
+title: Preserve Available Replicas in WorkloadRebalancer
+authors:
+  - "@zhy76"
+reviewers:
+  - "@RainbowMango"
+approvers:
+  - "@RainbowMango"
+
+creation-date: 2026-06-23
+---
+
+# Preserve Available Replicas in WorkloadRebalancer
+
+## Summary
+
+[`WorkloadRebalancer`](../workload-rebalancer/workload-rebalancer.md) currently asks the scheduler to discard the previous
+assignment and perform a Fresh scheduling cycle for each selected workload. Fresh scheduling is appropriate when the
+entire placement should be reconsidered. When only part of a divided workload is unavailable, however, it may also reassign
+replicas that are already available.
+
+This proposal adds an optional `spec.reschedule.preserveAvailableReplicas` field. When enabled, the scheduler queries the
+number of long-term unschedulable Pods in each member cluster. If a cluster has `A` assigned replicas and `U` long-term
+unschedulable Pods, at least `A-U` replicas remain assigned to that cluster and only `U` replicas are rescheduled. Omitting
+`spec.reschedule` or setting the field to `false` retains the current Fresh scheduling semantics.
+
+The change keeps `WorkloadRebalancer` as a one-shot request created by a user or higher-level controller.
+
+## Motivation
+
+Karmada scheduling and Kubernetes Pod scheduling make decisions at different levels. The Karmada scheduler selects member
+clusters and records the replica distribution in a `ResourceBinding`. Execution controllers then create `Work` objects,
+and each member cluster's workload controller and scheduler create and place the Pods.
+
+```mermaid
+flowchart LR
+    U["User creates WorkloadRebalancer"] --> KS["Karmada scheduler selects member clusters"]
+    KS --> B["ResourceBinding records replica targets"]
+    B --> W["Execution controllers create Works"]
+    W --> C["Member workload controller creates Pods"]
+    C --> MS["Member scheduler selects nodes"]
+    MS --> R["Replicas become available or remain unavailable"]
+```
+
+Offline spot and GPU workloads may become only partially available after Karmada completes cluster-level replica
+assignment. Concurrent workloads, quota, taints, affinity, topology, device models, or per-node resource constraints in a
+member cluster can prevent the remaining Pods from running for a long time. Accelerator workloads are especially exposed:
+aggregate free capacity may look sufficient while no node has the required device type, topology, or quantity.
+
+This proposal addresses the semantics of an explicit rescheduling command. After a user or higher-level controller decides
+that a distribution should be recalculated, it creates a `WorkloadRebalancer`. The existing controller writes
+`spec.rescheduleTriggeredAt` to each target `ResourceBinding` or `ClusterResourceBinding`, after which the scheduler
+discards the previous assignment and recalculates the complete placement with Fresh scheduling. When only some replicas
+have remained unschedulable, the caller needs another explicit behavior: keep the other replicas in place and ask the
+existing scheduler to reassign only the confirmed unschedulable deficit.
+
+Workload status provides aggregate counts but cannot generically identify which Pods should be rescheduled. `GetComponents`
+therefore returns a Pod selector for each component, and the member-cluster `GetUnschedulableReplicas` call uses that
+selector to count long-term unschedulable Pods. A Pod contributes to the deficit only when `PodScheduled=False`, the reason
+is `Unschedulable`, and the condition has lasted longer than the configured threshold.
+
+`preserveAvailableReplicas` states the preservation guarantee; it does not mean that the deficit is calculated as
+`desired - available`. The request removes only replicas reported as long-term unschedulable. Every other assigned replica
+is preserved. Available replicas are therefore preserved, and replicas that are unready but not reported as long-term
+unschedulable are preserved as well.
+
+An explicit retry does not need to discard useful placement. If a 100-replica workload has 20 Pods that the estimator
+confirms as long-term unschedulable, the scheduling problem is to place those 20 replicas, not all 100. Reconsidering the
+other 80 can cause avoidable restarts, cache or model reloads, loss of in-flight work, and temporary capacity reduction.
+
+The guarantee applies to replica counts per member cluster, not Pod UIDs. The estimator inspects Pods but returns only a
+count, not a list of Pod names. The Karmada scheduler changes member-cluster replica targets; the workload controller in the
+member cluster still decides which concrete Pods to retain or remove.
+
+### Goals
+
+- Preserve the existing Fresh behavior for all current `WorkloadRebalancer` clients.
+- Let a user keep the existing placement except for replicas confirmed as long-term unschedulable by an estimator.
+- Extend interpreter component metadata with Pod selectors and pass those selectors to `GetUnschedulableReplicas`.
+- Continue to use the scheduling rules stored in `ResourceBinding.spec.placement` and the existing filtering, scoring, and
+  replica-allocation logic.
+- Fail closed when component selectors are missing or invalid, an estimator is unavailable, or an estimator result is
+  inconsistent with the current assignment.
+- Fail closed when an upgraded controller sends a new request to an older scheduler, and preserve the ordering of legacy
+  and new requests.
+
+### Non-Goals
+
+- Preserving individual Pod UIDs.
+
+## Proposal
+
+Add an optional `spec.reschedule` object to `WorkloadRebalancer`, with independent fields for composable rescheduling
+behaviors:
+
+| `spec.reschedule` | Previous assignment | Scheduling work |
+| --- | --- | --- |
+| omitted, or `preserveAvailableReplicas: false` | Discarded as it is today | Recalculate all desired replicas with Fresh scheduling |
+| `preserveAvailableReplicas: true` | All replicas except estimator-confirmed long-term unschedulable replicas remain in their current clusters | Reassign only the confirmed unschedulable deficit |
+
+The preserve behavior reuses the existing dynamic scale-up path rather than introducing another placement algorithm. The
+scheduler creates a temporary copy of the binding specification, replaces its per-cluster replica counts with the preserved
+baseline, keeps the total desired replicas unchanged, and lets `dynamicScaleUp` fill the resulting deficit. The temporary
+baseline is never written to the API; only a complete final assignment can replace the current `spec.clusters`.
+
+`RescheduleBehavior` is a struct rather than an enum that allows only one value. This proposal defines only the
+`preserveAvailableReplicas` boolean. Future independent behaviors can add fields without changing this field's meaning.
+One `WorkloadRebalancer` represents one request; users create a new object for another scheduling attempt. If multiple
+requests target the same `ResourceBinding`, only the request with the latest trigger is processed.
+
+The scheduler uses the scheduling rules stored in `ResourceBinding.spec.placement`; it does not read the current
+`PropagationPolicy` or `ClusterPropagationPolicy` again during this request. If a policy change has not yet updated the
+`ResourceBinding`, the request still follows the rules currently stored in that `ResourceBinding`.
+
+### User Stories
+
+#### Reassign only long-term unschedulable replicas
+
+A 10-replica Deployment has the following assignment and estimator result:
+
+| Cluster | Assigned | Long-term unschedulable | Preserved |
+| --- | ---: | ---: | ---: |
+| `member1` | 6 | 2 | 4 |
+| `member2` | 4 | 0 | 4 |
+
+The user creates a `WorkloadRebalancer` with `spec.reschedule.preserveAvailableReplicas: true`. The scheduler keeps four
+replicas in each existing cluster and assigns only the two replicas confirmed as unschedulable. If `member3` is eligible
+and has sufficient capacity, one possible result is:
+
+```text
+member1=4, member2=4, member3=2
+```
+
+The destination of the two replicas is still determined by `ResourceBinding.spec.placement` and the current scheduling
+cycle.
+
+#### Reuse newly available accelerator capacity
+
+A divided 100-replica Deployment represents offline accelerator workers:
+
+| Cluster | Assigned | Long-term unschedulable | Preserved |
+| --- | ---: | ---: | ---: |
+| `gpu-a` | 60 | 40 | 20 |
+| `gpu-b` | 10 | 0 | 10 |
+| `gpu-c` | 30 | 0 | 30 |
+
+As time-shared capacity is released overnight, eligible capacity becomes available in `gpu-d`. A preserve-available
+request keeps the 60 replicas not selected by the estimator in place and asks the scheduler to place only the 40
+long-term unschedulable replicas. If no eligible cluster can place all 40, the request is reported as unschedulable and
+the previous assignment remains unchanged.
+
+### Supported Workloads and Preconditions
+
+The mechanism is not specific to Deployment. A namespaced workload can use it when its interpreter implements
+`GetComponents` and returns a selector that identifies its Pods. The first implementation accepts
+`preserveAvailableReplicas: true` only when all of the following are true:
+
+- the target is referenced by a `ResourceBinding`, and `GetComponents` returns exactly one component with a valid Pod
+  selector whose replica count maps one-to-one to the workload replicas;
+- the active binding placement uses dynamic divided replica scheduling (`Aggregated`, or `Weighted` with dynamic weights);
+- initial scheduling has completed, the current assignment sums to the workload's desired replicas, and no graceful
+  eviction task is active;
+- the placement stored in `spec.placement` matches the placement recorded as applied by the scheduler; and
+- an estimator that supports `GetUnschedulableReplicas` is available for every currently assigned cluster.
+
+These checks avoid combining preserve-available rescheduling with an unfinished scale operation, a concurrent placement
+change, or another eviction workflow. Complete requests with an omitted `spec.reschedule` or
+`preserveAvailableReplicas: false` remain valid for all workload types supported today.
+
+### Relationship to Karmada Descheduler
+
+The [Karmada descheduler](../697-descheduler/README.md) periodically asks scheduler estimators for long-lived
+unschedulable replicas, reduces the affected per-cluster targets, and lets the scheduler assign the removed replicas again.
+It currently supports dynamically divided Deployments and uses `readyReplicas` as a safety floor when reducing a target.
+
+Today the descheduler uses binding status as a coarse prefilter, then asks the estimator to inspect Pods. The estimator
+fetches the Deployment, resolves its current ReplicaSet, and counts Pods whose `PodScheduled=False` condition has reason
+`Unschedulable` for longer than the threshold. The selector added by this proposal replaces that Deployment-specific
+workload-to-Pod traversal: `GetComponents` supplies the selector and the estimator lists the matching Pods directly.
+
+| Capability | Trigger | Deficit source | Request scope |
+| --- | --- | --- | --- |
+| Descheduler | Periodic and automatic | Estimator-confirmed unschedulable Pods | All supported bindings found by the descheduler |
+| This proposal | Explicit and one-shot | The same estimator predicate, using selectors from `GetComponents` | Workloads named by one `WorkloadRebalancer` |
+
+The two paths deliberately share the estimator predicate and the same scheduler rather than introducing another placement
+algorithm. Their difference is the request source and lifecycle: the descheduler performs periodic discovery, while this
+proposal processes an explicit, one-shot command for named workloads.
+
+In the future, the descheduler can create a `WorkloadRebalancer` with the appropriate behavior after its existing estimator
+checks, allowing automatic repair and explicit requests to share one command object and behavior semantics. Workload
+discovery and rate control remain descheduler responsibilities; the `WorkloadRebalancer` expresses one rescheduling
+request, while binding conditions and Events record its processing result and failure reason. This integration requires a
+follow-up proposal. The current proposal does not change the descheduler flow and still handles explicit, one-shot requests
+only.
+
+## Design Details
+
+### API Changes
+
+#### WorkloadRebalancer
+
+```go
+type WorkloadRebalancerSpec struct {
+    // Workloads specifies the workloads to be rescheduled.
+    // +required
+    Workloads []ObjectReference `json:"workloads"`
+
+    // Reschedule declares fine-grained behaviors of the triggered rescheduling.
+    // Nil means a complete rescheduling, which totally discards the previous
+    // scheduling result.
+    // +optional
+    Reschedule *RescheduleBehavior `json:"reschedule,omitempty"`
+
+    // +optional
+    TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
+}
+
+// RescheduleBehavior declares composable behaviors applied to the rescheduling.
+type RescheduleBehavior struct {
+    // PreserveAvailableReplicas indicates that available replicas keep their
+    // placement untouched. Only replicas reported by the estimator as
+    // long-term unschedulable are selected for rescheduling.
+    // Defaults to false, which means a complete rescheduling.
+    // +optional
+    PreserveAvailableReplicas *bool `json:"preserveAvailableReplicas,omitempty"`
+}
+```
+
+The preserve-available request is explicit:
+
+```yaml
+apiVersion: apps.karmada.io/v1alpha1
+kind: WorkloadRebalancer
+metadata:
+  name: reschedule-unschedulable
+spec:
+  workloads:
+    - apiVersion: apps/v1
+      kind: Deployment
+      namespace: default
+      name: example
+  reschedule:
+    preserveAvailableReplicas: true
+```
+
+Omitting `reschedule`, using an empty object, or setting `preserveAvailableReplicas: false` means complete rescheduling.
+
+#### ResourceBinding and ClusterResourceBinding
+
+The new `reschedule` carries the trigger timestamp and behaviors together. The existing `rescheduleTriggeredAt` remains
+for compatibility with existing clients but is deprecated.
+
+```go
+type ResourceBindingSpec struct {
+    // ...
+
+    // Reschedule declares a rescheduling request against this binding as well
+    // as the expected rescheduling behaviors. The rescheduling actually executes
+    // only when TriggeredAt is later than status.lastScheduledTime.
+    // +optional
+    Reschedule *Reschedule `json:"reschedule,omitempty"`
+
+    // RescheduleTriggeredAt keeps compatibility with existing clients.
+    // Deprecated: use Reschedule.TriggeredAt instead.
+    // +optional
+    RescheduleTriggeredAt *metav1.Time `json:"rescheduleTriggeredAt,omitempty"`
+}
+
+type Reschedule struct {
+    // TriggeredAt keeps the exact semantics of the deprecated
+    // spec.rescheduleTriggeredAt.
+    // +required
+    TriggeredAt metav1.Time `json:"triggeredAt"`
+
+    // Behavior of this rescheduling. Nil means complete rescheduling.
+    // +optional
+    Behavior *RescheduleBehavior `json:"behavior,omitempty"`
+}
+```
+
+The `work/v1alpha2` package defines its own equivalent `RescheduleBehavior` struct so that the work API does not depend on
+the apps API package.
+
+`ClusterResourceBinding` uses the same spec and status types, as it does today. The API shape is therefore consistent, but
+the first implementation rejects preserve-available requests for cluster-scoped resources.
+
+#### Component Selector
+
+`GetComponents` already provides the scheduler-facing component description stored in `binding.spec.components`. Extend
+that description with a Pod selector:
+
+```go
+type Component struct {
+    // Name of this component.
+    Name string `json:"name"`
+
+    // Replicas represents the replica number of the component.
+    Replicas int32 `json:"replicas"`
+
+    // ReplicaRequirements represents the scheduling requirements of each replica.
+    // +optional
+    ReplicaRequirements *ComponentReplicaRequirements `json:"replicaRequirements,omitempty"`
+
+    // Selector identifies the Pods that belong to this component.
+    // +optional
+    Selector *metav1.LabelSelector `json:"selector,omitempty"`
+}
+```
+
+The interpreter must return a non-empty selector scoped to the workload namespace. The detector persists it with the other
+component metadata, so the scheduler does not need workload-specific owner traversal. The built-in Deployment interpreter
+returns one component with the Deployment's Pod selector; custom workloads provide the same contract through their
+`GetComponents` hook. A missing or invalid selector makes `preserveAvailableReplicas: true` unsupported for that workload;
+it does not change Fresh scheduling.
+
+#### Estimator Request
+
+Extend `UnschedulableReplicasRequest` with the selector. The scheduler converts `metav1.LabelSelector` into the canonical
+Kubernetes selector string before making the gRPC call:
+
+```protobuf
+message UnschedulableReplicasRequest {
+  optional string cluster = 1;
+  optional ObjectReference resource = 2;
+  optional int64 unschedulableThreshold = 3;
+  optional string selector = 4;
+}
+```
+
+The resource reference retains workload identity and namespace; the selector defines which Pods belong to the component.
+The estimator lists Pods in that namespace and counts only Pods with `PodScheduled=False`, reason `Unschedulable`, whose
+condition has lasted longer than `unschedulableThreshold`. The scheduler uses a non-negative configurable threshold with
+the same five-minute default as the descheduler. No threshold is added to the `WorkloadRebalancer` API.
+
+The scheduler compares `spec.reschedule.triggeredAt` with the deprecated `spec.rescheduleTriggeredAt` and selects the newer
+request. The legacy field always means complete rescheduling. A nil new `behavior`, or
+`preserveAvailableReplicas: false`, also means complete rescheduling. The selected request executes only when its timestamp
+is later than the existing `status.lastScheduledTime`. A successful cycle updates `lastScheduledTime` through the existing
+scheduler flow; no new checkpoint is added.
+
+### Backward Compatibility and Version Skew
+
+- The upgraded `WorkloadRebalancer` controller writes only binding `spec.reschedule`. When the WorkloadRebalancer declares
+  no behavior, the written `behavior` is nil and still means complete rescheduling.
+- An older controller continues to write `spec.rescheduleTriggeredAt`. A new scheduler supports that field and interprets
+  it as complete rescheduling.
+- Requests with `preserveAvailableReplicas: true` must not be created until every `WorkloadRebalancer` controller replica
+  is upgraded. An older controller cannot interpret the behavior and writes the legacy field for complete rescheduling.
+- An older scheduler ignores the new `spec.reschedule`, so it cannot accidentally execute a preserve request as Fresh.
+  The required upgrade order is CRDs, scheduler, then the `WorkloadRebalancer` controller.
+- When both fields are present, the new scheduler selects the request with the later timestamp. A successful cycle updates
+  the existing `lastScheduledTime`; an older request superseded by it does not execute again.
+- API and CRD updates must be installed before the upgraded controller accepts the new behavior. The
+  `WorkloadRebalancerPreserveAvailableReplicas` feature gate is Alpha and disabled by default in its first release.
+  While the gate is disabled, the controller rejects `preserveAvailableReplicas: true` as a per-workload failure;
+  complete requests without that behavior still use the new `spec.reschedule`.
+
+### Controller and Scheduler Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User or higher-level controller
+    participant WR as WorkloadRebalancer controller
+    participant B as ResourceBinding
+    participant S as Karmada scheduler
+    participant E as Member cluster estimators
+    participant M as Member clusters
+
+    U->>WR: Create preserveAvailableReplicas request
+    WR->>B: Write spec.reschedule(triggeredAt, behavior)
+    WR-->>U: Record request submission result
+    B->>S: Binding update enters scheduler queue
+    S->>B: Read assignment and component selector
+    loop Each assigned cluster
+        S->>E: GetUnschedulableReplicas(selector, threshold)
+        E-->>S: Long-term unschedulable replica count
+    end
+    S->>S: Calculate the minimum replicas to keep per cluster
+    S->>S: Choose destinations for the unschedulable replicas
+    alt Complete assignment found
+        S->>B: Commit clusters and update lastScheduledTime
+        B->>M: Existing execution controllers converge Works
+    else Validation or scheduling failure
+        S-->>B: Keep assignment and request pending, update condition and Event
+    end
+```
+
+The `WorkloadRebalancer` controller validates the request and writes it to the `ResourceBinding`. It does not choose target
+clusters or calculate replica distribution. The Karmada scheduler validates the selector, calls the estimators, checks the
+scheduling rules, and creates the final assignment.
+
+As in the current implementation, `triggeredAt` is the `WorkloadRebalancer` creation timestamp. The controller compares it
+with both binding request timestamps and writes `spec.reschedule` only when it is newer than the existing requests.
+`triggeredAt` and `behavior` are written in one API update. A delayed reconciliation of an older `WorkloadRebalancer`
+therefore cannot overwrite a newer request.
+
+### Calculating the Replicas to Reschedule
+
+When the detector processes a workload, it calls the interpreter's `GetComponents` hook and stores the returned component
+metadata, including the new selector, in the binding. For a preserve request, the scheduler reads that selector and calls
+`GetUnschedulableReplicas` for every cluster with a positive assignment.
+
+For current assignment `assigned[c]` and estimator result `unschedulable[c]`:
+
+```text
+preserved[c] = assigned[c] - unschedulable[c]
+deficit = sum(unschedulable[c])
+```
+
+`preserved[c]` is the minimum number of replicas that must remain assigned to cluster `c`. `deficit` is the total number
+of replicas to assign again. The scheduler applies these values to a temporary copy of the binding specification: it
+replaces the copied `spec.clusters` with the preserved baseline while leaving the desired `spec.replicas` unchanged. This
+makes the existing dynamic scale-up path see exactly `deficit` replicas to place.
+
+Every result must satisfy `0 <= unschedulable[c] <= assigned[c]`. If the selector is missing or invalid, an estimator call
+fails, or a result is outside that range, the request fails and the current assignment remains unchanged. The scheduler
+does not substitute workload ready/available counts or Pod phase.
+
+Each estimator reports the state at the time of its query, and Pod state may change afterward. The scheduler waits for all
+member-cluster responses and writes the `ResourceBinding` only after it has calculated a complete assignment. It does not
+first reduce the old assignment and wait for a later scheduling cycle to fill the deficit.
+
+### Scheduling and Commit Semantics
+
+The `preserveAvailableReplicas: true` path runs as follows:
+
+1. Compare `spec.reschedule.triggeredAt` and `spec.rescheduleTriggeredAt`, selecting the later request. Ignore it if its
+   timestamp is not later than `status.lastScheduledTime`. The legacy field, a nil new `behavior`, or
+   `preserveAvailableReplicas: false` follows the existing Fresh path; the remaining steps apply only when the field is
+   `true`.
+2. Validate that the workload and `ResourceBinding` meet the supported-scope requirements. If any prerequisite fails, stop
+   without changing the current assignment.
+3. Call `GetUnschedulableReplicas` for every cluster with assigned replicas. Every call must succeed and every result must
+   be within `0..assigned[c]`; otherwise stop without changing the current assignment.
+4. Calculate `preserved[c] = assigned[c] - unschedulable[c]` for each cluster. Build a temporary scheduling input whose
+   per-cluster replica counts are the preserved baseline and whose desired replica count is unchanged. The final assignment
+   must not reduce any cluster below its baseline.
+5. Reuse the existing `dynamicScaleUp` path to fill the resulting `sum(unschedulable[c])` deficit. Existing filtering,
+   scoring, and replica allocation decide the destination clusters; no separate placement algorithm is introduced.
+6. Commit one complete result only if all replicas can be assigned and the final sum equals the workload's desired replica
+   count. Otherwise keep the current assignment and `lastScheduledTime` unchanged.
+7. If the deficit is zero, leave `spec.clusters` unchanged and update `lastScheduledTime` through the existing flow to mark
+   the request as processed.
+
+The current Fresh path is unchanged. The preserve path must not reuse the existing FitError behavior that can replace
+`spec.clusters` with an empty result. A validation error, insufficient capacity, API conflict, or scheduler error leaves
+both the previous assignment and `lastScheduledTime` unchanged, allowing the normal rate-limited retry path.
+
+### Status Semantics
+
+No new execution-progress fields are added to `WorkloadRebalancerStatus`.
+
+- `ObservedWorkload.result=Successful` keeps its current meaning: the controller wrote the request to the referenced
+  `ResourceBinding`. It does not mean scheduling or workload recovery has completed.
+- Unsupported workload or placement modes, incomplete initial scheduling, or an active conflicting workflow are rejected
+  before submission and recorded as per-workload failures.
+- After submission, `ResourceBinding` `Scheduled` conditions and Events report validation and scheduling failures.
+- When `status.lastScheduledTime >= spec.reschedule.triggeredAt`, the scheduler considers the request processed and does
+  not execute it again. This means a complete assignment was written after the request; it does not mean all Pods are
+  running or ready.
+- Workload status remains the source of truth for whether the final replicas became available.
+- Existing TTL behavior remains unchanged.
+
+### Test Plan
+
+Unit and integration tests cover:
+
+- serialization and validation for an omitted `reschedule`, an empty object, and
+  `preserveAvailableReplicas: false` and `true`;
+- rejection of `preserveAvailableReplicas: true` while the feature gate is disabled, while complete rescheduling still
+  writes binding `spec.reschedule`;
+- the legacy `rescheduleTriggeredAt` continuing to mean complete rescheduling, and new-controller/old-scheduler
+  fail-closed behavior;
+- selection by the later timestamp when both request forms exist, using `lastScheduledTime` as the pending checkpoint;
+- serialization and validation of component selectors and the estimator request selector;
+- rejection of duplicated, static-weight, multi-component, cluster-scoped, missing-selector, invalid-selector, and
+  unsupported workload types;
+- estimator Pod matching for `PodScheduled=False` with reason `Unschedulable`, including threshold boundary cases and
+  exclusion of merely `Pending`, initializing, and `Running`-unready Pods;
+- missing estimators, RPC failures, and negative or greater-than-assigned responses leaving the assignment unchanged;
+- zero, partial, and all-unschedulable results;
+- final per-cluster assignments not falling below `preserved[c]`;
+- assigning only the deficit through dynamic `Aggregated` and dynamic-weight scheduling;
+- insufficient capacity and FitError leaving the assignment and `lastScheduledTime` unchanged;
+- complete-result commit and the existing `lastScheduledTime` update; and
+- unchanged `WorkloadRebalancer` status and TTL behavior.
+
+An end-to-end test creates a dynamically divided Deployment whose interpreter component includes a Pod selector and whose
+assigned cluster has Pods that remain `Unschedulable` beyond the threshold. After eligible capacity is added, it creates a
+preserve-available `WorkloadRebalancer` and verifies that only the estimator-reported replicas are reassigned, all other
+per-cluster counts are preserved, the final result follows active placement, and `lastScheduledTime` is updated. A second
+case removes sufficient eligible capacity and verifies that the previous assignment is retained while the binding reports
+an unschedulable attempt.
+
+## Alternatives
+
+### Use an enum of mutually exclusive modes
+
+An enum with `Full` and `PreserveAvailableReplicas` can express the two current behaviors, but it makes future behaviors
+mutually exclusive. A nested `RescheduleBehavior` struct allows independent boolean behaviors to be added later while
+retaining the compatible meaning that a nil `reschedule` means complete rescheduling.
+
+### Derive the deficit from workload status
+
+Aggregate ready or available counts can show that a workload is short of its target, but they cannot identify which Pods
+are long-term unschedulable. A Pod selector returned by `GetComponents` lets the estimator inspect Pods directly and apply
+the same condition to different workload kinds.

--- a/docs/proposals/scheduling/extend-workload-rebalancer/README.zh.md
+++ b/docs/proposals/scheduling/extend-workload-rebalancer/README.zh.md
@@ -1,0 +1,467 @@
+---
+title: WorkloadRebalancer 重调度时保留可用副本
+authors:
+  - "@zhy76"
+reviewers:
+  - "@RainbowMango"
+approvers:
+  - "@RainbowMango"
+
+creation-date: 2026-06-23
+---
+
+# WorkloadRebalancer 重调度时保留可用副本
+
+## 摘要
+
+[`WorkloadRebalancer`](../workload-rebalancer/workload-rebalancer.md) 当前会要求调度器丢弃旧分配结果，并对每个选中
+工作负载执行一次 Fresh 调度。当用户希望重新计算完整分布时，Fresh 调度是合适的；但对于仅有部分副本不可用的
+拆分型工作负载，它也可能重新分配已经可用的副本。
+
+本文建议增加可选字段 `spec.reschedule.preserveAvailableReplicas`。启用后，Karmada 调度器查询每个成员集群中长期
+无法调度的 Pod 数量。假设某集群当前分配 `A` 个副本，其中 `U` 个长期无法调度，本轮至少在该集群保留 `A-U` 个
+副本，只把 `U` 个副本交给调度器重新分配。省略 `spec.reschedule` 或将该字段设为 `false` 时，继续使用当前 Fresh
+语义，即丢弃旧分配并重新计算全部副本。
+
+`WorkloadRebalancer` 仍然表示一次重调度请求，可以由用户或上层控制器创建。
+
+## 动机
+
+Karmada 调度和 Kubernetes Pod 调度处在不同层次。Karmada 调度器选择成员集群，并将副本分布写入
+`ResourceBinding`。执行控制器随后创建 `Work`，各成员集群的工作负载控制器和调度器再创建、放置 Pod。
+
+```mermaid
+flowchart LR
+    U["用户创建 WorkloadRebalancer"] --> KS["Karmada 调度器选择成员集群"]
+    KS --> B["ResourceBinding 记录副本目标"]
+    B --> W["执行控制器创建 Work"]
+    W --> C["成员集群工作负载控制器创建 Pod"]
+    C --> MS["成员集群调度器选择节点"]
+    MS --> R["副本变为可用或继续不可用"]
+```
+
+离线 spot 和 GPU 工作负载可能在 Karmada 完成集群级副本分配后只实现部分可用。成员集群中的并发工作负载、配额、
+污点、亲和性、拓扑、设备型号或单节点资源约束，都可能使其余 Pod 长时间无法运行。加速卡工作负载尤其容易遇到这种
+情况：汇总空闲容量看似足够，但没有节点具备所需的设备型号、拓扑或数量。
+
+本文关注显式重调度命令的语义。用户或上层控制器在确认需要重新计算分布后创建 `WorkloadRebalancer`；现有控制器会
+向目标 `ResourceBinding` 或 `ClusterResourceBinding` 写入 `spec.rescheduleTriggeredAt`，调度器随后以 Fresh 方式
+丢弃旧分配并全量重算。当只有部分副本长期无法调度时，调用方需要另一种明确行为：其余副本留在原集群，只把已确认
+无法调度的差额交给现有调度器重新分配。
+
+工作负载状态只能提供汇总数量，不能通用地确定哪些 Pod 应当重新调度。因此，`GetComponents` 为每个组件返回 Pod
+标签选择器，成员集群的 `GetUnschedulableReplicas` 根据该选择器统计长期无法调度的 Pod。只有同时满足
+`PodScheduled=False`、原因为 `Unschedulable`、持续时间超过配置阈值的 Pod 才计入本轮差额。
+
+`preserveAvailableReplicas` 表示保留保证，不表示用 `期望副本数 - 可用副本数` 计算差额。本方案只移出调度估算器
+返回的长期无法调度副本；其余已分配副本全部保留。因此，已经可用的副本一定保留，未就绪但未被判定为长期无法调度
+的副本也不会被本次请求移出。
+
+显式重试不需要丢弃仍有价值的分配。如果一个 100 副本工作负载中有 20 个 Pod 被调度估算器确认为长期无法调度，
+真正需要重新放置的是这 20 个副本，而不是全部 100 个。重新考虑其余 80 个副本，可能造成不必要的重启、缓存或模型
+重新加载、执行中任务丢失和短时容量下降。
+
+本文只保证每个成员集群保留的副本数量，不保证具体 Pod UID 不变。调度估算器检查 Pod，但只向 Karmada 调度器返回
+数量，不返回 Pod 名单。Karmada 调度器修改的是成员集群的副本目标，具体删除哪些 Pod 仍由成员集群中的工作负载
+控制器决定。
+
+### 目标
+
+- 保持所有现有 `WorkloadRebalancer` 调用方的 Fresh 行为不变。
+- 除调度估算器确认长期无法调度的副本外，保持其余副本当前所在的成员集群不变。
+- 为解释器返回的组件信息增加 Pod 标签选择器，并把它传给 `GetUnschedulableReplicas`。
+- 继续使用 `ResourceBinding.spec.placement` 中保存的调度规则，以及调度器现有的过滤、打分和副本分配逻辑。
+- Pod 标签选择器缺失或无效、调度估算器不可用，或返回数量大于当前分配数量时，保持原分配并报错。
+- 升级后的控制器向旧调度器提交新式请求时保持原分配，并正确处理新旧请求的先后顺序。
+
+### 非目标
+
+- 保证具体 Pod UID 不变。
+
+## 方案
+
+为 `WorkloadRebalancer` 增加可选的 `spec.reschedule` 对象，用独立字段声明可组合的重调度行为：
+
+| `spec.reschedule` | 如何处理旧分配 | 本轮调度内容 |
+| --- | --- | --- |
+| 省略，或 `preserveAvailableReplicas: false` | 与当前行为相同，丢弃旧分配 | 以 Fresh 方式重新计算全部期望副本 |
+| `preserveAvailableReplicas: true` | 除调度估算器确认长期无法调度的副本外，其余副本留在原集群 | 只重新分配长期无法调度的副本 |
+
+保留行为复用现有动态扩容流程，不引入另一套放置算法。调度器复制当前 Binding 规格，把副本分布临时替换为各集群
+需要保留的基线，同时保持总期望副本数不变，再由 `dynamicScaleUp` 补足差额。临时基线不会写入 API；只有包含全部
+期望副本的最终分配才能替换当前 `spec.clusters`。
+
+`RescheduleBehavior` 使用结构体，而不使用只能选择一个值的枚举。本文只增加
+`preserveAvailableReplicas` 这一个布尔字段。以后如果需要增加其他相互独立的行为，可以继续增加字段，而不用修改该
+字段的含义。一个 `WorkloadRebalancer` 只表示一次请求；需要再次调度时，应创建新的对象。多个请求指向同一个
+`ResourceBinding` 时，只处理触发时间最新的请求。
+
+调度器继续使用 `ResourceBinding.spec.placement` 中保存的调度规则，不在本次重调度时重新读取
+`PropagationPolicy` 或 `ClusterPropagationPolicy`。因此，如果新策略尚未作用到当前 `ResourceBinding`，本次请求
+仍按当前 `ResourceBinding` 中的规则执行。
+
+### 用户场景
+
+#### 只重新分配长期无法调度的副本
+
+一个 10 副本 Deployment 的当前分配和调度估算器返回结果如下：
+
+| 集群 | 已分配 | 长期无法调度 | 保留 |
+| --- | ---: | ---: | ---: |
+| `member1` | 6 | 2 | 4 |
+| `member2` | 4 | 0 | 4 |
+
+用户创建设置了 `spec.reschedule.preserveAvailableReplicas: true` 的 `WorkloadRebalancer`。调度器在两个现有集群中
+各保留 4 个副本，只重新分配调度估算器确认无法调度的 2 个副本。如果 `member3` 符合约束且容量充足，一种可能的
+结果是：
+
+```text
+member1=4, member2=4, member3=2
+```
+
+这 2 个副本最终分配到哪个集群，仍由 `ResourceBinding.spec.placement` 和本次调度结果决定。
+
+#### 使用新释放的加速卡容量
+
+一个采用副本拆分的 100 副本 Deployment 表示离线加速卡 worker：
+
+| 集群 | 已分配 | 长期无法调度 | 保留 |
+| --- | ---: | ---: | ---: |
+| `gpu-a` | 60 | 40 | 20 |
+| `gpu-b` | 10 | 0 | 10 |
+| `gpu-c` | 30 | 0 | 30 |
+
+随着夜间潮汐资源释放，`gpu-d` 出现符合条件的空闲容量后，保留可用副本的请求把未被调度估算器选中的 60 个副本
+留在原集群，只让调度器分配 40 个长期无法调度的副本。如果所有合格集群都无法完整容纳这 40 个副本，请求会被
+报告为不可调度，旧分配保持不变。
+
+### 支持范围与前置条件
+
+该方案不只适用于 Deployment。其他命名空间级工作负载只要实现解释器的 `GetComponents`，并返回能够找到所属 Pod
+的标签选择器，也可以使用相同流程。首个版本只有同时满足以下条件时，才接受
+`preserveAvailableReplicas: true`：
+
+- 目标由 `ResourceBinding` 引用，并且 `GetComponents` 只返回一个组件；该组件包含有效的 Pod 标签选择器，组件
+  副本数与工作负载副本数一一对应；
+- `ResourceBinding.spec.placement` 使用动态副本拆分调度，即 `Aggregated` 或使用动态权重的 `Weighted`；
+- 首次调度已经完成，当前分配总和等于工作负载期望副本数，并且没有正在执行的优雅驱逐任务；
+- `spec.placement` 与调度器上次使用的调度规则一致；
+- 每个当前已分配集群都有可用的调度估算器，并且支持 `GetUnschedulableReplicas`。
+
+这些检查用于避免本次请求与尚未完成的扩缩容、同时发生的调度规则变更或其他驱逐流程相互覆盖。省略
+`spec.reschedule` 或将 `preserveAvailableReplicas` 设为 `false` 的全量请求，仍适用于当前已经支持的所有工作负载
+类型。
+
+### 与 Karmada Descheduler 的关系
+
+[Karmada descheduler](../697-descheduler/README.md) 会周期调用调度估算器，识别长期无法调度的副本，降低对应集群
+的副本目标，再由调度器重新分配被移出的副本。它当前支持动态拆分的 Deployment，并在降低目标时以
+`readyReplicas` 作为安全下限。
+
+当前 Descheduler 先根据 `ResourceBinding` 中汇总的就绪副本数找出可能存在问题的集群，再调用调度估算器检查 Pod。
+调度估算器读取 Deployment，找到当前 ReplicaSet，然后统计 `PodScheduled=False`、原因为 `Unschedulable` 且持续
+时间超过阈值的 Pod。这段查找方式只支持 Deployment。本文改为由 `GetComponents` 提供 Pod 标签选择器，调度估算器
+可以直接按标签查找 Pod，因此其他工作负载也能使用同一个接口。
+
+| 能力 | 触发方式 | 差额来源 | 请求范围 |
+| --- | --- | --- | --- |
+| Descheduler | 周期自动执行 | 调度估算器确认长期无法调度的 Pod | Descheduler 找到的所有受支持 `ResourceBinding` |
+| 本文方案 | 用户或控制器显式创建一次请求 | 调度估算器使用 `GetComponents` 返回的标签选择器进行相同判断 | 一个 `WorkloadRebalancer` 指定的工作负载 |
+
+两条路径使用同一种“长期无法调度”判断，也使用同一个 Karmada 调度器。区别只在触发方式：Descheduler 周期检查
+所有符合条件的工作负载；本文只处理用户或上层控制器明确指定的一次请求。
+
+后续可以让 Descheduler 在检测到长期无法调度的 Pod 后创建 `WorkloadRebalancer`。Descheduler 仍负责发现工作负载
+和控制触发频率，`WorkloadRebalancer` 只记录一次重调度请求，`ResourceBinding` 的 condition 和 Event 记录处理
+结果与失败原因。本文暂不修改 Descheduler 的现有流程。
+
+## 设计细节
+
+### API 变更
+
+#### WorkloadRebalancer
+
+```go
+type WorkloadRebalancerSpec struct {
+    // Workloads specifies the workloads to be rescheduled.
+    // +required
+    Workloads []ObjectReference `json:"workloads"`
+
+    // Reschedule declares fine-grained behaviors of the triggered rescheduling.
+    // Nil means a complete rescheduling, which totally discards the previous
+    // scheduling result.
+    // +optional
+    Reschedule *RescheduleBehavior `json:"reschedule,omitempty"`
+
+    // +optional
+    TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
+}
+
+// RescheduleBehavior declares composable behaviors applied to the rescheduling.
+type RescheduleBehavior struct {
+    // PreserveAvailableReplicas indicates that available replicas keep their
+    // placement untouched. Only replicas reported by the estimator as
+    // long-term unschedulable are selected for rescheduling.
+    // Defaults to false, which means a complete rescheduling.
+    // +optional
+    PreserveAvailableReplicas *bool `json:"preserveAvailableReplicas,omitempty"`
+}
+```
+
+保留可用副本的请求需要显式声明：
+
+```yaml
+apiVersion: apps.karmada.io/v1alpha1
+kind: WorkloadRebalancer
+metadata:
+  name: reschedule-unschedulable
+spec:
+  workloads:
+    - apiVersion: apps/v1
+      kind: Deployment
+      namespace: default
+      name: example
+  reschedule:
+    preserveAvailableReplicas: true
+```
+
+省略 `reschedule`、使用空对象或显式设置 `preserveAvailableReplicas: false` 时，均表示完整重调度。
+
+#### ResourceBinding 和 ClusterResourceBinding
+
+新增的 `reschedule` 同时携带触发时间和行为。现有 `rescheduleTriggeredAt` 保留但标记为废弃，用于兼容已有调用方。
+
+```go
+type ResourceBindingSpec struct {
+    // ...
+
+    // Reschedule declares a rescheduling request against this binding as well
+    // as the expected rescheduling behaviors. The rescheduling actually executes
+    // only when TriggeredAt is later than status.lastScheduledTime.
+    // +optional
+    Reschedule *Reschedule `json:"reschedule,omitempty"`
+
+    // RescheduleTriggeredAt keeps compatibility with existing clients.
+    // Deprecated: use Reschedule.TriggeredAt instead.
+    // +optional
+    RescheduleTriggeredAt *metav1.Time `json:"rescheduleTriggeredAt,omitempty"`
+}
+
+type Reschedule struct {
+    // TriggeredAt keeps the exact semantics of the deprecated
+    // spec.rescheduleTriggeredAt.
+    // +required
+    TriggeredAt metav1.Time `json:"triggeredAt"`
+
+    // Behavior of this rescheduling. Nil means complete rescheduling.
+    // +optional
+    Behavior *RescheduleBehavior `json:"behavior,omitempty"`
+}
+```
+
+`work/v1alpha2` 包定义一份字段相同的 `RescheduleBehavior`，避免 `work/v1alpha2` 导入 `apps/v1alpha1`。
+
+`ClusterResourceBinding` 继续使用相同的 spec 和 status 类型，所以也会出现这些字段；但首个版本不支持对集群级资源
+执行保留可用副本的重调度。
+
+#### Pod 标签选择器
+
+`GetComponents` 返回工作负载包含的组件，资源检测控制器将结果保存到 `ResourceBinding.spec.components`。本文为每个
+组件增加 `selector` 字段，用它查找属于该组件的 Pod：
+
+```go
+type Component struct {
+    // Name of this component.
+    Name string `json:"name"`
+
+    // Replicas represents the replica number of the component.
+    Replicas int32 `json:"replicas"`
+
+    // ReplicaRequirements represents the scheduling requirements of each replica.
+    // +optional
+    ReplicaRequirements *ComponentReplicaRequirements `json:"replicaRequirements,omitempty"`
+
+    // Selector identifies the Pods that belong to this component.
+    // +optional
+    Selector *metav1.LabelSelector `json:"selector,omitempty"`
+}
+```
+
+解释器必须返回非空的标签选择器。查找范围固定为工作负载所在的命名空间。资源检测控制器将标签选择器与其他组件
+信息一起写入 `ResourceBinding`，因此调度器不必了解 Deployment、ReplicaSet 或其他工作负载之间的从属关系。
+内置 Deployment 解释器返回一个组件，并使用 Deployment 的 Pod 标签选择器；自定义工作负载通过自己的
+`GetComponents` 钩子返回相同信息。标签选择器缺失或无效时，该工作负载不能使用
+`preserveAvailableReplicas: true`，但仍可使用原有 Fresh 调度。
+
+#### 调度估算器请求
+
+为 `UnschedulableReplicasRequest` 增加 `selector`。Karmada 调度器发起 gRPC 请求前，把
+`metav1.LabelSelector` 转换为 Kubernetes 标签选择器字符串：
+
+```protobuf
+message UnschedulableReplicasRequest {
+  optional string cluster = 1;
+  optional ObjectReference resource = 2;
+  optional int64 unschedulableThreshold = 3;
+  optional string selector = 4;
+}
+```
+
+请求中的 `resource` 字段说明工作负载的类型、名称和命名空间，`selector` 字段说明要查找哪些 Pod。调度估算器只
+统计同时满足以下条件的 Pod：`PodScheduled=False`、原因为 `Unschedulable`，并且该状态持续时间超过
+`unschedulableThreshold`。阈值由 Karmada 调度器配置，不能为负数，默认 5 分钟，与 Descheduler 的默认值相同。
+`WorkloadRebalancer` API 不增加阈值字段。
+
+调度器比较 `spec.reschedule.triggeredAt` 与已废弃的 `spec.rescheduleTriggeredAt`，选择时间较新的请求。旧字段始终表示
+完整重调度；新字段的 `behavior` 为 `nil` 或 `preserveAvailableReplicas` 为 `false` 时也表示完整重调度。只有所选时间
+晚于 `status.lastScheduledTime` 时才执行。调度成功后，现有流程会更新 `lastScheduledTime`；本文不增加新的状态字段来
+记录请求是否已经处理。
+
+### 向后兼容与升级顺序
+
+- 升级后的 `WorkloadRebalancer` 控制器只写 `ResourceBinding.spec.reschedule`。`WorkloadRebalancer` 未声明行为时，写入的
+  `behavior` 为 `nil`，语义仍是完整重调度。
+- 旧控制器继续写 `spec.rescheduleTriggeredAt`；新调度器兼容该字段，并将其解释为完整重调度。
+- 在所有 `WorkloadRebalancer` 控制器副本升级完成前，不能创建 `preserveAvailableReplicas: true` 的请求。旧控制器
+  无法识别该行为，会写入表示完整重调度的旧字段。
+- 旧调度器会忽略新的 `spec.reschedule`，因此不会把保留请求误执行为 Fresh。升级顺序必须是 CRD、调度器、
+  `WorkloadRebalancer` 控制器。
+- 两个字段同时存在时，新调度器选择时间较新的请求。成功处理后更新现有 `lastScheduledTime`；被较新请求取代的旧请求
+  不会再次执行。
+- 升级后的控制器接受新行为之前，必须先完成 API 和 CRD 更新。功能门控
+  `WorkloadRebalancerPreserveAvailableReplicas` 在首个版本处于 Alpha，默认关闭。
+  功能门控关闭时，控制器拒绝 `preserveAvailableReplicas: true` 并记录单个工作负载失败；未声明该行为的完整重调度
+  请求仍写入新的 `spec.reschedule`。
+
+### 控制器与调度器流程
+
+```mermaid
+sequenceDiagram
+    participant U as 用户或上层控制器
+    participant WR as WorkloadRebalancer 控制器
+    participant B as ResourceBinding
+    participant S as Karmada 调度器
+    participant E as 成员集群调度估算器
+    participant M as 成员集群
+
+    U->>WR: 创建 preserveAvailableReplicas 请求
+    WR->>B: 写入 spec.reschedule(triggeredAt, behavior)
+    WR-->>U: 记录请求提交结果
+    B->>S: ResourceBinding 更新进入调度队列
+    S->>B: 读取当前分配和 Pod 标签选择器
+    loop 每个已分配集群
+        S->>E: GetUnschedulableReplicas(标签选择器, 时间阈值)
+        E-->>S: 长期无法调度的副本数
+    end
+    S->>S: 计算各集群必须保留的副本数
+    S->>S: 为无法调度的副本选择新集群
+    alt 得到完整分配
+        S->>B: 一次写入完整分配并更新 lastScheduledTime
+        B->>M: 现有执行控制器更新 Work
+    else 校验或调度失败
+        S-->>B: 保留旧分配，记录失败 condition 和 Event
+    end
+```
+
+`WorkloadRebalancer` 控制器只负责检查请求并将其写入 `ResourceBinding`，不选择目标集群，也不计算副本分布。
+Karmada 调度器负责检查 Pod 标签选择器、调用调度估算器、检查调度规则并生成最终分配。
+
+与当前实现相同，`triggeredAt` 使用 `WorkloadRebalancer` 的创建时间。控制器将它与 `ResourceBinding` 中新旧两个请求时间比较，
+只有它比已有请求更新时才写入 `spec.reschedule`。`triggeredAt` 和 `behavior` 在一次 API 更新中写入。因此，延迟协调的
+旧 `WorkloadRebalancer` 不会覆盖新请求。
+
+### 计算需要重新分配的副本数
+
+资源检测控制器处理工作负载时调用解释器的 `GetComponents` 钩子，把组件信息和 Pod 标签选择器保存到
+`ResourceBinding`。处理保留请求时，Karmada 调度器读取标签选择器，并对每个已有副本的成员集群调用
+`GetUnschedulableReplicas`。
+
+设 `assigned[c]` 是当前分配给集群 `c` 的副本数，`unschedulable[c]` 是该集群的调度估算器返回的长期无法调度 Pod
+数量：
+
+```text
+preserved[c] = assigned[c] - unschedulable[c]
+deficit = sum(unschedulable[c])
+```
+
+其中，`preserved[c]` 是本轮必须留在集群 `c` 的副本数，`deficit` 是本轮需要重新分配的副本总数。调度器把这些
+值写入一份临时的 Binding 规格副本：用保留基线替换副本分布，同时保持 `spec.replicas` 中的期望副本数不变。这样，
+现有动态扩容流程看到的待分配数量正好是 `deficit`。
+
+每个结果都必须满足 `0 <= unschedulable[c] <= assigned[c]`。标签选择器缺失或无法解析、任一调度估算器调用失败，
+或者返回数量大于当前分配数量时，本次重调度失败并保留旧分配。Karmada 调度器不会用工作负载的就绪副本数、可用
+副本数或 Pod 的 `phase` 猜测一个替代值。
+
+调度估算器返回的是查询时刻的状态。查询完成后，Pod 状态仍可能变化。Karmada 调度器会等待所有成员集群都返回结果，
+并且只有在完整分配成功后才一次写入 `ResourceBinding`，不会先减少旧分配再等待后续调度。
+
+### 调度与提交语义
+
+`preserveAvailableReplicas: true` 的处理步骤如下：
+
+1. 比较 `spec.reschedule.triggeredAt` 和 `spec.rescheduleTriggeredAt`，选择时间较新的请求；如果该时间不晚于
+   `status.lastScheduledTime`，则忽略。旧字段始终进入现有 Fresh 路径；新字段的 `behavior` 为 `nil`，或
+   `preserveAvailableReplicas` 为 `false` 时也进入该路径。以下步骤只处理值为 `true` 的请求。
+2. 检查工作负载和 `ResourceBinding` 是否满足支持范围。任何前置条件不满足时，停止处理且不修改当前分配。
+3. 对每个当前分配了副本的集群调用 `GetUnschedulableReplicas`。必须收到所有集群的有效结果；任一调用失败或返回值
+   超出 `0..assigned[c]` 时，停止处理且不修改当前分配。
+4. 对每个集群计算 `preserved[c] = assigned[c] - unschedulable[c]`。构造一份临时调度输入：各集群副本数使用保留
+   基线，总期望副本数保持不变。最终结果不得让任何集群的副本数低于对应基线。
+5. 复用现有 `dynamicScaleUp` 补足 `sum(unschedulable[c])` 个副本。目标集群仍由现有过滤、打分和副本分配逻辑
+   决定，不引入另一套放置算法。
+6. 只有调度器能够分配全部待分配副本，并且最终副本总数等于工作负载期望副本数时，才一次写入完整结果。否则保留
+   当前分配和 `lastScheduledTime`。
+7. 如果待分配副本数为 0，不修改 `spec.clusters`，只按现有流程更新 `lastScheduledTime`，表示本次请求已经处理。
+
+当前 Fresh 路径保持不变。该路径不能使用 Fresh 调度中可能在 `FitError` 时清空 `spec.clusters` 的失败处理。校验错误、
+容量不足、API 冲突或调度错误都必须保留旧分配，并由现有的限速重试流程继续处理。
+
+### 状态语义
+
+本文不为 `WorkloadRebalancerStatus` 增加新的执行进度字段。
+
+- `ObservedWorkload.result=Successful` 保持当前含义：控制器已将请求写入对应 `ResourceBinding`；它不表示调度或工作负载恢复
+  已完成。
+- 不支持的工作负载或副本分配方式、未完成的首次调度以及正在执行的冲突流程，会在请求写入前被拒绝，并记录为
+  单个工作负载失败。
+- 请求写入后，`ResourceBinding` 的 `Scheduled` condition 和 Event 用于记录校验或调度失败。
+- 当 `status.lastScheduledTime >= spec.reschedule.triggeredAt` 时，调度器认为该请求已经处理，不再重复执行。这只表示
+  本轮已经生成并写入完整分配，不表示所有 Pod 已经运行或就绪。
+- 最终副本是否可用，仍以工作负载状态为准。
+- 现有 TTL 行为保持不变。
+
+### 测试计划
+
+单元测试和集成测试覆盖：
+
+- `reschedule` 省略、空对象、`preserveAvailableReplicas: false` 和 `true` 的序列化与校验；
+- 功能门控关闭时拒绝 `preserveAvailableReplicas: true`，但完整重调度仍写入 `ResourceBinding.spec.reschedule`；
+- 旧 `rescheduleTriggeredAt` 仍表示完整重调度，以及新控制器配合旧调度器时保持原分配；
+- 新旧请求同时存在时按较新时间选择，并使用 `lastScheduledTime` 判断是否待处理；
+- 组件中的 Pod 标签选择器，以及调度估算器请求中 `selector` 字段的序列化与校验；
+- 对复制型、静态权重、多组件、集群级、标签选择器缺失或无效，以及其他不支持类型的拒绝；
+- 只统计 `PodScheduled=False`、原因为 `Unschedulable` 且持续时间超过阈值的 Pod；
+- 调度估算器缺失、RPC 失败、返回负数或大于已分配副本数时，不修改原分配；
+- 无长期无法调度 Pod、部分 Pod 长期无法调度和全部 Pod 长期无法调度三种情况；
+- 最终结果不低于各集群必须保留的副本数；
+- 动态 `Aggregated` 和动态权重调度只分配差额；
+- 容量不足和 FitError 不修改分配与 `lastScheduledTime`；
+- 只提交完整分配，并按现有规则更新 `lastScheduledTime`；
+- `WorkloadRebalancer` 现有状态和 TTL 行为不变。
+
+端到端测试创建一个动态拆分的 Deployment，其解释器返回 Pod 标签选择器，并让已分配集群中的部分 Pod 超过阈值后
+仍为 `Unschedulable`。随后增加合格容量并创建保留可用副本的 `WorkloadRebalancer`。测试验证重新分配的副本数等于
+调度估算器返回值，各集群保留数量不被减少，最终结果遵守 `ResourceBinding.spec.placement`，并更新
+`lastScheduledTime`。第二个用例移除足够容量，验证 `ResourceBinding` 记录调度失败，同时保留旧分配。
+
+## 备选方案
+
+### 使用互斥的模式枚举
+
+`Full` 与 `PreserveAvailableReplicas` 枚举可以表达当前两种行为，但会把后续行为限制为互斥选项。嵌套的
+`RescheduleBehavior` 结构体允许以后增加彼此独立的布尔行为，同时保持 `nil` 表示完整重调度的兼容语义。
+
+### 从工作负载状态推导差额
+
+汇总后的就绪或可用副本数可以说明工作负载尚未达到目标，但不能确定哪些 Pod 是长期无法调度。通过
+`GetComponents` 返回 Pod 标签选择器，可以让调度估算器直接检查 Pod，并对不同工作负载使用同一判断条件。


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR adds a proposal for extending `WorkloadRebalancer` with strategy-based rebalancing semantics.

The proposal describes how `WorkloadRebalancer` can evolve from a single Fresh scheduling trigger into a reusable execution framework for multiple rescheduling scenarios, including:

- full rescheduling;
- preserving ready replicas while rescheduling only unavailable replicas;
- source-preserving safe migration with workload-specific migration units.

The goal is to define common execution primitives for future rescheduling features while keeping workload-specific readiness and migration semantics behind extensible executors.

**Which issue(s) this PR fixes**:

Fixes #7621 

**Special notes for your reviewer**:

This is a proposal-only PR. It does not change runtime behavior or APIs yet.

**Does this PR introduce a user-facing change?**:

```release-note
NONE