### PR TITLE
test(e2e): synchronize ClusterRole propagation before cleanup

### DIFF
--- a/test/e2e/suites/base/clusterresourcebinding_test.go
+++ b/test/e2e/suites/base/clusterresourcebinding_test.go
@@ -92,6 +92,10 @@ var _ = ginkgo.Describe("ClusterResourceBinding test", func() {
 
 				return workList != nil && len(workList.Items) == len(framework.ClusterNames())
 			})
+
+			framework.WaitClusterRolePresentOnClustersFitWith(framework.ClusterNames(), clusterRole.Name, func(_ *rbacv1.ClusterRole) bool {
+				return true
+			})
 		})
 
 		ginkgo.It("propagates resource with permanent ID label", func() {


### PR DESCRIPTION
**What type of PR is this?**

/kind flake
/kind failing-test

**What this PR does / why we need it**:

While investigating a recent e2e failure, I noticed that the `creates work with permanent ID label` test in `clusterresourcebinding_test.go` does not follow the synchronization pattern used by similar propagation tests.

The test currently waits for the corresponding `Work` objects to be created in the control plane before completing. Since propagation to member clusters is asynchronous, cleanup can begin before the propagated `ClusterRole` has been created.

This PR adds `WaitClusterRolePresentOnClustersFitWith(...)` before the test completes, aligning it with the synchronization pattern already used by similar e2e tests and by the second `It` block in the same file.

**Which issue(s) this PR fixes**:

Fixes #7691 

**Special notes for your reviewer**:

While investigating a recent e2e failure, I noticed this difference between the first and second `It` blocks in `clusterresourcebinding_test.go`. This change reuses the existing synchronization helper without changing the test assertions or production code.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```