### PR TITLE
fix: prevent duplicate objects in FetchResourceTemplatesByLabelSelector

### DIFF
--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -357,8 +357,10 @@ func FetchResourceTemplatesByLabelSelector(
 		objectList, err = informerManager.Lister(gvr).ByNamespace(resource.Namespace).List(selector)
 	}
 	var objects []*unstructured.Unstructured
+	usedFallback := false
 	if err != nil || len(objectList) == 0 {
 		// fall back to call api server in case the cache has not been synchronized yet
+		usedFallback = true
 		klog.Warningf("Failed to get resource template (%s/%s/%s) from cache, Error: %v. Fall back to call api server.",
 			resource.Kind, resource.Namespace, resource.Name, err)
 		unstructuredList, err := dynamicClient.Resource(gvr).Namespace(resource.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
@@ -372,13 +374,15 @@ func FetchResourceTemplatesByLabelSelector(
 		}
 	}
 
-	for i := range objectList {
-		unstructuredObj, err := ToUnstructured(objectList[i])
-		if err != nil {
-			klog.Errorf("Failed to transform object(%s/%s), Error: %v", resource.Namespace, resource.Name, err)
-			return nil, err
+	if !usedFallback {
+		for i := range objectList {
+			unstructuredObj, err := ToUnstructured(objectList[i])
+			if err != nil {
+				klog.Errorf("Failed to transform object(%s/%s), Error: %v", resource.Namespace, resource.Name, err)
+				return nil, err
+			}
+			objects = append(objects, unstructuredObj)
 		}
-		objects = append(objects, unstructuredObj)
 	}
 	return objects, nil
 }

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -357,10 +357,8 @@ func FetchResourceTemplatesByLabelSelector(
 		objectList, err = informerManager.Lister(gvr).ByNamespace(resource.Namespace).List(selector)
 	}
 	var objects []*unstructured.Unstructured
-	usedFallback := false
 	if err != nil || len(objectList) == 0 {
-		// fall back to call api server in case the cache has not been synchronized yet
-		usedFallback = true
+		// fall back to call api server
 		klog.Warningf("Failed to get resource template (%s/%s/%s) from cache, Error: %v. Fall back to call api server.",
 			resource.Kind, resource.Namespace, resource.Name, err)
 		unstructuredList, err := dynamicClient.Resource(gvr).Namespace(resource.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
@@ -372,17 +370,17 @@ func FetchResourceTemplatesByLabelSelector(
 		for i := range unstructuredList.Items {
 			objects = append(objects, &unstructuredList.Items[i])
 		}
+		return objects, nil
 	}
 
-	if !usedFallback {
-		for i := range objectList {
-			unstructuredObj, err := ToUnstructured(objectList[i])
-			if err != nil {
-				klog.Errorf("Failed to transform object(%s/%s), Error: %v", resource.Namespace, resource.Name, err)
-				return nil, err
-			}
-			objects = append(objects, unstructuredObj)
+	// Process cache objects
+	for i := range objectList {
+		unstructuredObj, err := ToUnstructured(objectList[i])
+		if err != nil {
+			klog.Errorf("Failed to transform object(%s/%s), Error: %v", resource.Namespace, resource.Name, err)
+			return nil, err
 		}
+		objects = append(objects, unstructuredObj)
 	}
 	return objects, nil
 }


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Fixes the duplicate objects bug in FetchResourceTemplatesByLabelSelector function in pkg/util/helper/binding.go.

When cache fails and falls back to API server, the function was appending both the fallback results AND the original (empty) cache results, causing duplicates.

Added a `usedFallback` flag to track when fallback is used, and only append cache objects if fallback was NOT used.

**Which issue(s) this PR fixes**:
Fixes #7670

**Special notes for your reviewer**:
Tested locally with: `go test ./pkg/util/helper/`
All tests passed successfully.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```