### PR TITLE
scheduler: tolerate partial cluster failures in replica estimation

### DIFF
--- a/pkg/estimator/client/accurate.go
+++ b/pkg/estimator/client/accurate.go
@@ -267,6 +267,9 @@ func getClusterReplicasConcurrently(parentCtx context.Context, clusters []string
 		funcs[index] = func() error {
 			replicas, err := getClusterReplicas(ctx, localCluster)
 			if err != nil {
+				// Mark the failed cluster instead of dropping the whole batch, so one
+				// cluster's failure does not discard the replicas estimated for the others.
+				clusterReplicas[localIndex] = workv1alpha2.TargetCluster{Name: localCluster, Replicas: UnauthenticReplica}
 				return err
 			}
 			clusterReplicas[localIndex] = workv1alpha2.TargetCluster{Name: localCluster, Replicas: replicas}
@@ -296,6 +299,9 @@ func getClusterComponentSetsConcurrently(
 		funcs[i] = func() error {
 			sets, err := getClusterSetsEstimation(ctx, localCluster.Name)
 			if err != nil {
+				// Mark the failed cluster instead of dropping the whole batch, so one
+				// cluster's failure does not discard the sets estimated for the others.
+				results[localIndex] = ComponentSetEstimationResponse{Name: localCluster.Name, Sets: UnauthenticReplica}
 				return err
 			}
 			results[localIndex] = ComponentSetEstimationResponse{Name: localCluster.Name, Sets: sets}

--- a/pkg/estimator/client/accurate_test.go
+++ b/pkg/estimator/client/accurate_test.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -26,7 +27,9 @@ import (
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/estimator/pb"
 	estimatorservice "github.com/karmada-io/karmada/pkg/estimator/service"
@@ -157,6 +160,126 @@ func Test_toAssumedWorkload(t *testing.T) {
 			assert.Len(t, got.Components, tt.wantLen)
 			if tt.wantComponents != nil {
 				tt.wantComponents(t, got.Components)
+			}
+		})
+	}
+}
+
+func Test_getClusterReplicasConcurrently_partialFailure(t *testing.T) {
+	clusters := []string{"cluster1", "cluster2", "cluster3"}
+
+	tests := []struct {
+		name         string
+		getReplicas  getClusterReplicasFunc
+		wantReplicas map[string]int32
+		wantErr      bool
+	}{
+		{
+			name: "all clusters succeed",
+			getReplicas: func(_ context.Context, cluster string) (int32, error) {
+				return map[string]int32{"cluster1": 10, "cluster2": 20, "cluster3": 30}[cluster], nil
+			},
+			wantReplicas: map[string]int32{"cluster1": 10, "cluster2": 20, "cluster3": 30},
+			wantErr:      false,
+		},
+		{
+			name: "one cluster fails — others keep their replicas, failed one is UnauthenticReplica",
+			getReplicas: func(_ context.Context, cluster string) (int32, error) {
+				if cluster == "cluster2" {
+					return 0, errors.New("estimator unavailable")
+				}
+				return map[string]int32{"cluster1": 10, "cluster3": 30}[cluster], nil
+			},
+			wantReplicas: map[string]int32{"cluster1": 10, "cluster2": UnauthenticReplica, "cluster3": 30},
+			wantErr:      true,
+		},
+		{
+			name: "all clusters fail — every cluster marked UnauthenticReplica with error",
+			getReplicas: func(_ context.Context, _ string) (int32, error) {
+				return 0, errors.New("estimator unavailable")
+			},
+			wantReplicas: map[string]int32{"cluster1": UnauthenticReplica, "cluster2": UnauthenticReplica, "cluster3": UnauthenticReplica},
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getClusterReplicasConcurrently(context.Background(), clusters, 5*time.Second, tt.getReplicas)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Every cluster keeps a named slot in the result, even on failure.
+			require.Len(t, got, len(clusters))
+			for _, tc := range got {
+				want, ok := tt.wantReplicas[tc.Name]
+				require.True(t, ok, "unexpected cluster %q in result", tc.Name)
+				assert.Equal(t, want, tc.Replicas, "cluster %q replicas", tc.Name)
+			}
+		})
+	}
+}
+
+func Test_getClusterComponentSetsConcurrently_partialFailure(t *testing.T) {
+	clusters := []*clusterv1alpha1.Cluster{
+		{ObjectMeta: metav1.ObjectMeta{Name: "cluster1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "cluster2"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "cluster3"}},
+	}
+
+	tests := []struct {
+		name     string
+		getSets  func(ctx context.Context, cluster string) (int32, error)
+		wantSets map[string]int32
+		wantErr  bool
+	}{
+		{
+			name: "all clusters succeed",
+			getSets: func(_ context.Context, cluster string) (int32, error) {
+				return map[string]int32{"cluster1": 10, "cluster2": 20, "cluster3": 30}[cluster], nil
+			},
+			wantSets: map[string]int32{"cluster1": 10, "cluster2": 20, "cluster3": 30},
+			wantErr:  false,
+		},
+		{
+			name: "one cluster fails — others keep their sets, failed one is UnauthenticReplica",
+			getSets: func(_ context.Context, cluster string) (int32, error) {
+				if cluster == "cluster2" {
+					return 0, errors.New("estimator unavailable")
+				}
+				return map[string]int32{"cluster1": 10, "cluster3": 30}[cluster], nil
+			},
+			wantSets: map[string]int32{"cluster1": 10, "cluster2": UnauthenticReplica, "cluster3": 30},
+			wantErr:  true,
+		},
+		{
+			name: "all clusters fail — every cluster marked UnauthenticReplica with error",
+			getSets: func(_ context.Context, _ string) (int32, error) {
+				return 0, errors.New("estimator unavailable")
+			},
+			wantSets: map[string]int32{"cluster1": UnauthenticReplica, "cluster2": UnauthenticReplica, "cluster3": UnauthenticReplica},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getClusterComponentSetsConcurrently(context.Background(), clusters, 5*time.Second, tt.getSets)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Every cluster keeps a named slot in the result, even on failure.
+			require.Len(t, got, len(clusters))
+			for _, r := range got {
+				want, ok := tt.wantSets[r.Name]
+				require.True(t, ok, "unexpected cluster %q in result", r.Name)
+				assert.Equal(t, want, r.Sets, "cluster %q sets", r.Name)
 			}
 		})
 	}

--- a/pkg/scheduler/core/estimation.go
+++ b/pkg/scheduler/core/estimation.go
@@ -85,31 +85,47 @@ func calculateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTempla
 	namespacedKey := names.NamespacedKey(estCtx.spec.Resource.Namespace, estCtx.spec.Resource.Name)
 	resp, err := estCtx.estimator.MaxAvailableComponentSets(ctx, req)
 	if err != nil {
+		// Don't return early: on a partial failure resp still carries the clusters that
+		// succeeded, so fall through and build a result from what is available.
 		klog.Errorf("Failed to calculate available component set with estimator(%s) for workload(%s, kind=%s, %s): %v",
 			estCtx.estimatorName, estCtx.spec.Resource.APIVersion, estCtx.spec.Resource.Kind, namespacedKey, err)
-		return nil, err
 	}
 
-	// Use a map to safely update replicas regardless of order.
+	// Use a map to safely update replicas regardless of order. Clusters the estimator
+	// responded for but could not estimate are recorded separately so they are not later
+	// reported as a missed estimation.
 	resMap := make(map[string]int32, len(resp))
+	unauthentic := make(map[string]struct{})
 	for i := range resp {
 		if resp[i].Sets == estimatorclient.UnauthenticReplica {
+			unauthentic[resp[i].Name] = struct{}{}
 			continue
 		}
 		resMap[resp[i].Name] = resp[i].Sets
+	}
+
+	// No cluster produced a usable estimation. Return the error without walking every
+	// cluster below, which would otherwise log a missed-estimation warning for each one
+	// when the estimator returned nothing at all.
+	if len(resMap) == 0 {
+		return []workv1alpha2.TargetCluster{}, err
 	}
 
 	result := make([]workv1alpha2.TargetCluster, 0, len(estCtx.clusters))
 	for _, cluster := range estCtx.clusters {
 		sets, ok := resMap[cluster.Name]
 		if !ok {
-			klog.Warningf("The estimator(%s) missed estimation from cluster(%s) when estimating for workload(%s, kind=%s, %s).",
-				estCtx.estimatorName, cluster.Name, estCtx.spec.Resource.APIVersion, estCtx.spec.Resource.Kind, namespacedKey)
+			if _, failed := unauthentic[cluster.Name]; !failed {
+				// Only a cluster genuinely absent from the response is a missed estimation;
+				// a cluster that failed was already reported by the estimator.
+				klog.Warningf("The estimator(%s) missed estimation from cluster(%s) when estimating for workload(%s, kind=%s, %s).",
+					estCtx.estimatorName, cluster.Name, estCtx.spec.Resource.APIVersion, estCtx.spec.Resource.Kind, namespacedKey)
+			}
 			continue
 		}
 		result = append(result, workv1alpha2.TargetCluster{Name: cluster.Name, Replicas: sets})
 	}
-	return result, nil
+	return result, err
 }
 
 // buildAssumedWorkloadsByCluster builds a map of assumed workloads for each cluster based on the assigning cache.

--- a/pkg/scheduler/core/estimation_test.go
+++ b/pkg/scheduler/core/estimation_test.go
@@ -33,13 +33,15 @@ import (
 
 // mockReplicaEstimator is a mock implementation of ReplicaEstimator for testing
 type mockReplicaEstimator struct {
+	maxAvailableReplicasResponse      []workv1alpha2.TargetCluster
+	maxAvailableReplicasError         error
 	maxAvailableComponentSetsResponse []estimatorclient.ComponentSetEstimationResponse
 	maxAvailableComponentSetsError    error
 	lastComponentSetRequest           estimatorclient.ComponentSetEstimationRequest
 }
 
 func (m *mockReplicaEstimator) MaxAvailableReplicas(_ context.Context, _ estimatorclient.ReplicaEstimationRequest) ([]workv1alpha2.TargetCluster, error) {
-	return nil, nil
+	return m.maxAvailableReplicasResponse, m.maxAvailableReplicasError
 }
 
 func (m *mockReplicaEstimator) MaxAvailableComponentSets(_ context.Context, req estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
@@ -290,11 +292,25 @@ func Test_calculateMultiTemplateAvailableSets(t *testing.T) {
 			},
 		},
 		{
-			name:           "estimator error — returns nil result",
+			name:           "estimator error with no results — returns empty result and propagates error",
 			mockResponse:   nil,
 			mockError:      errors.New("estimator error"),
-			expectedResult: nil,
+			expectedResult: []workv1alpha2.TargetCluster{},
 			expectedError:  true,
+		},
+		{
+			name: "partial failure — successful clusters returned, failed cluster skipped, error propagated",
+			mockResponse: []estimatorclient.ComponentSetEstimationResponse{
+				{Name: "cluster1", Sets: 50},
+				{Name: "cluster2", Sets: estimatorclient.UnauthenticReplica},
+				{Name: "cluster3", Sets: 250},
+			},
+			mockError: errors.New("cluster2: estimator unavailable"),
+			expectedResult: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 50},
+				{Name: "cluster3", Replicas: 250},
+			},
+			expectedError: true,
 		},
 		{
 			name:           "empty estimator response — returns empty result",
@@ -325,6 +341,100 @@ func Test_calculateMultiTemplateAvailableSets(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func Test_runSingleTemplateEstimator_partialFailure(t *testing.T) {
+	clusters := []*clusterv1alpha1.Cluster{
+		helper.NewCluster("cluster1"),
+		helper.NewCluster("cluster2"),
+	}
+	spec := &workv1alpha2.ResourceBindingSpec{
+		Resource: workv1alpha2.ObjectReference{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Namespace:  "default",
+			Name:       "test-deployment",
+		},
+		Replicas: 1,
+	}
+
+	// cluster2 failed (UnauthenticReplica) and an error is returned; the path must still
+	// surface the partial result rather than discarding it.
+	partial := []workv1alpha2.TargetCluster{
+		{Name: "cluster1", Replicas: 5},
+		{Name: "cluster2", Replicas: estimatorclient.UnauthenticReplica},
+	}
+	mockEstimator := &mockReplicaEstimator{
+		maxAvailableReplicasResponse: partial,
+		maxAvailableReplicasError:    errors.New("cluster2: estimator unavailable"),
+	}
+
+	res, err := runSingleTemplateEstimator(context.Background(), replicaEstimationContext{
+		estimatorName: "test-estimator",
+		estimator:     mockEstimator,
+		clusters:      clusters,
+		spec:          spec,
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, partial, res)
+}
+
+func Test_mergeReplicaResults(t *testing.T) {
+	tests := []struct {
+		name      string
+		available []workv1alpha2.TargetCluster
+		res       []workv1alpha2.TargetCluster
+		want      []workv1alpha2.TargetCluster
+	}{
+		{
+			name: "takes the minimum replicas per cluster",
+			available: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 10},
+				{Name: "cluster2", Replicas: 10},
+			},
+			res: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 4},
+				{Name: "cluster2", Replicas: 20},
+			},
+			want: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 4},
+				{Name: "cluster2", Replicas: 10},
+			},
+		},
+		{
+			name: "skips clusters marked UnauthenticReplica so a partial failure does not corrupt them",
+			available: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 10},
+				{Name: "cluster2", Replicas: 10},
+			},
+			res: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 4},
+				{Name: "cluster2", Replicas: estimatorclient.UnauthenticReplica},
+			},
+			want: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 4},
+				{Name: "cluster2", Replicas: 10},
+			},
+		},
+		{
+			name: "nil result leaves available unchanged",
+			available: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 10},
+			},
+			res: nil,
+			want: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 10},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeReplicaResults(tt.available, tt.res)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/scheduler/core/util.go
+++ b/pkg/scheduler/core/util.go
@@ -92,7 +92,11 @@ func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha
 			assumedWorkloads: assumedWorkloads,
 		})
 		if err != nil {
-			continue
+			// On a partial failure res still holds the clusters that succeeded; failed ones
+			// are marked UnauthenticReplica and skipped by mergeReplicaResults. Keep merging
+			// instead of discarding the estimator for every cluster. The estimator already
+			// logged the error, so only trace it here to avoid a duplicate error log.
+			klog.V(4).Infof("Estimator %s returned an error, merging any partial results: %v", name, err)
 		}
 		availableTargetClusters = mergeReplicaResults(availableTargetClusters, res)
 	}
@@ -145,8 +149,10 @@ func runSingleTemplateEstimator(ctx context.Context, in replicaEstimationContext
 		AssumedWorkloads:    in.assumedWorkloads,
 	})
 	if err != nil {
+		// Return res alongside the error so the caller can still use the clusters that
+		// succeeded; failed clusters are marked UnauthenticReplica.
 		klog.Errorf("Max cluster available replicas error: %v", err)
-		return nil, err
+		return res, err
 	}
 	klog.V(4).Infof("Invoked MaxAvailableReplicas of estimator %s for workload(%s, kind=%s, %s): %v", in.estimatorName,
 		in.spec.Resource.APIVersion, in.spec.Resource.Kind, names.NamespacedKey(in.spec.Resource.Namespace, in.spec.Resource.Name), res)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When multiple replica estimators are configured (e.g. `general-estimator` and `scheduler-estimator`), a failure to estimate a single cluster made the scheduler discard the whole estimator result. Every cluster then fell back to the `general-estimator`, including the clusters that the `scheduler-estimator` had estimated successfully.

This changes the estimation to degrade per cluster instead of all-or-nothing:

- `getClusterReplicasConcurrently` and `getClusterComponentSetsConcurrently` now mark a failed cluster as `UnauthenticReplica` instead of leaving its slot empty, while still aggregating the error for logging.
- `calAvailableReplicas` and `calculateMultiTemplateAvailableSets` merge the partial results instead of skipping the estimator entirely. `mergeReplicaResults` already ignores `UnauthenticReplica` entries, so only the clusters that succeeded are merged and a failed cluster keeps its previous value.

The descheduler path (`FillUnschedulableReplicas`) keeps its existing behavior and is unaffected.

**Which issue(s) this PR fixes**:

Fixes #6815

**Special notes for your reviewer**:

Unit tests cover both the single-template replica path and the multi-template component-set path:

- `Test_getClusterReplicasConcurrently_partialFailure`
- `Test_runSingleTemplateEstimator_partialFailure`
- `Test_mergeReplicaResults`
- a new partial-failure case in `Test_calculateMultiTemplateAvailableSets`

`go test ./pkg/estimator/client/... ./pkg/scheduler/core/...` passes.

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-scheduler`: A failure to estimate available replicas for a single cluster no longer discards the estimation results of the other clusters.
```
