### PR TITLE
fix(webhook): correct FederatedResourceQuota log message typo

### DIFF
--- a/pkg/webhook/federatedresourcequota/validating.go
+++ b/pkg/webhook/federatedresourcequota/validating.go
@@ -51,7 +51,7 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	klog.V(2).Infof("Validating FederatedResourceQuote(%s) for request: %s", klog.KObj(quota).String(), req.Operation)
+	klog.V(2).Infof("Validating FederatedResourceQuota(%s) for request: %s", klog.KObj(quota).String(), req.Operation)
 
 	if errs := validateFederatedResourceQuota(quota); len(errs) != 0 {
 		klog.Errorf("%v", errs)


### PR DESCRIPTION
## What does this PR do?

This PR corrects a typo in the log message of the FederatedResourceQuota validating webhook.

The resource name in the log message was incorrectly written as `FederatedResourceQuote`. This change updates it to `FederatedResourceQuota` for consistency with the actual resource name and other validating webhooks.

## Does this PR introduce a user-facing change?

```release-note
NONE 
```
Fixes #7679