### PR TITLE
metricsadapter: implement GetExternalMetric for external metrics

### DIFF
--- a/pkg/metricsadapter/adapter.go
+++ b/pkg/metricsadapter/adapter.go
@@ -36,7 +36,7 @@ func NewMetricsAdapter(controller *MetricsController, customMetricsAdapterServer
 	adapter.CustomMetricsAdapterServerOptions = customMetricsAdapterServerOptions
 	adapter.ResourceMetricsProvider = provider.NewResourceMetricsProvider(controller.ClusterLister, controller.TypedInformerManager, controller.InformerManager)
 	customProvider := provider.MakeCustomMetricsProvider(controller.ClusterLister, controller.MultiClusterDiscovery)
-	externalProvider := provider.MakeExternalMetricsProvider()
+	externalProvider := provider.MakeExternalMetricsProvider(controller.ClusterLister, controller.MultiClusterDiscovery)
 	adapter.WithCustomMetrics(customProvider)
 	adapter.WithExternalMetrics(externalProvider)
 

--- a/pkg/metricsadapter/provider/externalmetrics.go
+++ b/pkg/metricsadapter/provider/externalmetrics.go
@@ -19,27 +19,190 @@ package provider
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
+	"sync"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	"k8s.io/metrics/pkg/apis/external_metrics"
+	externalmetricsv1beta1 "k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	clusterlister "github.com/karmada-io/karmada/pkg/generated/listers/cluster/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/metricsadapter/multiclient"
 )
 
-// ExternalMetricsProvider is a custom metrics provider
-type ExternalMetricsProvider struct {
+var (
+	externalMetricsScheme = runtime.NewScheme()
+	externalMetricsCodecs = serializer.NewCodecFactory(externalMetricsScheme)
+)
+
+func init() {
+	utilruntime.Must(externalmetricsv1beta1.AddToScheme(externalMetricsScheme))
 }
 
-// MakeExternalMetricsProvider creates a new custom metrics provider
-func MakeExternalMetricsProvider() *ExternalMetricsProvider {
-	return &ExternalMetricsProvider{}
+// ExternalMetricsProvider queries external metrics from member clusters.
+type ExternalMetricsProvider struct {
+	// multiClusterDiscovery returns a discovery client for member cluster apiserver
+	multiClusterDiscovery multiclient.MultiClusterDiscoveryInterface
+	clusterLister         clusterlister.ClusterLister
+}
+
+// MakeExternalMetricsProvider creates a new external metrics provider
+func MakeExternalMetricsProvider(clusterLister clusterlister.ClusterLister, multiClusterDiscovery multiclient.MultiClusterDiscoveryInterface) *ExternalMetricsProvider {
+	return &ExternalMetricsProvider{
+		clusterLister:         clusterLister,
+		multiClusterDiscovery: multiClusterDiscovery,
+	}
 }
 
 // GetExternalMetric will query metrics by selector from member clusters and return the result
-func (c *ExternalMetricsProvider) GetExternalMetric(_ context.Context, _ string, _ labels.Selector, _ provider.ExternalMetricInfo) (*external_metrics.ExternalMetricValueList, error) {
-	return nil, fmt.Errorf("karmada-metrics-adapter still not implement it")
+func (c *ExternalMetricsProvider) GetExternalMetric(ctx context.Context, namespace string, metricSelector labels.Selector, info provider.ExternalMetricInfo) (*external_metrics.ExternalMetricValueList, error) {
+	clusters, err := c.clusterLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list clusters: %v", err)
+		return nil, err
+	}
+	metricsChannel := make(chan *external_metrics.ExternalMetricValueList)
+	wg := sync.WaitGroup{}
+	for _, cluster := range clusters {
+		wg.Add(1)
+		go func(clusterName string) {
+			defer wg.Done()
+			metrics, err := c.getExternalMetric(ctx, clusterName, namespace, metricSelector, info)
+			if err != nil {
+				klog.Warningf("query %s external metric from cluster %s failed, err: %+v", info.Metric, clusterName, err)
+				return
+			}
+			metricsChannel <- metrics
+		}(cluster.Name)
+	}
+	go func() {
+		wg.Wait()
+		close(metricsChannel)
+	}()
+
+	// A single metric may be reported by multiple clusters. Values that share the same
+	// labels are summed, the same way the custom metrics provider folds duplicates.
+	merged := make(map[string]external_metrics.ExternalMetricValue)
+	for metrics := range metricsChannel {
+		for _, item := range metrics.Items {
+			key := externalMetricKey(item)
+			if existing, ok := merged[key]; ok {
+				existing.Value.Add(item.Value)
+				merged[key] = existing
+				continue
+			}
+			merged[key] = item
+		}
+	}
+	if len(merged) == 0 {
+		return nil, provider.NewMetricNotFoundError(externalmetricsv1beta1.Resource(info.Metric), info.Metric)
+	}
+
+	metricValueList := &external_metrics.ExternalMetricValueList{Items: make([]external_metrics.ExternalMetricValue, 0, len(merged))}
+	for _, item := range merged {
+		metricValueList.Items = append(metricValueList.Items, item)
+	}
+	return metricValueList, nil
+}
+
+func (c *ExternalMetricsProvider) getExternalMetric(ctx context.Context, clusterName, namespace string, metricSelector labels.Selector, info provider.ExternalMetricInfo) (*external_metrics.ExternalMetricValueList, error) {
+	discoveryClient := c.multiClusterDiscovery.Get(clusterName)
+	if discoveryClient == nil {
+		err := fmt.Errorf("failed to get MultiClusterDiscovery for cluster(%s)", clusterName)
+		klog.Error(err)
+		return nil, err
+	}
+	gv := externalmetricsv1beta1.SchemeGroupVersion
+	raw, err := discoveryClient.RESTClient().Get().
+		Prefix("apis", gv.Group, gv.Version).
+		Namespace(namespace).
+		Resource(info.Metric).
+		VersionedParams(&metav1.ListOptions{LabelSelector: metricSelector.String()}, metav1.ParameterCodec).
+		DoRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+	versioned := &externalmetricsv1beta1.ExternalMetricValueList{}
+	if err := runtime.DecodeInto(externalMetricsCodecs.UniversalDeserializer(), raw, versioned); err != nil {
+		return nil, err
+	}
+	result := &external_metrics.ExternalMetricValueList{}
+	if err := externalmetricsv1beta1.Convert_v1beta1_ExternalMetricValueList_To_external_metrics_ExternalMetricValueList(versioned, result, nil); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// externalMetricKey builds a stable identity for a metric value from its name and labels.
+func externalMetricKey(value external_metrics.ExternalMetricValue) string {
+	if len(value.MetricLabels) == 0 {
+		return value.MetricName
+	}
+	keys := make([]string, 0, len(value.MetricLabels))
+	for k := range value.MetricLabels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString(value.MetricName)
+	for _, k := range keys {
+		b.WriteString(",")
+		b.WriteString(k)
+		b.WriteString("=")
+		b.WriteString(value.MetricLabels[k])
+	}
+	return b.String()
 }
 
 // ListAllExternalMetrics returns all metrics in all member clusters
 func (c *ExternalMetricsProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo {
-	return []provider.ExternalMetricInfo{}
+	clusters, err := c.clusterLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list clusters: %v", err)
+		return []provider.ExternalMetricInfo{}
+	}
+	metricNameChan := make(chan string)
+	wg := sync.WaitGroup{}
+	gv := externalmetricsv1beta1.SchemeGroupVersion
+	for _, cluster := range clusters {
+		wg.Add(1)
+		go func(clusterName string) {
+			defer wg.Done()
+			discoveryClient := c.multiClusterDiscovery.Get(clusterName)
+			if discoveryClient == nil {
+				klog.Errorf("failed to get MultiClusterDiscovery for cluster(%s)", clusterName)
+				return
+			}
+			resources, err := discoveryClient.ServerResourcesForGroupVersion(gv.String())
+			if err != nil {
+				klog.Warningf("Failed to query %s resource in cluster(%s): %+v", gv.String(), clusterName, err)
+				return
+			}
+			for _, resource := range resources.APIResources {
+				metricNameChan <- resource.Name
+			}
+		}(cluster.Name)
+	}
+	go func() {
+		wg.Wait()
+		close(metricNameChan)
+	}()
+
+	metricNames := sets.New[string]()
+	for name := range metricNameChan {
+		metricNames.Insert(name)
+	}
+	externalMetricInfos := make([]provider.ExternalMetricInfo, 0, metricNames.Len())
+	for _, name := range sets.List(metricNames) {
+		externalMetricInfos = append(externalMetricInfos, provider.ExternalMetricInfo{Metric: name})
+	}
+	return externalMetricInfos
 }

--- a/pkg/metricsadapter/provider/externalmetrics_test.go
+++ b/pkg/metricsadapter/provider/externalmetrics_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/metrics/pkg/apis/external_metrics"
+	externalmetricsv1beta1 "k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	clusterlister "github.com/karmada-io/karmada/pkg/generated/listers/cluster/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/metricsadapter/multiclient"
+)
+
+// fakeMultiClusterDiscovery returns a preconfigured discovery client per cluster.
+type fakeMultiClusterDiscovery struct {
+	clients map[string]*discovery.DiscoveryClient
+}
+
+func (f *fakeMultiClusterDiscovery) Get(clusterName string) *discovery.DiscoveryClient {
+	return f.clients[clusterName]
+}
+
+func (f *fakeMultiClusterDiscovery) Set(string) error { return nil }
+
+func (f *fakeMultiClusterDiscovery) Remove(string) {}
+
+var _ multiclient.MultiClusterDiscoveryInterface = (*fakeMultiClusterDiscovery)(nil)
+
+func newClusterLister(t *testing.T, names ...string) clusterlister.ClusterLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, name := range names {
+		require.NoError(t, indexer.Add(&clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: name}}))
+	}
+	return clusterlister.NewClusterLister(indexer)
+}
+
+func mustQuantity(t *testing.T, s string) resource.Quantity {
+	t.Helper()
+	q, err := resource.ParseQuantity(s)
+	require.NoError(t, err)
+	return q
+}
+
+// fakeMemberCluster serves the external metrics API of a single member cluster.
+type fakeMemberCluster struct {
+	// metrics maps a metric name to the values returned by GetExternalMetric.
+	metrics map[string][]externalmetricsv1beta1.ExternalMetricValue
+	// resources lists the metric names advertised through API discovery.
+	resources []string
+}
+
+func startMemberCluster(t *testing.T, cluster fakeMemberCluster) *discovery.DiscoveryClient {
+	t.Helper()
+	const apiPrefix = "/apis/external.metrics.k8s.io/v1beta1"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == apiPrefix:
+			list := &metav1.APIResourceList{GroupVersion: "external.metrics.k8s.io/v1beta1"}
+			for _, name := range cluster.resources {
+				list.APIResources = append(list.APIResources, metav1.APIResource{Name: name, Namespaced: true})
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(list))
+		case strings.HasPrefix(r.URL.Path, apiPrefix+"/namespaces/"):
+			metricName := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+			list := &externalmetricsv1beta1.ExternalMetricValueList{
+				TypeMeta: metav1.TypeMeta{APIVersion: "external.metrics.k8s.io/v1beta1", Kind: "ExternalMetricValueList"},
+				Items:    cluster.metrics[metricName],
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(list))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return discovery.NewDiscoveryClientForConfigOrDie(&rest.Config{Host: server.URL})
+}
+
+func TestGetExternalMetric(t *testing.T) {
+	const namespace = "default"
+	const metricName = "queue_messages"
+
+	tests := []struct {
+		name      string
+		clusters  map[string]fakeMemberCluster
+		wantErr   bool
+		wantItems map[string]string // metric label "queue" value -> expected quantity
+	}{
+		{
+			name: "values with the same labels are summed across clusters",
+			clusters: map[string]fakeMemberCluster{
+				"member1": {metrics: map[string][]externalmetricsv1beta1.ExternalMetricValue{
+					metricName: {{MetricName: metricName, MetricLabels: map[string]string{"queue": "worker"}, Value: mustQuantity(t, "10")}},
+				}},
+				"member2": {metrics: map[string][]externalmetricsv1beta1.ExternalMetricValue{
+					metricName: {{MetricName: metricName, MetricLabels: map[string]string{"queue": "worker"}, Value: mustQuantity(t, "5")}},
+				}},
+			},
+			wantItems: map[string]string{"worker": "15"},
+		},
+		{
+			name: "values with different labels are kept separate",
+			clusters: map[string]fakeMemberCluster{
+				"member1": {metrics: map[string][]externalmetricsv1beta1.ExternalMetricValue{
+					metricName: {{MetricName: metricName, MetricLabels: map[string]string{"queue": "worker"}, Value: mustQuantity(t, "10")}},
+				}},
+				"member2": {metrics: map[string][]externalmetricsv1beta1.ExternalMetricValue{
+					metricName: {{MetricName: metricName, MetricLabels: map[string]string{"queue": "batch"}, Value: mustQuantity(t, "7")}},
+				}},
+			},
+			wantItems: map[string]string{"worker": "10", "batch": "7"},
+		},
+		{
+			name: "no values from any cluster returns a not-found error",
+			clusters: map[string]fakeMemberCluster{
+				"member1": {metrics: map[string][]externalmetricsv1beta1.ExternalMetricValue{}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clients := map[string]*discovery.DiscoveryClient{}
+			names := make([]string, 0, len(tt.clusters))
+			for name, cluster := range tt.clusters {
+				clients[name] = startMemberCluster(t, cluster)
+				names = append(names, name)
+			}
+			p := MakeExternalMetricsProvider(newClusterLister(t, names...), &fakeMultiClusterDiscovery{clients: clients})
+
+			got, err := p.GetExternalMetric(context.Background(), namespace, labels.Everything(), provider.ExternalMetricInfo{Metric: metricName})
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			gotItems := map[string]string{}
+			for _, item := range got.Items {
+				gotItems[item.MetricLabels["queue"]] = item.Value.String()
+			}
+			assert.Equal(t, tt.wantItems, gotItems)
+		})
+	}
+}
+
+func TestListAllExternalMetrics(t *testing.T) {
+	clients := map[string]*discovery.DiscoveryClient{
+		"member1": startMemberCluster(t, fakeMemberCluster{resources: []string{"queue_messages", "http_requests"}}),
+		"member2": startMemberCluster(t, fakeMemberCluster{resources: []string{"queue_messages", "rabbitmq_queue"}}),
+	}
+	p := MakeExternalMetricsProvider(newClusterLister(t, "member1", "member2"), &fakeMultiClusterDiscovery{clients: clients})
+
+	got := p.ListAllExternalMetrics()
+
+	names := make([]string, 0, len(got))
+	for _, info := range got {
+		names = append(names, info.Metric)
+	}
+	// Metrics are deduplicated across clusters and returned in sorted order.
+	assert.Equal(t, []string{"http_requests", "queue_messages", "rabbitmq_queue"}, names)
+}
+
+func TestExternalMetricKey(t *testing.T) {
+	withLabels := external_metrics.ExternalMetricValue{
+		MetricName:   "queue_messages",
+		MetricLabels: map[string]string{"queue": "worker", "region": "eu"},
+	}
+	// Label order in the map must not change the key.
+	reordered := external_metrics.ExternalMetricValue{
+		MetricName:   "queue_messages",
+		MetricLabels: map[string]string{"region": "eu", "queue": "worker"},
+	}
+	assert.Equal(t, externalMetricKey(withLabels), externalMetricKey(reordered))
+	assert.NotEqual(t, externalMetricKey(withLabels), externalMetricKey(external_metrics.ExternalMetricValue{MetricName: "queue_messages"}))
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`karmada-metrics-adapter` serves the external metrics API, but `GetExternalMetric` was a stub that returned "karmada-metrics-adapter still not implement it" and `ListAllExternalMetrics` always returned an empty list. As a result FederatedHPA cannot scale on `External` metric sources end to end.

This implements both methods, following the existing custom metrics provider:

- `GetExternalMetric` queries `external.metrics.k8s.io/v1beta1` on every member cluster concurrently and merges the results. Values that carry the same metric labels are summed, matching how the custom metrics provider folds a metric reported by multiple clusters.
- `ListAllExternalMetrics` discovers the external metric names exposed by member clusters and returns them deduplicated.

`MakeExternalMetricsProvider` now takes the cluster lister and the multi-cluster discovery client, wired up the same way as the custom metrics provider.

**Which issue(s) this PR fixes**:

Fixes #7396

**Special notes for your reviewer**:

Unit tests use httptest-backed member clusters to cover:

- summing values with identical labels across clusters
- keeping values with different labels separate
- returning a not-found error when no cluster reports the metric
- deduplicated discovery through `ListAllExternalMetrics`

`go test ./pkg/metricsadapter/...` passes.

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-metrics-adapter`: Implemented `GetExternalMetric` so that FederatedHPA can scale workloads based on external metric sources.
```
