### PR TITLE
fix(validation): guard against nil TolerationSeconds in ValidateApplicationFailover

### DIFF
--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -333,7 +333,7 @@ func ValidateApplicationFailover(applicationFailoverBehavior *policyv1alpha1.App
 		return nil
 	}
 
-	if *applicationFailoverBehavior.DecisionConditions.TolerationSeconds < 0 {
+	if applicationFailoverBehavior.DecisionConditions.TolerationSeconds != nil && *applicationFailoverBehavior.DecisionConditions.TolerationSeconds < 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("decisionConditions").Child("tolerationSeconds"), *applicationFailoverBehavior.DecisionConditions.TolerationSeconds, "must be greater than or equal to 0"))
 	}
 

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -923,6 +923,15 @@ func TestValidateApplicationFailover(t *testing.T) {
 			expectedErr:                 "",
 		},
 		{
+			name: "tolerationSeconds is nil",
+			applicationFailoverBehavior: &policyv1alpha1.ApplicationFailoverBehavior{
+				DecisionConditions: policyv1alpha1.DecisionConditions{
+					TolerationSeconds: nil,
+				},
+			},
+			expectedErr: "",
+		},
+		{
 			name: "the tolerationSeconds is less than zero",
 			applicationFailoverBehavior: &policyv1alpha1.ApplicationFailoverBehavior{
 				DecisionConditions: policyv1alpha1.DecisionConditions{


### PR DESCRIPTION
## What does this PR do?

This PR adds a nil check before dereferencing `DecisionConditions.TolerationSeconds` in `ValidateApplicationFailover`.

Although the CRD currently provides a default value for this field, the validation function can also be invoked directly where the field may still be nil. This change makes the validation more defensive and consistent with the handling of other optional pointer fields in the same function.

In addition, this PR adds a unit test covering the nil `TolerationSeconds` case to prevent regressions.

Fixes #7688 

## Does this PR introduce a user-facing change?

```release-note
NONE
```

