### PR TITLE
Fix: Helm post-delete hook

### DIFF
--- a/charts/karmada/templates/post-delete-job.yaml
+++ b/charts/karmada/templates/post-delete-job.yaml
@@ -47,7 +47,11 @@ spec:
               set -ex
               kubectl delete -f /opt/mount/ --ignore-not-found=true
               kubectl delete -f /opt/crds/ --ignore-not-found=true -R
-              kubectl delete -f /opt/static-resources/ --ignore-not-found=true -R
+              for file in /opt/static-resources/*; do
+                if [ "$(basename "$file")" != "system-namespace.yaml" ]; then
+                  kubectl delete -f "$file" --ignore-not-found=true -R || true
+                fi
+              done
               kubectl delete cm/{{ $name }}-config -n {{ $namespace }} --ignore-not-found=true
               kubectl delete deployment/{{ $name }}-controller-manager -n {{ $namespace }} --ignore-not-found=true
               EOF


### PR DESCRIPTION
**What type of PR is this?**
  /kind bug

**What this PR does / why we need it**: 
This PR resolves a critical issue in the Helm chart where uninstalling the chart via the post-delete hook accidentally deletes cluster-scoped Namespace objects (like karmada-system and karmada-cluster) on the host cluster.

During uninstallation, the post-delete-job.yaml hook ran kubectl delete -f /opt/static-resources/ against the host cluster. Because system-namespace.yaml is located in that directory, the host cluster was instructed to delete those namespaces, cascading and destroying all resources inside them.

This PR replaces the broad kubectl delete -f command with a shell loop that explicitly ignores system-namespace.yaml during the cleanup process, preserving the namespaces on the host cluster while maintaining the cleanup logic for all other static resources.

**Which issue(s) this PR fixes**: 
Fixes #7618

**Special notes for your reviewer**: 
This has been manually verified by installing the Helm chart with --set systemNamespace=karmada-test-system onto a host cluster, and confirming that karmada-test-system is no longer deleted from the host cluster upon running helm uninstall.

**Does this PR introduce a user-facing change?**:
```release-note
`Helm chart`: Fixed an issue where the `post-delete` hook accidentally deleted the `karmada-system` namespace 
on the host cluster during uninstallation.
```