### PR TITLE
karmadactl: add a timeout to the InternetIP public IP lookup

### DIFF
--- a/pkg/karmadactl/cmdinit/utils/format.go
+++ b/pkg/karmadactl/cmdinit/utils/format.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
@@ -39,6 +40,11 @@ const (
 	labelSeparator = "="
 	// MaxRespBodyLength is the max length of http response body
 	MaxRespBodyLength = 1 << 20 // 1 MiB
+	// internetIPTimeout bounds the best-effort public IP lookup so that init does
+	// not hang when egress to the lookup service is blocked or slow. 10s mirrors
+	// the timeout style used by DownloadFile and is short enough to fail fast in
+	// air-gapped setups while still succeeding on a slow-but-working network.
+	internetIPTimeout = 10 * time.Second
 )
 
 // StringToNetIP String To NetIP
@@ -67,12 +73,26 @@ func FlagsDNS(dns string) []string {
 
 // InternetIP Current host Internet IP.
 func InternetIP() (net.IP, error) {
-	resp, err := http.Get(getInternetIPUrl)
+	return internetIP(getInternetIPUrl)
+}
+
+// internetIP looks up the host public IP from the given URL. The URL is a
+// parameter so the behavior can be unit tested with an httptest server instead
+// of reaching the live external service.
+func internetIP(url string) (net.IP, error) {
+	httpClient := http.Client{
+		Timeout: internetIPTimeout,
+	}
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return nil, err
 	}
 
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get internet IP, status code: %v", resp.StatusCode)
+	}
 
 	content, err := io.ReadAll(io.LimitReader(resp.Body, MaxRespBodyLength))
 	if err != nil {

--- a/pkg/karmadactl/cmdinit/utils/format_test.go
+++ b/pkg/karmadactl/cmdinit/utils/format_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"slices"
@@ -123,12 +126,44 @@ func TestFlagsDNS(t *testing.T) {
 }
 
 func TestInternetIP(t *testing.T) {
-	got, err := InternetIP()
-	if got == nil {
-		t.Errorf("InternetIP() want return not nil, but return nil")
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantIP     string
+		wantErr    bool
+	}{
+		{
+			name:       "valid IP is returned",
+			statusCode: http.StatusOK,
+			body:       "203.0.113.7",
+			wantIP:     "203.0.113.7",
+			wantErr:    false,
+		},
+		{
+			name:       "non-200 status returns an error instead of falling back to 127.0.0.1",
+			statusCode: http.StatusTooManyRequests,
+			body:       "rate limited",
+			wantErr:    true,
+		},
 	}
-	if err != nil {
-		t.Errorf("InternetIP() want return not error, but return error")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				fmt.Fprint(w, tt.body)
+			}))
+			defer server.Close()
+
+			got, err := internetIP(server.URL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("internetIP() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got.String() != tt.wantIP {
+				t.Errorf("internetIP() = %v, want %v", got, tt.wantIP)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`karmadactl init` looks up the host's public IP by calling an external service with `http.Get`, which uses Go's default client with no timeout. In air-gapped or restricted-egress networks where that request is silently dropped, init can hang during certificate generation. This PR gives the lookup a bounded timeout (mirroring `DownloadFile` in the same package, which already sets one), so it fails fast and init continues. The result is best-effort and the existing code already logs a warning on failure, so a timeout is safe.

**Which issue(s) this PR fixes**:
Fixes #7695

**Special notes for your reviewer**:

The change mirrors the existing `http.Client{Timeout: ...}` pattern used by `DownloadFile` in `pkg/karmadactl/cmdinit/utils/util.go`. `InternetIP()` calls a live external endpoint so it has no unit test today; happy to make the URL/client injectable and add an `httptest`-based test if you'd prefer. `gofmt`, `go vet`, `go build`, and the package tests all pass.

**Does this PR introduce a user-facing change?**:

```release-note
`karmadactl`: Fixed the issue that `init` could hang when looking up the host public IP, by adding a timeout to the lookup.
```
