### PR TITLE
feat: support rotating init-managed certificates

### DIFF
--- a/docs/command-line-flags/karmadactl_init.md
+++ b/docs/command-line-flags/karmadactl_init.md
@@ -54,6 +54,8 @@ karmadactl init
   # Specify external IPs(load balancer or HA IP) which used to sign the certificate
   karmadactl init --cert-external-ip 10.235.1.2 --cert-external-dns www.karmada.io
   
+  # Rotate certificates that are managed by karmadactl init, keeping other flags consistent with the original installation
+  karmadactl init --cert-mode=rotate
   # Install Karmada using a configuration file
   karmadactl init --config /path/to/your/config/file.yaml
   
@@ -96,10 +98,11 @@ karmadactl init
 ### Options
 
 ```
-      --ca-cert-file string                                     The root CA certificate file which will be used to issue new certificates for Karmada components. If not set, a new self-signed root CA certificate will be generated. This must be used together with --ca-key-file.
-      --ca-key-file string                                      The root CA private key file which will be used to issue new certificates for Karmada components. If not set, a new self-signed root CA key will be generated. This must be used together with --ca-cert-file.
+      --ca-cert-file string                                     The root CA certificate file used to issue Karmada component certificates. In install mode, a new self-signed CA is generated when omitted. In rotate mode, the file must match the existing CA; when omitted, the CA is loaded from the existing Secret. This must be used together with --ca-key-file.
+      --ca-key-file string                                      The root CA private key file used to issue Karmada component certificates. In install mode, a new self-signed CA key is generated when omitted. In rotate mode, the existing CA key is loaded from the Secret when omitted. This must be used together with --ca-cert-file.
       --cert-external-dns string                                the external DNS of Karmada certificate (e.g localhost,localhost.com)
       --cert-external-ip string                                 the external IP of Karmada certificate (e.g 192.168.1.2,172.16.1.2)
+      --cert-mode string                                        The certificate operation mode. Supported values are install and rotate. In rotate mode, external etcd CA and client credentials are preserved and must be rotated separately. (default "install")
       --cert-validity-period duration                           the validity period of Karmada certificate (e.g 8760h0m0s, that is 365 days) (default 8760h0m0s)
       --config string                                           Karmada init file path
       --context string                                          The name of the kubeconfig context to use

--- a/pkg/karmadactl/cmdinit/cert/cert.go
+++ b/pkg/karmadactl/cmdinit/cert/cert.go
@@ -86,6 +86,46 @@ func EncodeCertPEM(cert *x509.Certificate) []byte {
 	return pem.EncodeToMemory(&block)
 }
 
+// EncodePrivateKeyPEM returns PEM-encoded private key data.
+func EncodePrivateKeyPEM(key crypto.Signer) ([]byte, error) {
+	if key == nil {
+		return nil, errors.New("private key cannot be nil when encoding to PEM")
+	}
+	return keyutil.MarshalPrivateKeyToPEM(key)
+}
+
+// LoadCertificatePEM loads a certificate from PEM-encoded bytes.
+func LoadCertificatePEM(certPEM []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, errors.New("failed to decode certificate PEM")
+	}
+	if block.Type != certificateBlockType {
+		return nil, fmt.Errorf("expected PEM block type %q, got %q", certificateBlockType, block.Type)
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+// LoadCertAndKeyPEM loads a certificate and private key from PEM-encoded bytes.
+func LoadCertAndKeyPEM(certPEM, keyPEM []byte) (*x509.Certificate, crypto.Signer, error) {
+	keyPair, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(keyPair.Certificate) == 0 {
+		return nil, nil, errors.New("certificate PEM does not contain certificates")
+	}
+	loadedCert, err := x509.ParseCertificate(keyPair.Certificate[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	loadedKey, ok := keyPair.PrivateKey.(crypto.Signer)
+	if !ok {
+		return nil, nil, errors.New("private key does not implement crypto.Signer")
+	}
+	return loadedCert, loadedKey, nil
+}
+
 // NewCertificateAuthority creates new certificate and private key for the certificate authority
 func NewCertificateAuthority(config *CertsConfig) (*x509.Certificate, crypto.Signer, error) {
 	key, err := NewPrivateKey(config.PublicKeyAlgorithm)
@@ -230,7 +270,7 @@ func WriteKey(pkiPath, name string, key crypto.Signer) error {
 	}
 
 	privateKeyPath := PathForKey(pkiPath, name)
-	encoded, err := keyutil.MarshalPrivateKeyToPEM(key)
+	encoded, err := EncodePrivateKeyPEM(key)
 	if err != nil {
 		return fmt.Errorf("unable to marshal private key to PEM %v", err)
 	}

--- a/pkg/karmadactl/cmdinit/cert/cert_test.go
+++ b/pkg/karmadactl/cmdinit/cert/cert_test.go
@@ -146,6 +146,50 @@ func TestGenCerts(t *testing.T) {
 	}
 }
 
+func TestLoadCertAndKeyPEM(t *testing.T) {
+	caCert, caKey, err := NewCACertAndKey("test-ca")
+	if err != nil {
+		t.Fatal(err)
+	}
+	caKeyPEM, err := EncodePrivateKeyPEM(*caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loadedCert, loadedKey, err := LoadCertAndKeyPEM(EncodeCertPEM(caCert), caKeyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loadedCert.Subject.CommonName != caCert.Subject.CommonName {
+		t.Fatalf("LoadCertAndKeyPEM() CommonName = %s, want %s", loadedCert.Subject.CommonName, caCert.Subject.CommonName)
+	}
+
+	notAfter := time.Now().Add(Duration365d).UTC()
+	leafConfig := NewCertConfig("leaf", nil, certutil.AltNames{}, &notAfter)
+	leafCert, _, err := NewCertAndKey(loadedCert, loadedKey, leafConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := leafCert.CheckSignatureFrom(loadedCert); err != nil {
+		t.Fatalf("rotated leaf certificate is not signed by the loaded CA: %v", err)
+	}
+}
+
+func TestLoadCertAndKeyPEMRejectsInvalidData(t *testing.T) {
+	if _, _, err := LoadCertAndKeyPEM([]byte("invalid cert"), []byte("invalid key")); err == nil {
+		t.Fatal("LoadCertAndKeyPEM() expected an error for invalid PEM data")
+	}
+	if _, err := LoadCertificatePEM([]byte("invalid cert")); err == nil {
+		t.Fatal("LoadCertificatePEM() expected an error for invalid PEM data")
+	}
+}
+
+func TestEncodePrivateKeyPEMRejectsNilKey(t *testing.T) {
+	if _, err := EncodePrivateKeyPEM(nil); err == nil {
+		t.Fatal("EncodePrivateKeyPEM() expected an error for nil key")
+	}
+}
+
 func checkCertFiles(path string, files []string) error {
 	for _, file := range files {
 		filePath := filepath.Join(path, file)

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -78,6 +78,8 @@ var (
 		# Specify external IPs(load balancer or HA IP) which used to sign the certificate
 		%[1]s init --cert-external-ip 10.235.1.2 --cert-external-dns www.karmada.io
 
+		# Rotate certificates that are managed by karmadactl init, keeping other flags consistent with the original installation
+		%[1]s init --cert-mode=rotate
 		# Install Karmada using a configuration file
 		%[1]s init --config /path/to/your/config/file.yaml
 		
@@ -163,8 +165,9 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	flags.StringVar(&opts.ExternalIP, "cert-external-ip", "", "the external IP of Karmada certificate (e.g 192.168.1.2,172.16.1.2)")
 	flags.StringVar(&opts.ExternalDNS, "cert-external-dns", "", "the external DNS of Karmada certificate (e.g localhost,localhost.com)")
 	flags.DurationVar(&opts.CertValidity, "cert-validity-period", cert.Duration365d, "the validity period of Karmada certificate (e.g 8760h0m0s, that is 365 days)")
-	flags.StringVarP(&opts.CaCertFile, "ca-cert-file", "", "", "The root CA certificate file which will be used to issue new certificates for Karmada components. If not set, a new self-signed root CA certificate will be generated. This must be used together with --ca-key-file.")
-	flags.StringVarP(&opts.CaKeyFile, "ca-key-file", "", "", "The root CA private key file which will be used to issue new certificates for Karmada components. If not set, a new self-signed root CA key will be generated. This must be used together with --ca-cert-file.")
+	flags.StringVar(&opts.CertMode, "cert-mode", kubernetes.CertModeInstall, fmt.Sprintf("The certificate operation mode. Supported values are %s and %s. In rotate mode, external etcd CA and client credentials are preserved and must be rotated separately.", kubernetes.CertModeInstall, kubernetes.CertModeRotate))
+	flags.StringVarP(&opts.CaCertFile, "ca-cert-file", "", "", "The root CA certificate file used to issue Karmada component certificates. In install mode, a new self-signed CA is generated when omitted. In rotate mode, the file must match the existing CA; when omitted, the CA is loaded from the existing Secret. This must be used together with --ca-key-file.")
+	flags.StringVarP(&opts.CaKeyFile, "ca-key-file", "", "", "The root CA private key file used to issue Karmada component certificates. In install mode, a new self-signed CA key is generated when omitted. In rotate mode, the existing CA key is loaded from the Secret when omitted. This must be used together with --ca-cert-file.")
 	// Kubernetes
 	flags.StringVarP(&opts.Namespace, "namespace", "n", "karmada-system", "Kubernetes namespace")
 	flags.StringVar(&opts.StorageClassesName, "storage-classes-name", "", "Kubernetes StorageClasses Name")

--- a/pkg/karmadactl/cmdinit/cmdinit_test.go
+++ b/pkg/karmadactl/cmdinit/cmdinit_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmdinit
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -24,6 +25,14 @@ func TestNewCmdInit(t *testing.T) {
 	cmdinit := NewCmdInit("karmadactl")
 	if cmdinit == nil {
 		t.Errorf("NewCmdInit() want return not nil, but return nil")
+	}
+	certModeFlag := cmdinit.Flags().Lookup("cert-mode")
+	if certModeFlag == nil {
+		t.Errorf("NewCmdInit() should include cert-mode flag")
+		return
+	}
+	if !strings.Contains(certModeFlag.Usage, "external etcd CA and client credentials are preserved and must be rotated separately") {
+		t.Errorf("cert-mode flag usage should document external etcd credential rotation, got %q", certModeFlag.Usage)
 	}
 }
 

--- a/pkg/karmadactl/cmdinit/kubernetes/cert_rotation.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/cert_rotation.go
@@ -1,0 +1,630 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+
+	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/cert"
+	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
+	globaloptions "github.com/karmada-io/karmada/pkg/karmadactl/options"
+)
+
+type caMaterial struct {
+	cert    *x509.Certificate
+	key     crypto.Signer
+	certPEM []byte
+	keyPEM  []byte
+}
+
+// runCertRotate executes certificate rotation for the cert material managed by karmadactl init.
+func (i *CommandInitOption) runCertRotate() error {
+	i.CertAndKeyFileData = map[string][]byte{}
+	if err := i.prepareRotatedCertAndKeyData(); err != nil {
+		return err
+	}
+
+	if err := i.refreshLocalAdminKubeconfigIfExists(); err != nil {
+		return err
+	}
+
+	if err := i.updateCertsSecrets(); err != nil {
+		return err
+	}
+
+	klog.Infof("Certificate Secrets in namespace %q have been updated. Restart Karmada control plane components to load the rotated certificates.", i.Namespace)
+	return nil
+}
+
+// prepareRotatedCertAndKeyData rebuilds CertAndKeyFileData from existing CA material.
+func (i *CommandInitOption) prepareRotatedCertAndKeyData() error {
+	karmadaSecret, err := i.getExistingSecret(globaloptions.KarmadaCertsName)
+	if err != nil {
+		return err
+	}
+	certConfigs, err := i.buildRotateCertConfigs(karmadaSecret)
+	if err != nil {
+		return err
+	}
+
+	rootCA, err := i.loadRootCAMaterial(karmadaSecret)
+	if err != nil {
+		return err
+	}
+	i.setCertAndKeyData(globaloptions.CaCertAndKeyName, rootCA.certPEM, rootCA.keyPEM)
+
+	frontProxyCA, err := loadCAMaterialFromSecret(karmadaSecret, options.FrontProxyCaCertAndKeyName)
+	if err != nil {
+		return err
+	}
+	i.setCertAndKeyData(options.FrontProxyCaCertAndKeyName, frontProxyCA.certPEM, frontProxyCA.keyPEM)
+
+	// karmada.key is also the ServiceAccount signing key, so keep it stable during TLS certificate rotation.
+	if err := i.signLeafCertWithExistingKey(options.KarmadaCertAndKeyName, rootCA, certConfigs.karmada, karmadaSecret); err != nil {
+		return err
+	}
+	if err := i.signLeafCert(options.ApiserverCertAndKeyName, rootCA, certConfigs.apiserver); err != nil {
+		return err
+	}
+	if err := i.signLeafCert(options.FrontProxyClientCertAndKeyName, frontProxyCA, certConfigs.frontProxyClient); err != nil {
+		return err
+	}
+
+	if i.isExternalEtcdProvided() {
+		return i.prepareExternalEtcdCertAndKeyData(karmadaSecret)
+	}
+	return i.prepareInternalEtcdCertAndKeyData(karmadaSecret, certConfigs)
+}
+
+// buildRotateCertConfigs builds deterministic configs and preserves identities from existing leaf certificates.
+func (i *CommandInitOption) buildRotateCertConfigs(karmadaSecret *corev1.Secret) (*initCertConfigs, error) {
+	certConfigs, err := i.buildCertConfigs(false)
+	if err != nil {
+		return nil, err
+	}
+
+	existingKarmadaCert, err := loadCertificateFromSecret(karmadaSecret, options.KarmadaCertAndKeyName)
+	if err != nil {
+		return nil, err
+	}
+	mergeCertificateAltNames(certConfigs.karmada, existingKarmadaCert)
+
+	existingAPIServerCert, err := loadCertificateFromSecret(karmadaSecret, options.ApiserverCertAndKeyName)
+	if err != nil {
+		return nil, err
+	}
+	mergeCertificateAltNames(certConfigs.apiserver, existingAPIServerCert)
+	return certConfigs, nil
+}
+
+// mergeCertificateAltNames adds persisted DNS and IP identities without sharing mutable config slices.
+func mergeCertificateAltNames(certConfig *cert.CertsConfig, existingCert *x509.Certificate) {
+	certConfig.AltNames.DNSNames = append(append([]string(nil), certConfig.AltNames.DNSNames...), existingCert.DNSNames...)
+	certConfig.AltNames.IPs = append(append([]net.IP(nil), certConfig.AltNames.IPs...), existingCert.IPAddresses...)
+	cert.RemoveDuplicateAltNames(&certConfig.AltNames)
+}
+
+func (i *CommandInitOption) prepareInternalEtcdCertAndKeyData(karmadaSecret *corev1.Secret, certConfigs *initCertConfigs) error {
+	etcdSecret, err := i.getExistingSecret(etcdCertName)
+	if err != nil {
+		return err
+	}
+	if !hasExistingEtcdServerCert(etcdSecret) {
+		return fmt.Errorf("internal etcd parameters cannot be used to rotate certificates for an existing external etcd installation")
+	}
+
+	etcdCA, err := loadCAMaterialFromSecret(etcdSecret, options.EtcdCaCertAndKeyName)
+	if err != nil {
+		etcdCA, err = loadCAMaterialFromSecret(karmadaSecret, options.EtcdCaCertAndKeyName)
+		if err != nil {
+			return err
+		}
+	}
+	i.setCertAndKeyData(options.EtcdCaCertAndKeyName, etcdCA.certPEM, etcdCA.keyPEM)
+
+	existingEtcdServerCert, err := loadCertificateFromSecret(etcdSecret, options.EtcdServerCertAndKeyName)
+	if err != nil {
+		return err
+	}
+	mergeCertificateAltNames(certConfigs.etcdServer, existingEtcdServerCert)
+
+	if err := i.signLeafCert(options.EtcdServerCertAndKeyName, etcdCA, certConfigs.etcdServer); err != nil {
+		return err
+	}
+	return i.signLeafCert(options.EtcdClientCertAndKeyName, etcdCA, certConfigs.etcdClient)
+}
+
+func (i *CommandInitOption) prepareExternalEtcdCertAndKeyData(karmadaSecret *corev1.Secret) error {
+	etcdSecret, err := i.getExistingSecret(etcdCertName)
+	if err != nil {
+		return err
+	}
+	if hasExistingEtcdServerCert(etcdSecret) {
+		return fmt.Errorf("external etcd parameters cannot be used to rotate certificates for an existing internal etcd installation")
+	}
+
+	existingCACertPEM, err := firstSecretDataValue(certFileName(options.EtcdCaCertAndKeyName), etcdSecret, karmadaSecret)
+	if err != nil {
+		return err
+	}
+	if err := i.validateExternalEtcdCA(existingCACertPEM); err != nil {
+		return err
+	}
+	i.setCertAndKeyData(options.EtcdCaCertAndKeyName, existingCACertPEM, emptyByteSlice)
+
+	i.setCertAndKeyData(options.EtcdServerCertAndKeyName, emptyByteSlice, emptyByteSlice)
+
+	existingClientCertPEM, err := firstSecretDataValue(certFileName(options.EtcdClientCertAndKeyName), karmadaSecret)
+	if err != nil {
+		return err
+	}
+	existingClientKeyPEM, err := firstSecretDataValue(keyFileName(options.EtcdClientCertAndKeyName), karmadaSecret)
+	if err != nil {
+		return err
+	}
+	if err := i.validateExternalEtcdClientCredential(existingClientCertPEM, existingClientKeyPEM); err != nil {
+		return err
+	}
+	i.setCertAndKeyData(options.EtcdClientCertAndKeyName, existingClientCertPEM, existingClientKeyPEM)
+	return nil
+}
+
+// validateExternalEtcdCA verifies that supplied external etcd files do not replace the existing trust root.
+func (i *CommandInitOption) validateExternalEtcdCA(existingCertPEM []byte) error {
+	existingCert, err := cert.LoadCertificatePEM(existingCertPEM)
+	if err != nil {
+		return fmt.Errorf("failed to load existing external etcd CA certificate: %w", err)
+	}
+	if i.ExternalEtcdCACertPath == "" {
+		return nil
+	}
+
+	suppliedCertPEM, err := os.ReadFile(i.ExternalEtcdCACertPath)
+	if err != nil {
+		return err
+	}
+	suppliedCert, err := cert.LoadCertificatePEM(suppliedCertPEM)
+	if err != nil {
+		return fmt.Errorf("failed to load external etcd CA certificate file %q: %w", i.ExternalEtcdCACertPath, err)
+	}
+	if !bytes.Equal(suppliedCert.Raw, existingCert.Raw) {
+		return errors.New("external etcd CA certificate cannot be changed by certificate rotation; rotate external etcd credentials separately")
+	}
+	return nil
+}
+
+// validateExternalEtcdClientCredential verifies the existing pair and rejects supplied replacement credentials.
+func (i *CommandInitOption) validateExternalEtcdClientCredential(existingCertPEM, existingKeyPEM []byte) error {
+	existingCert, _, err := cert.LoadCertAndKeyPEM(existingCertPEM, existingKeyPEM)
+	if err != nil {
+		return fmt.Errorf("failed to load existing external etcd client certificate and key: %w", err)
+	}
+	if i.ExternalEtcdClientCertPath == "" || i.ExternalEtcdClientKeyPath == "" {
+		return nil
+	}
+
+	suppliedCertPEM, err := os.ReadFile(i.ExternalEtcdClientCertPath)
+	if err != nil {
+		return err
+	}
+	suppliedKeyPEM, err := os.ReadFile(i.ExternalEtcdClientKeyPath)
+	if err != nil {
+		return err
+	}
+	suppliedCert, _, err := cert.LoadCertAndKeyPEM(suppliedCertPEM, suppliedKeyPEM)
+	if err != nil {
+		return fmt.Errorf("failed to load external etcd client certificate and key files: %w", err)
+	}
+	if !bytes.Equal(suppliedCert.Raw, existingCert.Raw) {
+		return errors.New("external etcd client certificate cannot be changed by certificate rotation; rotate external etcd credentials separately")
+	}
+	return nil
+}
+
+// loadRootCAMaterial loads the root CA from files or the existing karmada-cert Secret.
+func (i *CommandInitOption) loadRootCAMaterial(karmadaSecret *corev1.Secret) (*caMaterial, error) {
+	existingCert, err := loadCertificateFromSecret(karmadaSecret, globaloptions.CaCertAndKeyName)
+	if err != nil {
+		return nil, err
+	}
+
+	if i.CaCertFile != "" && i.CaKeyFile != "" {
+		fileCA, err := loadCAMaterialFromFiles(i.CaCertFile, i.CaKeyFile)
+		if err != nil {
+			return nil, err
+		}
+		if !bytes.Equal(fileCA.cert.Raw, existingCert.Raw) {
+			return nil, fmt.Errorf("ca-cert-file must match the existing %s/%s Secret CA certificate during certificate rotation", i.Namespace, globaloptions.KarmadaCertsName)
+		}
+		return fileCA, nil
+	}
+
+	return loadCAMaterialFromSecret(karmadaSecret, globaloptions.CaCertAndKeyName)
+}
+
+// signLeafCert signs one leaf certificate using existing CA material.
+func (i *CommandInitOption) signLeafCert(name string, ca *caMaterial, certConfig *cert.CertsConfig) error {
+	if certConfig == nil {
+		return fmt.Errorf("certificate config for %s is nil", name)
+	}
+	if err := validateCAForLeaf(ca, certConfig, time.Now().UTC()); err != nil {
+		return fmt.Errorf("cannot sign certificate %q: %w", name, err)
+	}
+
+	leafCert, leafKey, err := cert.NewCertAndKey(ca.cert, ca.key, certConfig)
+	if err != nil {
+		return err
+	}
+	leafKeyPEM, err := cert.EncodePrivateKeyPEM(leafKey)
+	if err != nil {
+		return err
+	}
+	i.setCertAndKeyData(name, cert.EncodeCertPEM(leafCert), leafKeyPEM)
+	return nil
+}
+
+// signLeafCertWithExistingKey renews a leaf certificate without replacing its private key.
+func (i *CommandInitOption) signLeafCertWithExistingKey(name string, ca *caMaterial, certConfig *cert.CertsConfig, secret *corev1.Secret) error {
+	if certConfig == nil {
+		return fmt.Errorf("certificate config for %s is nil", name)
+	}
+	if len(certConfig.Usages) == 0 {
+		return fmt.Errorf("certificate config for %s must specify at least one ExtKeyUsage", name)
+	}
+	if err := validateCAForLeaf(ca, certConfig, time.Now().UTC()); err != nil {
+		return fmt.Errorf("cannot sign certificate %q: %w", name, err)
+	}
+
+	certPEM, err := secretDataValue(secret, certFileName(name))
+	if err != nil {
+		return err
+	}
+	keyPEM, err := secretDataValue(secret, keyFileName(name))
+	if err != nil {
+		return err
+	}
+	_, existingKey, err := cert.LoadCertAndKeyPEM(certPEM, keyPEM)
+	if err != nil {
+		return fmt.Errorf("failed to load existing certificate and key for %q: %w", name, err)
+	}
+
+	leafCert, err := cert.NewSignedCert(certConfig, existingKey, ca.cert, ca.key, false)
+	if err != nil {
+		return fmt.Errorf("unable to sign certificate: %w", err)
+	}
+	i.setCertAndKeyData(name, cert.EncodeCertPEM(leafCert), keyPEM)
+	return nil
+}
+
+// validateCAForLeaf verifies that the existing CA can issue the requested leaf certificate.
+func validateCAForLeaf(ca *caMaterial, certConfig *cert.CertsConfig, now time.Time) error {
+	if ca == nil || ca.cert == nil || ca.key == nil {
+		return errors.New("ca certificate and private key must not be nil")
+	}
+	if !ca.cert.BasicConstraintsValid || !ca.cert.IsCA {
+		return fmt.Errorf("certificate %q is not a valid certificate authority", ca.cert.Subject.CommonName)
+	}
+	// RFC 5280 requires keyCertSign only when the optional keyUsage extension is present.
+	if ca.cert.KeyUsage != 0 && ca.cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		return fmt.Errorf("ca certificate %q is not authorized to sign certificates", ca.cert.Subject.CommonName)
+	}
+	if now.Before(ca.cert.NotBefore) {
+		return fmt.Errorf("ca certificate %q is not valid before %s", ca.cert.Subject.CommonName, ca.cert.NotBefore.UTC().Format(time.RFC3339))
+	}
+	if now.After(ca.cert.NotAfter) {
+		return fmt.Errorf("ca certificate %q expired at %s", ca.cert.Subject.CommonName, ca.cert.NotAfter.UTC().Format(time.RFC3339))
+	}
+
+	leafNotAfter := now.Add(cert.Duration365d)
+	if certConfig != nil && certConfig.NotAfter != nil {
+		leafNotAfter = certConfig.NotAfter.UTC()
+	}
+	if !leafNotAfter.After(now) {
+		return fmt.Errorf("requested certificate expiry %s is not after the current time", leafNotAfter.Format(time.RFC3339))
+	}
+	if leafNotAfter.After(ca.cert.NotAfter) {
+		return fmt.Errorf("requested certificate expiry %s exceeds CA expiry %s", leafNotAfter.Format(time.RFC3339), ca.cert.NotAfter.UTC().Format(time.RFC3339))
+	}
+	return nil
+}
+
+// refreshLocalAdminKubeconfigIfExists updates the generated local kubeconfig without changing its endpoint or context.
+func (i *CommandInitOption) refreshLocalAdminKubeconfigIfExists() error {
+	if i.KarmadaDataPath == "" {
+		return nil
+	}
+
+	kubeconfigPath := filepath.Join(i.KarmadaDataPath, options.KarmadaKubeConfigName)
+	fileInfo, err := os.Lstat(kubeconfigPath)
+	if os.IsNotExist(err) {
+		klog.Warningf("Local Karmada kubeconfig %q was not found; only certificate Secrets will be updated.", kubeconfigPath)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect local Karmada kubeconfig %q: %w", kubeconfigPath, err)
+	}
+	if !fileInfo.Mode().IsRegular() {
+		return fmt.Errorf("local Karmada kubeconfig %q must be a regular file", kubeconfigPath)
+	}
+
+	kubeconfig, err := clientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load local Karmada kubeconfig %q: %w", kubeconfigPath, err)
+	}
+	cluster, ok := kubeconfig.Clusters[options.ClusterName]
+	if !ok || cluster == nil {
+		return fmt.Errorf("local Karmada kubeconfig %q does not contain cluster %q", kubeconfigPath, options.ClusterName)
+	}
+	authInfo, ok := kubeconfig.AuthInfos[options.UserName]
+	if !ok || authInfo == nil {
+		return fmt.Errorf("local Karmada kubeconfig %q does not contain user %q", kubeconfigPath, options.UserName)
+	}
+	if err := i.validateLocalAdminKubeconfigIdentity(kubeconfigPath, cluster.CertificateAuthorityData, cluster.CertificateAuthority,
+		authInfo.ClientCertificateData, authInfo.ClientCertificate); err != nil {
+		return err
+	}
+
+	cluster.CertificateAuthority = ""
+	cluster.CertificateAuthorityData = cloneBytes(i.CertAndKeyFileData[certFileName(globaloptions.CaCertAndKeyName)])
+	authInfo.ClientCertificate = ""
+	authInfo.ClientCertificateData = cloneBytes(i.CertAndKeyFileData[certFileName(options.KarmadaCertAndKeyName)])
+	authInfo.ClientKey = ""
+	authInfo.ClientKeyData = cloneBytes(i.CertAndKeyFileData[keyFileName(options.KarmadaCertAndKeyName)])
+
+	configBytes, err := clientcmd.Write(*kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to serialize local Karmada kubeconfig %q: %w", kubeconfigPath, err)
+	}
+	if err := writeFileAtomically(kubeconfigPath, configBytes, fileInfo.Mode().Perm()); err != nil {
+		return fmt.Errorf("failed to update local Karmada kubeconfig %q: %w", kubeconfigPath, err)
+	}
+	return nil
+}
+
+// validateLocalAdminKubeconfigIdentity binds the local endpoint to the selected remote certificate identity.
+func (i *CommandInitOption) validateLocalAdminKubeconfigIdentity(kubeconfigPath string, caData []byte, caFile string, clientCertData []byte, clientCertFile string) error {
+	localCA, err := loadKubeconfigCA(kubeconfigPath, caData, caFile)
+	if err != nil {
+		return err
+	}
+	targetCA, err := cert.LoadCertificatePEM(i.CertAndKeyFileData[certFileName(globaloptions.CaCertAndKeyName)])
+	if err != nil {
+		return fmt.Errorf("failed to load target CA certificate from Secret %s/%s: %w", i.Namespace, globaloptions.KarmadaCertsName, err)
+	}
+	if !bytes.Equal(localCA.Raw, targetCA.Raw) {
+		return fmt.Errorf("local Karmada kubeconfig %q CA does not match Secret %s/%s CA", kubeconfigPath, i.Namespace, globaloptions.KarmadaCertsName)
+	}
+
+	localClientCert, err := loadKubeconfigClientCertificate(kubeconfigPath, clientCertData, clientCertFile)
+	if err != nil {
+		return err
+	}
+	targetClientCert, err := cert.LoadCertificatePEM(i.CertAndKeyFileData[certFileName(options.KarmadaCertAndKeyName)])
+	if err != nil {
+		return fmt.Errorf("failed to load target client certificate from Secret %s/%s: %w", i.Namespace, globaloptions.KarmadaCertsName, err)
+	}
+	if !bytes.Equal(localClientCert.RawSubjectPublicKeyInfo, targetClientCert.RawSubjectPublicKeyInfo) {
+		return fmt.Errorf("local Karmada kubeconfig %q client certificate does not match Secret %s/%s client identity", kubeconfigPath, i.Namespace, globaloptions.KarmadaCertsName)
+	}
+	return nil
+}
+
+// loadKubeconfigCA loads an embedded CA or resolves its file relative to the kubeconfig.
+func loadKubeconfigCA(kubeconfigPath string, caData []byte, caFile string) (*x509.Certificate, error) {
+	if len(caData) > 0 {
+		loadedCA, err := cert.LoadCertificatePEM(caData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load CA certificate embedded in local Karmada kubeconfig %q: %w", kubeconfigPath, err)
+		}
+		return loadedCA, nil
+	}
+	if caFile == "" {
+		return nil, fmt.Errorf("local Karmada kubeconfig %q does not contain CA certificate data or a CA certificate file", kubeconfigPath)
+	}
+	if !filepath.IsAbs(caFile) {
+		caFile = filepath.Join(filepath.Dir(kubeconfigPath), caFile)
+	}
+	caData, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certificate file %q referenced by local Karmada kubeconfig: %w", caFile, err)
+	}
+	loadedCA, err := cert.LoadCertificatePEM(caData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load CA certificate file %q referenced by local Karmada kubeconfig: %w", caFile, err)
+	}
+	return loadedCA, nil
+}
+
+// loadKubeconfigClientCertificate loads an embedded client certificate or resolves its file relative to the kubeconfig.
+func loadKubeconfigClientCertificate(kubeconfigPath string, certData []byte, certFile string) (*x509.Certificate, error) {
+	if len(certData) > 0 {
+		loadedCert, err := cert.LoadCertificatePEM(certData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate embedded in local Karmada kubeconfig %q: %w", kubeconfigPath, err)
+		}
+		return loadedCert, nil
+	}
+	if certFile == "" {
+		return nil, fmt.Errorf("local Karmada kubeconfig %q does not contain client certificate data or a client certificate file", kubeconfigPath)
+	}
+	if !filepath.IsAbs(certFile) {
+		certFile = filepath.Join(filepath.Dir(kubeconfigPath), certFile)
+	}
+	certData, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read client certificate file %q referenced by local Karmada kubeconfig: %w", certFile, err)
+	}
+	loadedCert, err := cert.LoadCertificatePEM(certData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client certificate file %q referenced by local Karmada kubeconfig: %w", certFile, err)
+	}
+	return loadedCert, nil
+}
+
+// writeFileAtomically replaces a file using a temporary file in the same directory.
+func writeFileAtomically(filename string, data []byte, mode os.FileMode) error {
+	tempFile, err := os.CreateTemp(filepath.Dir(filename), "."+filepath.Base(filename)+"-*")
+	if err != nil {
+		return err
+	}
+	tempName := tempFile.Name()
+	defer func() {
+		_ = tempFile.Close()
+		_ = os.Remove(tempName)
+	}()
+
+	if err := tempFile.Chmod(mode); err != nil {
+		return err
+	}
+	if _, err := tempFile.Write(data); err != nil {
+		return err
+	}
+	if err := tempFile.Sync(); err != nil {
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempName, filename)
+}
+
+func (i *CommandInitOption) setCertAndKeyData(name string, certPEM, keyPEM []byte) {
+	i.CertAndKeyFileData[certFileName(name)] = cloneBytes(certPEM)
+	i.CertAndKeyFileData[keyFileName(name)] = cloneBytes(keyPEM)
+}
+
+func (i *CommandInitOption) getExistingSecret(name string) (*corev1.Secret, error) {
+	existingSecret, err := i.KubeClientSet.CoreV1().Secrets(i.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get existing Secret %s/%s: %w", i.Namespace, name, err)
+	}
+	return existingSecret, nil
+}
+
+// loadCAMaterialFromFiles loads a CA certificate and private key from local files.
+func loadCAMaterialFromFiles(certFile, keyFile string) (*caMaterial, error) {
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, err
+	}
+	keyPEM, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	loadedCert, loadedKey, err := cert.LoadCertAndKeyPEM(certPEM, keyPEM)
+	if err != nil {
+		return nil, err
+	}
+	return &caMaterial{
+		cert:    loadedCert,
+		key:     loadedKey,
+		certPEM: cloneBytes(certPEM),
+		keyPEM:  cloneBytes(keyPEM),
+	}, nil
+}
+
+// loadCAMaterialFromSecret loads a CA certificate and private key from a Secret.
+func loadCAMaterialFromSecret(secret *corev1.Secret, name string) (*caMaterial, error) {
+	certPEM, err := secretDataValue(secret, certFileName(name))
+	if err != nil {
+		return nil, err
+	}
+	keyPEM, err := secretDataValue(secret, keyFileName(name))
+	if err != nil {
+		return nil, err
+	}
+	loadedCert, loadedKey, err := cert.LoadCertAndKeyPEM(certPEM, keyPEM)
+	if err != nil {
+		return nil, err
+	}
+	return &caMaterial{
+		cert:    loadedCert,
+		key:     loadedKey,
+		certPEM: certPEM,
+		keyPEM:  keyPEM,
+	}, nil
+}
+
+func loadCertificateFromSecret(secret *corev1.Secret, name string) (*x509.Certificate, error) {
+	certPEM, err := secretDataValue(secret, certFileName(name))
+	if err != nil {
+		return nil, err
+	}
+	return cert.LoadCertificatePEM(certPEM)
+}
+
+// hasExistingEtcdServerCert checks whether an existing etcd-cert Secret belongs to an internal etcd installation.
+func hasExistingEtcdServerCert(secret *corev1.Secret) bool {
+	if secret == nil {
+		return false
+	}
+	cert, err := secretDataValue(secret, certFileName(options.EtcdServerCertAndKeyName))
+	if err != nil || len(cert) == 0 {
+		return false
+	}
+	key, err := secretDataValue(secret, keyFileName(options.EtcdServerCertAndKeyName))
+	return err == nil && len(key) > 0
+}
+
+func firstSecretDataValue(key string, secrets ...*corev1.Secret) ([]byte, error) {
+	for _, secret := range secrets {
+		value, err := secretDataValue(secret, key)
+		if err == nil {
+			return value, nil
+		}
+	}
+	return nil, fmt.Errorf("failed to find non-empty %q in existing certificate Secrets", key)
+}
+
+func secretDataValue(secret *corev1.Secret, key string) ([]byte, error) {
+	if secret == nil {
+		return nil, fmt.Errorf("secret is nil")
+	}
+	if value, ok := secret.Data[key]; ok && len(value) > 0 {
+		return cloneBytes(value), nil
+	}
+	if value, ok := secret.StringData[key]; ok && value != "" {
+		return []byte(value), nil
+	}
+	return nil, fmt.Errorf("failed to find non-empty %q in Secret %s/%s", key, secret.Namespace, secret.Name)
+}
+
+func certFileName(name string) string {
+	return fmt.Sprintf("%s.crt", name)
+}
+
+func keyFileName(name string) string {
+	return fmt.Sprintf("%s.key", name)
+}
+
+func cloneBytes(value []byte) []byte {
+	return append([]byte(nil), value...)
+}

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -111,6 +112,13 @@ var (
 	DefaultKarmadaWebhookImage string
 	// DefaultKarmadaAggregatedAPIServerImage Karmada aggregated apiserver image
 	DefaultKarmadaAggregatedAPIServerImage string
+)
+
+const (
+	// CertModeInstall instructs karmadactl init to run the default installation flow.
+	CertModeInstall = "install"
+	// CertModeRotate instructs karmadactl init to rotate init-managed certificates.
+	CertModeRotate = "rotate"
 )
 
 const (
@@ -217,6 +225,8 @@ type CommandInitOption struct {
 	ExternalDNS        string
 	PullSecrets        []string
 	CertValidity       time.Duration
+	// CertMode configures the certificate operation mode, such as "install" or "rotate".
+	CertMode           string
 	KubeClientSet      kubernetes.Interface
 	CertAndKeyFileData map[string][]byte
 	RestConfig         *rest.Config
@@ -265,6 +275,23 @@ func (i *CommandInitOption) validateExternalEtcd(_ string) error {
 
 func (i *CommandInitOption) isExternalEtcdProvided() bool {
 	return i.ExternalEtcdServers != ""
+}
+
+func (i *CommandInitOption) certMode() string {
+	if i.CertMode == "" {
+		return CertModeInstall
+	}
+	return i.CertMode
+}
+
+// validateCertMode validates that the configured certificate mode is supported.
+func (i *CommandInitOption) validateCertMode() error {
+	switch i.certMode() {
+	case CertModeInstall, CertModeRotate:
+		return nil
+	default:
+		return fmt.Errorf("unsupported cert-mode %q, supported values are %q and %q", i.CertMode, CertModeInstall, CertModeRotate)
+	}
 }
 
 // validateCommandLineArgs The parameters that are successfully validated will be reassigned to the corresponding xxxExtraArgs.
@@ -330,6 +357,9 @@ func (i *CommandInitOption) Validate(parentCommand string) error {
 	if (i.CaCertFile != "") != (i.CaKeyFile != "") {
 		return fmt.Errorf("ca-cert-file and ca-key-file must be used together")
 	}
+	if err := i.validateCertMode(); err != nil {
+		return err
+	}
 
 	switch i.ImagePullPolicy {
 	case string(corev1.PullAlways), string(corev1.PullIfNotPresent), string(corev1.PullNever):
@@ -346,6 +376,16 @@ func (i *CommandInitOption) Validate(parentCommand string) error {
 
 // Complete Initialize k8s client
 func (i *CommandInitOption) Complete() error {
+	if err := i.completeCommon(); err != nil {
+		return err
+	}
+	if i.certMode() == CertModeRotate {
+		return i.completeRotate()
+	}
+	return i.completeInstall()
+}
+
+func (i *CommandInitOption) completeCommon() error {
 	restConfig, err := apiclient.RestConfig(i.Context, i.KubeConfig)
 	if err != nil {
 		return err
@@ -359,6 +399,10 @@ func (i *CommandInitOption) Complete() error {
 	}
 	i.KubeClientSet = clientSet
 
+	return nil
+}
+
+func (i *CommandInitOption) completeInstall() error {
 	if i.isNodePortExist() {
 		return fmt.Errorf("nodePort of karmada apiserver %v already exist", i.KarmadaAPIServerNodePort)
 	}
@@ -390,6 +434,15 @@ func (i *CommandInitOption) Complete() error {
 	i.initializeCommandLineArgs()
 
 	return initializeDirectory(i.KarmadaDataPath)
+}
+
+// completeRotate completes the options required by certificate rotation.
+func (i *CommandInitOption) completeRotate() error {
+	if err := i.getKarmadaAPIServerIP(); err != nil {
+		return err
+	}
+	klog.Infof("karmada apiserver ip: %s", i.KarmadaAPIServerIP)
+	return nil
 }
 
 // initializeCommandLineArgs Merge default parameters and validated user parameters.
@@ -440,6 +493,23 @@ func initializeDirectory(path string) error {
 
 // genCerts create ca etcd karmada cert
 func (i *CommandInitOption) genCerts() error {
+	certConfigs, err := i.buildInitCertConfigs()
+	if err != nil {
+		return err
+	}
+	if err = cert.GenCerts(i.KarmadaPkiPath, i.CaCertFile, i.CaKeyFile, certConfigs.etcdServer, certConfigs.etcdClient, certConfigs.karmada, certConfigs.apiserver, certConfigs.frontProxyClient); err != nil {
+		return err
+	}
+	return nil
+}
+
+// buildInitCertConfigs builds certificate configs shared by install and rotation flows.
+func (i *CommandInitOption) buildInitCertConfigs() (*initCertConfigs, error) {
+	return i.buildCertConfigs(true)
+}
+
+// buildCertConfigs builds certificate configs and optionally discovers the execution host's internet IP.
+func (i *CommandInitOption) buildCertConfigs(discoverInternetIP bool) (*initCertConfigs, error) {
 	notAfter := time.Now().Add(i.CertValidity).UTC()
 
 	var etcdServerCertConfig, etcdClientCertCfg *cert.CertsConfig
@@ -483,11 +553,13 @@ func (i *CommandInitOption) genCerts() error {
 	)
 	karmadaIPs = append(karmadaIPs, i.KarmadaAPIServerIP...)
 
-	internetIP, err := utils.InternetIP()
-	if err != nil {
-		klog.Warningln("Failed to obtain internet IP. ", err)
-	} else {
-		karmadaIPs = append(karmadaIPs, internetIP)
+	if discoverInternetIP {
+		internetIP, err := utils.InternetIP()
+		if err != nil {
+			klog.Warningln("Failed to obtain internet IP. ", err)
+		} else {
+			karmadaIPs = append(karmadaIPs, internetIP)
+		}
 	}
 
 	karmadaAltNames := certutil.AltNames{
@@ -499,10 +571,13 @@ func (i *CommandInitOption) genCerts() error {
 	apiserverCertCfg := cert.NewCertConfig("karmada-apiserver", []string{""}, karmadaAltNames, &notAfter)
 
 	frontProxyClientCertCfg := cert.NewCertConfig("front-proxy-client", []string{}, certutil.AltNames{}, &notAfter)
-	if err = cert.GenCerts(i.KarmadaPkiPath, i.CaCertFile, i.CaKeyFile, etcdServerCertConfig, etcdClientCertCfg, karmadaCertCfg, apiserverCertCfg, frontProxyClientCertCfg); err != nil {
-		return err
-	}
-	return nil
+	return &initCertConfigs{
+		etcdServer:       etcdServerCertConfig,
+		etcdClient:       etcdClientCertCfg,
+		karmada:          karmadaCertCfg,
+		apiserver:        apiserverCertCfg,
+		frontProxyClient: frontProxyClientCertCfg,
+	}, nil
 }
 
 // prepareCRD download or unzip `crds.tar.gz` to `options.DataPath`
@@ -540,21 +615,21 @@ func (i *CommandInitOption) prepareCRD() error {
 	return nil
 }
 
-func (i *CommandInitOption) createCertsSecrets() error {
+// certSecretSpecs builds the Secret specs that contain init-managed certificate data.
+func (i *CommandInitOption) certSecretSpecs() ([]*corev1.Secret, error) {
 	// Create karmada-config Secret
 	karmadaServerURL := fmt.Sprintf("https://%s.%s.svc.%s:%v", karmadaAPIServerDeploymentAndServiceName, i.Namespace, i.HostClusterDomain, karmadaAPIServerContainerPort)
 	config := utils.CreateWithCerts(karmadaServerURL, options.UserName, options.UserName, i.CertAndKeyFileData[fmt.Sprintf("%s.crt", globaloptions.CaCertAndKeyName)],
 		i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)])
 	configBytes, err := clientcmd.Write(*config)
 	if err != nil {
-		return fmt.Errorf("failure while serializing admin kubeConfig. %v", err)
+		return nil, fmt.Errorf("failure while serializing admin kubeConfig. %v", err)
 	}
 
+	var secrets []*corev1.Secret
 	for _, karmadaConfigSecretName := range karmadaConfigList {
 		karmadaConfigSecret := i.SecretFromSpec(karmadaConfigSecretName, corev1.SecretTypeOpaque, map[string]string{util.KarmadaConfigFieldName: string(configBytes)})
-		if err = util.CreateOrUpdateSecret(i.KubeClientSet, karmadaConfigSecret); err != nil {
-			return err
-		}
+		secrets = append(secrets, karmadaConfigSecret)
 	}
 
 	// Create certs Secret
@@ -565,9 +640,7 @@ func (i *CommandInitOption) createCertsSecrets() error {
 		fmt.Sprintf("%s.key", options.EtcdServerCertAndKeyName): string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.EtcdServerCertAndKeyName)]),
 	}
 	etcdSecret := i.SecretFromSpec(etcdCertName, corev1.SecretTypeOpaque, etcdCert)
-	if err := util.CreateOrUpdateSecret(i.KubeClientSet, etcdSecret); err != nil {
-		return err
-	}
+	secrets = append(secrets, etcdSecret)
 
 	karmadaCert := map[string]string{}
 	for _, v := range certList {
@@ -575,19 +648,62 @@ func (i *CommandInitOption) createCertsSecrets() error {
 		karmadaCert[fmt.Sprintf("%s.key", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", v)])
 	}
 	karmadaSecret := i.SecretFromSpec(globaloptions.KarmadaCertsName, corev1.SecretTypeOpaque, karmadaCert)
-	if err := util.CreateOrUpdateSecret(i.KubeClientSet, karmadaSecret); err != nil {
-		return err
-	}
+	secrets = append(secrets, karmadaSecret)
 
 	karmadaWebhookCert := map[string]string{
 		"tls.crt": string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)]),
 		"tls.key": string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)]),
 	}
 	karmadaWebhookSecret := i.SecretFromSpec(webhookCertsName, corev1.SecretTypeOpaque, karmadaWebhookCert)
-	if err := util.CreateOrUpdateSecret(i.KubeClientSet, karmadaWebhookSecret); err != nil {
+	secrets = append(secrets, karmadaWebhookSecret)
+
+	return secrets, nil
+}
+
+func (i *CommandInitOption) createCertsSecrets() error {
+	secrets, err := i.certSecretSpecs()
+	if err != nil {
 		return err
 	}
+	for _, secret := range secrets {
+		if err := util.CreateOrUpdateSecret(i.KubeClientSet, secret); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
+// updateCertsSecrets updates existing certificate Secrets without creating new ones.
+func (i *CommandInitOption) updateCertsSecrets() error {
+	secrets, err := i.certSecretSpecs()
+	if err != nil {
+		return err
+	}
+	for _, secret := range secrets {
+		if err := i.setExistingSecretMetadata(secret); err != nil {
+			return err
+		}
+	}
+
+	for _, secret := range secrets {
+		if _, err := i.KubeClientSet.CoreV1().Secrets(secret.Namespace).Update(context.TODO(), secret, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("unable to update Secret %s/%s: %w", secret.Namespace, secret.Name, err)
+		}
+	}
+	return nil
+}
+
+// setExistingSecretMetadata copies metadata from the existing Secret before update.
+func (i *CommandInitOption) setExistingSecretMetadata(secret *corev1.Secret) error {
+	existingSecret, err := i.KubeClientSet.CoreV1().Secrets(secret.Namespace).Get(context.TODO(), secret.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("secret %s/%s must exist before certificate rotation", secret.Namespace, secret.Name)
+		}
+		return err
+	}
+	secret.ObjectMeta = existingSecret.ObjectMeta
+	secret.ResourceVersion = existingSecret.ResourceVersion
 	return nil
 }
 
@@ -686,8 +802,15 @@ func (i *CommandInitOption) readExternalEtcdCert(name string) (isExternalEtcdCer
 	return
 }
 
-// RunInit Deploy karmada in kubernetes
+// RunInit deploys Karmada or rotates init-managed certificates in Kubernetes.
 func (i *CommandInitOption) RunInit(parentCommand string) error {
+	if i.certMode() == CertModeRotate {
+		return i.runCertRotate()
+	}
+	return i.runInstall(parentCommand)
+}
+
+func (i *CommandInitOption) runInstall(parentCommand string) error {
 	// generate certificate
 	if err := i.genCerts(); err != nil {
 		return fmt.Errorf("certificate generation failed.%v", err)
@@ -860,6 +983,14 @@ func (i *CommandInitOption) getImagePullSecrets() []corev1.LocalObjectReference 
 		imagePullSecrets = append(imagePullSecrets, secret)
 	}
 	return imagePullSecrets
+}
+
+type initCertConfigs struct {
+	etcdServer       *cert.CertsConfig
+	etcdClient       *cert.CertsConfig
+	karmada          *cert.CertsConfig
+	apiserver        *cert.CertsConfig
+	frontProxyClient *cert.CertsConfig
 }
 
 func (i *CommandInitOption) handleEtcdNodeSelectorLabels() error {

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
@@ -17,20 +17,42 @@ limitations under the License.
 package kubernetes
 
 import (
+	"bytes"
 	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"fmt"
+	"maps"
+	"math/big"
 	"net"
 	"os"
+	"path/filepath"
 	"reflect"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
 
+	certpkg "github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/cert"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/config"
+	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
+	globaloptions "github.com/karmada-io/karmada/pkg/karmadactl/options"
+	"github.com/karmada-io/karmada/pkg/karmadactl/util"
 )
 
 func Test_initializeDirectory(t *testing.T) {
@@ -207,6 +229,26 @@ func TestCommandInitOption_Validate(t *testing.T) {
 			wantErr:  true,
 			errorMsg: "CommandInitOption.Validate() returns err when invalid ImagePullPolicy",
 		},
+		{
+			name: "Invalid CertMode",
+			opt: CommandInitOption{
+				CertMode:        "unknown",
+				EtcdStorageMode: "",
+				ImagePullPolicy: string(corev1.PullIfNotPresent),
+			},
+			wantErr:  true,
+			errorMsg: "CommandInitOption.Validate() does not return err when cert-mode is invalid",
+		},
+		{
+			name: "Valid rotate CertMode",
+			opt: CommandInitOption{
+				CertMode:        CertModeRotate,
+				EtcdStorageMode: "",
+				ImagePullPolicy: string(corev1.PullIfNotPresent),
+			},
+			wantErr:  false,
+			errorMsg: "CommandInitOption.Validate() returns err when cert-mode is rotate",
+		},
 	}
 
 	for _, tt := range tests {
@@ -215,6 +257,47 @@ func TestCommandInitOption_Validate(t *testing.T) {
 				t.Errorf("%s err = %v, want %v", tt.name, err.Error(), tt.errorMsg)
 			}
 		})
+	}
+}
+
+func TestCommandInitOption_completeRotateSkipsInstallOnlyChecks(t *testing.T) {
+	clientset := fake.NewClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node-1",
+				Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{{Address: "192.0.2.10"}},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "existing-node-port-service",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{{
+					NodePort: 32443,
+				}},
+			},
+		},
+	)
+	opt := &CommandInitOption{
+		CertMode:                         CertModeRotate,
+		KubeClientSet:                    clientset,
+		KarmadaAPIServerNodePort:         32443,
+		EtcdStorageMode:                  etcdStorageModeHostPath,
+		KarmadaAPIServerAdvertiseAddress: "",
+	}
+
+	err := opt.completeRotate()
+	assert.NoError(t, err)
+
+	for _, action := range clientset.Actions() {
+		assert.NotEqual(t, "services", action.GetResource().Resource)
+		assert.NotEqual(t, "patch", action.GetVerb())
 	}
 }
 
@@ -234,6 +317,879 @@ func TestCommandInitOption_genCerts(t *testing.T) {
 	err := opt.genCerts()
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestCommandInitOption_runCertRotateUpdatesSecretsOnly(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             3,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "host.example",
+		ExternalDNS:              "api.example.test",
+		ExternalIP:               "198.51.100.10",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KarmadaDataPath:          t.TempDir(),
+		KubeClientSet:            clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.NoError(t, err)
+
+	updatedKarmadaSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), globaloptions.KarmadaCertsName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, oldCertData[certFileName(globaloptions.CaCertAndKeyName)], updatedKarmadaSecret.StringData[certFileName(globaloptions.CaCertAndKeyName)])
+	assert.Equal(t, oldCertData[keyFileName(globaloptions.CaCertAndKeyName)], updatedKarmadaSecret.StringData[keyFileName(globaloptions.CaCertAndKeyName)])
+	assert.NotEqual(t, oldCertData[certFileName(options.KarmadaCertAndKeyName)], updatedKarmadaSecret.StringData[certFileName(options.KarmadaCertAndKeyName)])
+	assert.True(t, bytes.Equal([]byte(oldCertData[keyFileName(options.KarmadaCertAndKeyName)]), []byte(updatedKarmadaSecret.StringData[keyFileName(options.KarmadaCertAndKeyName)])), "karmada private key must be preserved")
+
+	rotatedKarmadaCert, err := certpkg.LoadCertificatePEM([]byte(updatedKarmadaSecret.StringData[certFileName(options.KarmadaCertAndKeyName)]))
+	assert.NoError(t, err)
+	rootCA, err := certpkg.LoadCertificatePEM([]byte(updatedKarmadaSecret.StringData[certFileName(globaloptions.CaCertAndKeyName)]))
+	assert.NoError(t, err)
+	assert.NoError(t, rotatedKarmadaCert.CheckSignatureFrom(rootCA))
+	assert.Contains(t, rotatedKarmadaCert.DNSNames, "api.example.test")
+	assert.True(t, slices.ContainsFunc(rotatedKarmadaCert.IPAddresses, func(ip net.IP) bool {
+		return ip.Equal(net.ParseIP("198.51.100.10"))
+	}))
+	_, _, err = certpkg.LoadCertAndKeyPEM(
+		[]byte(updatedKarmadaSecret.StringData[certFileName(options.KarmadaCertAndKeyName)]),
+		[]byte(oldCertData[keyFileName(options.KarmadaCertAndKeyName)]),
+	)
+	assert.NoError(t, err)
+	rotatedEtcdServerCert, err := certpkg.LoadCertificatePEM([]byte(updatedKarmadaSecret.StringData[certFileName(options.EtcdServerCertAndKeyName)]))
+	assert.NoError(t, err)
+	for replica := range 3 {
+		assert.Contains(t, rotatedEtcdServerCert.DNSNames, fmt.Sprintf("%s-%d.%s.%s.svc.host.example",
+			etcdStatefulSetAndServiceName, replica, etcdStatefulSetAndServiceName, namespace))
+	}
+
+	updatedWebhookSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), webhookCertsName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, updatedKarmadaSecret.StringData[certFileName(options.KarmadaCertAndKeyName)], updatedWebhookSecret.StringData["tls.crt"])
+	assert.Equal(t, oldCertData[keyFileName(options.KarmadaCertAndKeyName)], updatedWebhookSecret.StringData["tls.key"])
+
+	assertNoInstallResourceActions(t, clientset.Actions())
+}
+
+func TestCommandInitOption_runCertRotateConvergesAfterSecretUpdateTimeout(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+	failedOnce := false
+	clientset.PrependReactor("update", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		secret := action.(k8stesting.UpdateAction).GetObject().(*corev1.Secret)
+		if !failedOnce && secret.Name == webhookCertsName {
+			failedOnce = true
+			return true, nil, apierrors.NewTimeoutError("forced Secret update timeout", 1)
+		}
+		return false, nil, nil
+	})
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KubeClientSet:            clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.Error(t, err)
+	assert.True(t, apierrors.IsTimeout(err))
+	assert.True(t, failedOnce)
+
+	partiallyUpdatedSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), globaloptions.KarmadaCertsName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotEqual(t, oldCertData[certFileName(options.KarmadaCertAndKeyName)], partiallyUpdatedSecret.StringData[certFileName(options.KarmadaCertAndKeyName)])
+
+	assert.NoError(t, opt.runCertRotate())
+	expectedSecrets, err := opt.certSecretSpecs()
+	assert.NoError(t, err)
+	for _, expectedSecret := range expectedSecrets {
+		actualSecret, getErr := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), expectedSecret.Name, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, expectedSecret.StringData, actualSecret.StringData)
+	}
+}
+
+func TestCommandInitOption_runCertRotateRenewsExpiringLeafCertificates(t *testing.T) {
+	namespace := "karmada-system"
+	now := time.Now().UTC()
+	oldCertData := buildTestCertAndKeyDataWithLeafNotAfter(t, now.Add(time.Minute))
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KubeClientSet:            clientset,
+	}
+
+	oldKarmadaCert := loadTestCertFromData(t, oldCertData, options.KarmadaCertAndKeyName)
+	oldEtcdServerCert := loadTestCertFromData(t, oldCertData, options.EtcdServerCertAndKeyName)
+	assert.WithinDuration(t, now.Add(time.Minute), oldKarmadaCert.NotAfter, 10*time.Second)
+	assert.WithinDuration(t, now.Add(time.Minute), oldEtcdServerCert.NotAfter, 10*time.Second)
+
+	err := opt.runCertRotate()
+	assert.NoError(t, err)
+
+	updatedKarmadaSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), globaloptions.KarmadaCertsName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	updatedEtcdSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), etcdCertName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	rootCA := loadTestCertFromSecret(t, updatedKarmadaSecret, globaloptions.CaCertAndKeyName)
+	etcdCA := loadTestCertFromSecret(t, updatedEtcdSecret, options.EtcdCaCertAndKeyName)
+	rotatedKarmadaCert := loadTestCertFromSecret(t, updatedKarmadaSecret, options.KarmadaCertAndKeyName)
+	rotatedEtcdServerCert := loadTestCertFromSecret(t, updatedEtcdSecret, options.EtcdServerCertAndKeyName)
+
+	assert.Equal(t, oldCertData[certFileName(globaloptions.CaCertAndKeyName)], updatedKarmadaSecret.StringData[certFileName(globaloptions.CaCertAndKeyName)])
+	assert.Equal(t, oldCertData[certFileName(options.EtcdCaCertAndKeyName)], updatedEtcdSecret.StringData[certFileName(options.EtcdCaCertAndKeyName)])
+	assert.NoError(t, rotatedKarmadaCert.CheckSignatureFrom(rootCA))
+	assert.NoError(t, rotatedEtcdServerCert.CheckSignatureFrom(etcdCA))
+	assert.True(t, rotatedKarmadaCert.NotAfter.After(now.Add(300*24*time.Hour)))
+	assert.True(t, rotatedEtcdServerCert.NotAfter.After(now.Add(300*24*time.Hour)))
+	assert.True(t, rotatedKarmadaCert.NotAfter.After(oldKarmadaCert.NotAfter.Add(300*24*time.Hour)))
+	assert.True(t, rotatedEtcdServerCert.NotAfter.After(oldEtcdServerCert.NotAfter.Add(300*24*time.Hour)))
+}
+
+func TestCommandInitOption_runCertRotatePreservesExistingServingCertificateSANs(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	replaceTestLeafCertAndKeyData(t, oldCertData, options.KarmadaCertAndKeyName, globaloptions.CaCertAndKeyName, certutil.AltNames{
+		DNSNames: []string{"old-webhook.example.test"},
+		IPs:      []net.IP{net.ParseIP("203.0.113.10")},
+	})
+	replaceTestLeafCertAndKeyData(t, oldCertData, options.ApiserverCertAndKeyName, globaloptions.CaCertAndKeyName, certutil.AltNames{
+		DNSNames: []string{"old-api.example.test"},
+		IPs:      []net.IP{net.ParseIP("203.0.113.11")},
+	})
+	replaceTestLeafCertAndKeyData(t, oldCertData, options.EtcdServerCertAndKeyName, options.EtcdCaCertAndKeyName, certutil.AltNames{
+		DNSNames: []string{"karmada-etcd-2.karmada-etcd.karmada-system.svc.old.example"},
+		IPs:      []net.IP{net.ParseIP("203.0.113.12")},
+	})
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KubeClientSet:            clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.NoError(t, err)
+
+	updatedKarmadaSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), globaloptions.KarmadaCertsName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	updatedEtcdSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), etcdCertName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	rotatedKarmadaCert := loadTestCertFromSecret(t, updatedKarmadaSecret, options.KarmadaCertAndKeyName)
+	rotatedAPIServerCert := loadTestCertFromSecret(t, updatedKarmadaSecret, options.ApiserverCertAndKeyName)
+	rotatedEtcdServerCert := loadTestCertFromSecret(t, updatedEtcdSecret, options.EtcdServerCertAndKeyName)
+	assert.Contains(t, rotatedKarmadaCert.DNSNames, "old-webhook.example.test")
+	assert.True(t, slices.ContainsFunc(rotatedKarmadaCert.IPAddresses, func(ip net.IP) bool { return ip.Equal(net.ParseIP("203.0.113.10")) }))
+	assert.Contains(t, rotatedAPIServerCert.DNSNames, "old-api.example.test")
+	assert.True(t, slices.ContainsFunc(rotatedAPIServerCert.IPAddresses, func(ip net.IP) bool { return ip.Equal(net.ParseIP("203.0.113.11")) }))
+	assert.Contains(t, rotatedEtcdServerCert.DNSNames, "karmada-etcd-2.karmada-etcd.karmada-system.svc.old.example")
+	assert.True(t, slices.ContainsFunc(rotatedEtcdServerCert.IPAddresses, func(ip net.IP) bool { return ip.Equal(net.ParseIP("203.0.113.12")) }))
+}
+
+func TestCommandInitOption_runCertRotateRefreshesExistingLocalAdminKubeconfig(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+	dataPath := t.TempDir()
+	kubeconfigPath := filepath.Join(dataPath, options.KarmadaKubeConfigName)
+	serverURL := "https://karmada.example.test:32443"
+	oldConfig := utils.CreateWithCerts(serverURL, options.UserName, options.ClusterName,
+		[]byte(oldCertData[certFileName(globaloptions.CaCertAndKeyName)]),
+		[]byte(oldCertData[keyFileName(options.KarmadaCertAndKeyName)]),
+		[]byte(oldCertData[certFileName(options.KarmadaCertAndKeyName)]))
+	assert.NoError(t, os.WriteFile(filepath.Join(dataPath, "old-ca.crt"), []byte(oldCertData[certFileName(globaloptions.CaCertAndKeyName)]), 0600))
+	assert.NoError(t, os.WriteFile(filepath.Join(dataPath, "old-karmada.crt"), []byte(oldCertData[certFileName(options.KarmadaCertAndKeyName)]), 0600))
+	oldConfig.Clusters[options.ClusterName].CertificateAuthorityData = nil
+	oldConfig.Clusters[options.ClusterName].CertificateAuthority = "old-ca.crt"
+	oldConfig.AuthInfos[options.UserName].ClientCertificateData = nil
+	oldConfig.AuthInfos[options.UserName].ClientCertificate = "old-karmada.crt"
+	oldConfig.AuthInfos[options.UserName].ClientKey = "/old/karmada.key"
+	oldConfig.Clusters["other"] = &clientcmdapi.Cluster{Server: "https://other.example.test:6443"}
+	oldConfig.AuthInfos["other-user"] = &clientcmdapi.AuthInfo{Token: "other-token"}
+	oldConfig.Contexts["secondary"] = &clientcmdapi.Context{Cluster: "other", AuthInfo: "other-user"}
+	oldConfig.CurrentContext = "secondary"
+	configBytes, err := clientcmd.Write(*oldConfig)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(kubeconfigPath, configBytes, 0600))
+
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KarmadaDataPath:          dataPath,
+		KubeClientSet:            clientset,
+	}
+
+	err = opt.runCertRotate()
+	assert.NoError(t, err)
+
+	updatedSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), globaloptions.KarmadaCertsName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	updatedConfig, err := clientcmd.LoadFromFile(kubeconfigPath)
+	assert.NoError(t, err)
+	assert.Equal(t, "secondary", updatedConfig.CurrentContext)
+	assert.Equal(t, serverURL, updatedConfig.Clusters[options.ClusterName].Server)
+	assert.Equal(t, "https://other.example.test:6443", updatedConfig.Clusters["other"].Server)
+	assert.Equal(t, "other-token", updatedConfig.AuthInfos["other-user"].Token)
+	assert.Empty(t, updatedConfig.Clusters[options.ClusterName].CertificateAuthority)
+	assert.Empty(t, updatedConfig.AuthInfos[options.UserName].ClientCertificate)
+	assert.Empty(t, updatedConfig.AuthInfos[options.UserName].ClientKey)
+	assert.True(t, bytes.Equal([]byte(updatedSecret.StringData[certFileName(globaloptions.CaCertAndKeyName)]), updatedConfig.Clusters[options.ClusterName].CertificateAuthorityData), "embedded CA certificate must be refreshed")
+	assert.True(t, bytes.Equal([]byte(updatedSecret.StringData[certFileName(options.KarmadaCertAndKeyName)]), updatedConfig.AuthInfos[options.UserName].ClientCertificateData), "embedded client certificate must be refreshed")
+	assert.True(t, bytes.Equal([]byte(updatedSecret.StringData[keyFileName(options.KarmadaCertAndKeyName)]), updatedConfig.AuthInfos[options.UserName].ClientKeyData), "embedded client key must be refreshed")
+	fileInfo, err := os.Stat(kubeconfigPath)
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), fileInfo.Mode().Perm())
+}
+
+func TestCommandInitOption_runCertRotateRejectsInvalidLocalAdminKubeconfigBeforeSecretUpdates(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+	dataPath := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(dataPath, options.KarmadaKubeConfigName), []byte("invalid: ["), 0600))
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KarmadaDataPath:          dataPath,
+		KubeClientSet:            clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load local Karmada kubeconfig")
+	assertNoSecretUpdateActions(t, clientset.Actions())
+}
+
+func TestCommandInitOption_runCertRotateRejectsLocalAdminKubeconfigFromAnotherCluster(t *testing.T) {
+	namespace := "karmada-system"
+	targetCertData := buildTestCertAndKeyData(t)
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, targetCertData)...)
+	otherCA, _ := newTestCA(t, "other-karmada")
+	dataPath := t.TempDir()
+	kubeconfigPath := filepath.Join(dataPath, options.KarmadaKubeConfigName)
+	otherConfig := utils.CreateWithCerts("https://other-karmada.example.test:32443", options.UserName, options.ClusterName,
+		certpkg.EncodeCertPEM(otherCA),
+		[]byte(targetCertData[keyFileName(options.KarmadaCertAndKeyName)]),
+		[]byte(targetCertData[certFileName(options.KarmadaCertAndKeyName)]))
+	configBytes, err := clientcmd.Write(*otherConfig)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(kubeconfigPath, configBytes, 0600))
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KarmadaDataPath:          dataPath,
+		KubeClientSet:            clientset,
+	}
+
+	err = opt.runCertRotate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "CA does not match Secret")
+	assertNoSecretUpdateActions(t, clientset.Actions())
+	unchangedConfigBytes, readErr := os.ReadFile(kubeconfigPath)
+	assert.NoError(t, readErr)
+	assert.Equal(t, configBytes, unchangedConfigBytes)
+}
+
+func TestCommandInitOption_runCertRotateRejectsLocalAdminKubeconfigWithDifferentClientIdentity(t *testing.T) {
+	namespace := "karmada-system"
+	targetCertData := buildTestCertAndKeyData(t)
+	otherCertData := maps.Clone(targetCertData)
+	replaceTestLeafCertAndKeyData(t, otherCertData, options.KarmadaCertAndKeyName, globaloptions.CaCertAndKeyName, certutil.AltNames{})
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, targetCertData)...)
+	dataPath := t.TempDir()
+	kubeconfigPath := filepath.Join(dataPath, options.KarmadaKubeConfigName)
+	otherConfig := utils.CreateWithCerts("https://other-karmada.example.test:32443", options.UserName, options.ClusterName,
+		[]byte(otherCertData[certFileName(globaloptions.CaCertAndKeyName)]),
+		[]byte(otherCertData[keyFileName(options.KarmadaCertAndKeyName)]),
+		[]byte(otherCertData[certFileName(options.KarmadaCertAndKeyName)]))
+	configBytes, err := clientcmd.Write(*otherConfig)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(kubeconfigPath, configBytes, 0600))
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KarmadaDataPath:          dataPath,
+		KubeClientSet:            clientset,
+	}
+
+	err = opt.runCertRotate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "client certificate does not match")
+	assertNoSecretUpdateActions(t, clientset.Actions())
+	unchangedConfigBytes, readErr := os.ReadFile(kubeconfigPath)
+	assert.NoError(t, readErr)
+	assert.Equal(t, configBytes, unchangedConfigBytes)
+}
+
+func TestCommandInitOption_runCertRotatePreservesExistingSecretMetadata(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	objects := buildExistingRotateSecrets(namespace, oldCertData)
+	for _, object := range objects {
+		secret := object.(*corev1.Secret)
+		secret.Labels = map[string]string{
+			"karmada.io/bootstrapping": "secret-defaults",
+			"backup.example.io/name":   "daily",
+		}
+		secret.Annotations = map[string]string{"policy.example.io/managed": "true"}
+	}
+	clientset := fake.NewClientset(objects...)
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KubeClientSet:            clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.NoError(t, err)
+
+	updatedSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), globaloptions.KarmadaCertsName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "daily", updatedSecret.Labels["backup.example.io/name"])
+	assert.Equal(t, "true", updatedSecret.Annotations["policy.example.io/managed"])
+}
+
+func TestCommandInitOption_runCertRotateRejectsEtcdModeSwitch(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		ExternalEtcdServers:      "https://external-etcd.example.com:2379",
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KubeClientSet:            clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "external etcd parameters cannot be used")
+	assertNoSecretUpdateActions(t, clientset.Actions())
+}
+
+func TestCommandInitOption_runCertRotateRejectsExternalEtcdModeSwitch(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	objects := buildExistingExternalEtcdRotateSecrets(namespace, oldCertData)
+	clientset := fake.NewClientset(objects...)
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KubeClientSet:            clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "internal etcd parameters cannot be used")
+	assertNoSecretUpdateActions(t, clientset.Actions())
+}
+
+func TestCommandInitOption_runCertRotateWithExistingExternalEtcdCerts(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	clientset := fake.NewClientset(buildExistingExternalEtcdRotateSecrets(namespace, oldCertData)...)
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		ExternalEtcdServers:      "https://external-etcd.example.com:2379",
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KubeClientSet:            clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.NoError(t, err)
+
+	updatedEtcdSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), etcdCertName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Empty(t, updatedEtcdSecret.StringData[certFileName(options.EtcdServerCertAndKeyName)])
+	assert.Empty(t, updatedEtcdSecret.StringData[keyFileName(options.EtcdServerCertAndKeyName)])
+	assert.Equal(t, oldCertData[certFileName(options.EtcdCaCertAndKeyName)], updatedEtcdSecret.StringData[certFileName(options.EtcdCaCertAndKeyName)])
+
+	updatedKarmadaSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), globaloptions.KarmadaCertsName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, oldCertData[certFileName(options.EtcdClientCertAndKeyName)], updatedKarmadaSecret.StringData[certFileName(options.EtcdClientCertAndKeyName)])
+	assert.Equal(t, oldCertData[keyFileName(options.EtcdClientCertAndKeyName)], updatedKarmadaSecret.StringData[keyFileName(options.EtcdClientCertAndKeyName)])
+	assertNoInstallResourceActions(t, clientset.Actions())
+}
+
+func TestCommandInitOption_runCertRotateWithExternalEtcdCertFiles(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	certDir := t.TempDir()
+	etcdCAFile := writeTestFile(t, certDir, certFileName(options.EtcdCaCertAndKeyName), oldCertData[certFileName(options.EtcdCaCertAndKeyName)])
+	etcdClientCertFile := writeTestFile(t, certDir, certFileName(options.EtcdClientCertAndKeyName), oldCertData[certFileName(options.EtcdClientCertAndKeyName)])
+	etcdClientKeyFile := writeTestFile(t, certDir, keyFileName(options.EtcdClientCertAndKeyName), oldCertData[keyFileName(options.EtcdClientCertAndKeyName)])
+	clientset := fake.NewClientset(buildExistingExternalEtcdRotateSecrets(namespace, oldCertData)...)
+	opt := &CommandInitOption{
+		CertMode:                   CertModeRotate,
+		CertValidity:               365 * 24 * time.Hour,
+		ExternalEtcdServers:        "https://external-etcd.example.com:2379",
+		ExternalEtcdCACertPath:     etcdCAFile,
+		ExternalEtcdClientCertPath: etcdClientCertFile,
+		ExternalEtcdClientKeyPath:  etcdClientKeyFile,
+		Namespace:                  namespace,
+		HostClusterDomain:          "cluster.local",
+		KarmadaAPIServerIP:         []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort:   32443,
+		KubeClientSet:              clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.NoError(t, err)
+
+	updatedEtcdSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), etcdCertName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, oldCertData[certFileName(options.EtcdCaCertAndKeyName)], updatedEtcdSecret.StringData[certFileName(options.EtcdCaCertAndKeyName)])
+	assert.Empty(t, updatedEtcdSecret.StringData[keyFileName(options.EtcdCaCertAndKeyName)])
+
+	updatedKarmadaSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), globaloptions.KarmadaCertsName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, oldCertData[certFileName(options.EtcdClientCertAndKeyName)], updatedKarmadaSecret.StringData[certFileName(options.EtcdClientCertAndKeyName)])
+	assert.Equal(t, oldCertData[keyFileName(options.EtcdClientCertAndKeyName)], updatedKarmadaSecret.StringData[keyFileName(options.EtcdClientCertAndKeyName)])
+}
+
+func TestCommandInitOption_runCertRotateRejectsExternalEtcdCredentialReplacement(t *testing.T) {
+	oldCertData := buildTestCertAndKeyData(t)
+	otherCertData := buildTestCertAndKeyData(t)
+	tests := []struct {
+		name           string
+		caCertData     string
+		clientCertData string
+		clientKeyData  string
+		wantError      string
+	}{
+		{
+			name:           "different CA",
+			caCertData:     otherCertData[certFileName(options.EtcdCaCertAndKeyName)],
+			clientCertData: oldCertData[certFileName(options.EtcdClientCertAndKeyName)],
+			clientKeyData:  oldCertData[keyFileName(options.EtcdClientCertAndKeyName)],
+			wantError:      "external etcd CA certificate cannot be changed",
+		},
+		{
+			name:           "different client credential",
+			caCertData:     oldCertData[certFileName(options.EtcdCaCertAndKeyName)],
+			clientCertData: otherCertData[certFileName(options.EtcdClientCertAndKeyName)],
+			clientKeyData:  otherCertData[keyFileName(options.EtcdClientCertAndKeyName)],
+			wantError:      "external etcd client certificate cannot be changed",
+		},
+		{
+			name:           "mismatched client certificate and key",
+			caCertData:     oldCertData[certFileName(options.EtcdCaCertAndKeyName)],
+			clientCertData: oldCertData[certFileName(options.EtcdClientCertAndKeyName)],
+			clientKeyData:  otherCertData[keyFileName(options.EtcdClientCertAndKeyName)],
+			wantError:      "failed to load external etcd client certificate and key files",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := "karmada-system"
+			certDir := t.TempDir()
+			clientset := fake.NewClientset(buildExistingExternalEtcdRotateSecrets(namespace, oldCertData)...)
+			opt := &CommandInitOption{
+				CertMode:                   CertModeRotate,
+				CertValidity:               365 * 24 * time.Hour,
+				ExternalEtcdServers:        "https://external-etcd.example.com:2379",
+				ExternalEtcdCACertPath:     writeTestFile(t, certDir, certFileName(options.EtcdCaCertAndKeyName), tt.caCertData),
+				ExternalEtcdClientCertPath: writeTestFile(t, certDir, certFileName(options.EtcdClientCertAndKeyName), tt.clientCertData),
+				ExternalEtcdClientKeyPath:  writeTestFile(t, certDir, keyFileName(options.EtcdClientCertAndKeyName), tt.clientKeyData),
+				Namespace:                  namespace,
+				HostClusterDomain:          "cluster.local",
+				KarmadaAPIServerIP:         []net.IP{utils.StringToNetIP("192.0.2.11")},
+				KarmadaAPIServerNodePort:   32443,
+				KubeClientSet:              clientset,
+			}
+
+			err := opt.runCertRotate()
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+			assertNoSecretUpdateActions(t, clientset.Actions())
+		})
+	}
+}
+
+func TestCommandInitOption_runCertRotateWithCAFiles(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	certDir := t.TempDir()
+	caCertFile := writeTestFile(t, certDir, certFileName(globaloptions.CaCertAndKeyName), oldCertData[certFileName(globaloptions.CaCertAndKeyName)])
+	caKeyFile := writeTestFile(t, certDir, keyFileName(globaloptions.CaCertAndKeyName), oldCertData[keyFileName(globaloptions.CaCertAndKeyName)])
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		CaCertFile:               caCertFile,
+		CaKeyFile:                caKeyFile,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KubeClientSet:            clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.NoError(t, err)
+
+	updatedKarmadaSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), globaloptions.KarmadaCertsName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, oldCertData[certFileName(globaloptions.CaCertAndKeyName)], updatedKarmadaSecret.StringData[certFileName(globaloptions.CaCertAndKeyName)])
+	assert.Equal(t, oldCertData[keyFileName(globaloptions.CaCertAndKeyName)], updatedKarmadaSecret.StringData[keyFileName(globaloptions.CaCertAndKeyName)])
+	assert.NotEqual(t, oldCertData[certFileName(options.KarmadaCertAndKeyName)], updatedKarmadaSecret.StringData[certFileName(options.KarmadaCertAndKeyName)])
+}
+
+func TestCommandInitOption_runCertRotateRejectsMismatchedCAFile(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	otherCertData := buildTestCertAndKeyData(t)
+	certDir := t.TempDir()
+	caCertFile := writeTestFile(t, certDir, certFileName(globaloptions.CaCertAndKeyName), otherCertData[certFileName(globaloptions.CaCertAndKeyName)])
+	caKeyFile := writeTestFile(t, certDir, keyFileName(globaloptions.CaCertAndKeyName), otherCertData[keyFileName(globaloptions.CaCertAndKeyName)])
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		CaCertFile:               caCertFile,
+		CaKeyFile:                caKeyFile,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KubeClientSet:            clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ca-cert-file must match")
+	assertNoSecretUpdateActions(t, clientset.Actions())
+}
+
+func TestCommandInitOption_updateCertsSecretsIncludesSecretIdentityOnUpdateFailure(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+	clientset.PrependReactor("update", "secrets", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errors.New("forced update failure"))
+	})
+	opt := &CommandInitOption{
+		Namespace:         namespace,
+		HostClusterDomain: "cluster.local",
+		KubeClientSet:     clientset,
+		CertAndKeyFileData: stringMapToByteMap(map[string]string{
+			certFileName(globaloptions.CaCertAndKeyName):         oldCertData[certFileName(globaloptions.CaCertAndKeyName)],
+			keyFileName(globaloptions.CaCertAndKeyName):          oldCertData[keyFileName(globaloptions.CaCertAndKeyName)],
+			certFileName(options.EtcdCaCertAndKeyName):           oldCertData[certFileName(options.EtcdCaCertAndKeyName)],
+			keyFileName(options.EtcdCaCertAndKeyName):            oldCertData[keyFileName(options.EtcdCaCertAndKeyName)],
+			certFileName(options.EtcdServerCertAndKeyName):       oldCertData[certFileName(options.EtcdServerCertAndKeyName)],
+			keyFileName(options.EtcdServerCertAndKeyName):        oldCertData[keyFileName(options.EtcdServerCertAndKeyName)],
+			certFileName(options.EtcdClientCertAndKeyName):       oldCertData[certFileName(options.EtcdClientCertAndKeyName)],
+			keyFileName(options.EtcdClientCertAndKeyName):        oldCertData[keyFileName(options.EtcdClientCertAndKeyName)],
+			certFileName(options.KarmadaCertAndKeyName):          oldCertData[certFileName(options.KarmadaCertAndKeyName)],
+			keyFileName(options.KarmadaCertAndKeyName):           oldCertData[keyFileName(options.KarmadaCertAndKeyName)],
+			certFileName(options.ApiserverCertAndKeyName):        oldCertData[certFileName(options.ApiserverCertAndKeyName)],
+			keyFileName(options.ApiserverCertAndKeyName):         oldCertData[keyFileName(options.ApiserverCertAndKeyName)],
+			certFileName(options.FrontProxyCaCertAndKeyName):     oldCertData[certFileName(options.FrontProxyCaCertAndKeyName)],
+			keyFileName(options.FrontProxyCaCertAndKeyName):      oldCertData[keyFileName(options.FrontProxyCaCertAndKeyName)],
+			certFileName(options.FrontProxyClientCertAndKeyName): oldCertData[certFileName(options.FrontProxyClientCertAndKeyName)],
+			keyFileName(options.FrontProxyClientCertAndKeyName):  oldCertData[keyFileName(options.FrontProxyClientCertAndKeyName)],
+		}),
+	}
+
+	err := opt.updateCertsSecrets()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to update Secret")
+	assert.True(t, strings.Contains(err.Error(), namespace+"/"))
+	assert.True(t, apierrors.IsInternalError(err))
+}
+
+func TestCommandInitOption_runCertRotateRequiresExistingSecrets(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	secrets := buildExistingRotateSecrets(namespace, oldCertData)
+	clientset := fake.NewClientset(secrets[0])
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KubeClientSet:            clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.Error(t, err)
+	for _, action := range clientset.Actions() {
+		assert.NotEqual(t, "create", action.GetVerb())
+		assert.NotEqual(t, "update", action.GetVerb())
+	}
+}
+
+func TestCommandInitOption_runCertRotateRequiresExistingCAKey(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	delete(oldCertData, keyFileName(globaloptions.CaCertAndKeyName))
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KubeClientSet:            clientset,
+	}
+
+	err := opt.runCertRotate()
+	assert.Error(t, err)
+	assertNoInstallResourceActions(t, clientset.Actions())
+	assertNoSecretUpdateActions(t, clientset.Actions())
+}
+
+func TestCommandInitOption_runCertRotateRejectsMismatchedKarmadaKeyBeforeSecretUpdates(t *testing.T) {
+	namespace := "karmada-system"
+	oldCertData := buildTestCertAndKeyData(t)
+	otherKey, err := certpkg.NewPrivateKey(x509.ECDSA)
+	assert.NoError(t, err)
+	otherKeyPEM, err := certpkg.EncodePrivateKeyPEM(otherKey)
+	assert.NoError(t, err)
+	oldCertData[keyFileName(options.KarmadaCertAndKeyName)] = string(otherKeyPEM)
+	clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+	opt := &CommandInitOption{
+		CertMode:                 CertModeRotate,
+		CertValidity:             365 * 24 * time.Hour,
+		EtcdReplicas:             1,
+		EtcdStorageMode:          etcdStorageModeEmptyDir,
+		Namespace:                namespace,
+		HostClusterDomain:        "cluster.local",
+		KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+		KarmadaAPIServerNodePort: 32443,
+		KubeClientSet:            clientset,
+	}
+
+	err = opt.runCertRotate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load existing certificate and key")
+	assertNoSecretUpdateActions(t, clientset.Actions())
+}
+
+func TestCommandInitOption_runCertRotateRejectsInvalidCALifetimeBeforeSecretUpdates(t *testing.T) {
+	now := time.Now().UTC()
+	baseCertData := buildTestCertAndKeyData(t)
+	tests := []struct {
+		name        string
+		caNotBefore time.Time
+		caNotAfter  time.Time
+	}{
+		{
+			name:        "expired CA",
+			caNotBefore: now.Add(-48 * time.Hour),
+			caNotAfter:  now.Add(-24 * time.Hour),
+		},
+		{
+			name:        "CA expires before requested leaf certificate",
+			caNotBefore: now.Add(-time.Hour),
+			caNotAfter:  now.Add(30 * 24 * time.Hour),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := "karmada-system"
+			oldCertData := maps.Clone(baseCertData)
+			replaceTestRootCAWithValidity(t, oldCertData, tt.caNotBefore, tt.caNotAfter)
+			clientset := fake.NewClientset(buildExistingRotateSecrets(namespace, oldCertData)...)
+			opt := &CommandInitOption{
+				CertMode:                 CertModeRotate,
+				CertValidity:             365 * 24 * time.Hour,
+				EtcdReplicas:             1,
+				EtcdStorageMode:          etcdStorageModeEmptyDir,
+				Namespace:                namespace,
+				HostClusterDomain:        "cluster.local",
+				KarmadaAPIServerIP:       []net.IP{utils.StringToNetIP("192.0.2.11")},
+				KarmadaAPIServerNodePort: 32443,
+				KubeClientSet:            clientset,
+			}
+
+			err := opt.runCertRotate()
+			assert.Error(t, err)
+			assertNoSecretUpdateActions(t, clientset.Actions())
+		})
+	}
+}
+
+func TestValidateCAForLeaf(t *testing.T) {
+	now := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	validNotAfter := now.Add(time.Hour)
+	key, err := certpkg.NewPrivateKey(x509.ECDSA)
+	assert.NoError(t, err)
+	tests := []struct {
+		name         string
+		mutateCA     func(*x509.Certificate)
+		leafNotAfter time.Time
+		wantError    string
+	}{
+		{
+			name:         "valid including equal CA and leaf expiry",
+			leafNotAfter: validNotAfter,
+		},
+		{
+			name: "valid without key usage extension",
+			mutateCA: func(certificate *x509.Certificate) {
+				certificate.KeyUsage = 0
+			},
+			leafNotAfter: validNotAfter,
+		},
+		{
+			name: "invalid basic constraints",
+			mutateCA: func(certificate *x509.Certificate) {
+				certificate.BasicConstraintsValid = false
+			},
+			leafNotAfter: validNotAfter,
+			wantError:    "not a valid certificate authority",
+		},
+		{
+			name: "not a CA",
+			mutateCA: func(certificate *x509.Certificate) {
+				certificate.IsCA = false
+			},
+			leafNotAfter: validNotAfter,
+			wantError:    "not a valid certificate authority",
+		},
+		{
+			name: "key usage does not allow certificate signing",
+			mutateCA: func(certificate *x509.Certificate) {
+				certificate.KeyUsage = x509.KeyUsageDigitalSignature
+			},
+			leafNotAfter: validNotAfter,
+			wantError:    "not authorized to sign certificates",
+		},
+		{
+			name: "CA is not valid yet",
+			mutateCA: func(certificate *x509.Certificate) {
+				certificate.NotBefore = now.Add(time.Minute)
+			},
+			leafNotAfter: validNotAfter,
+			wantError:    "is not valid before",
+		},
+		{
+			name: "CA is expired",
+			mutateCA: func(certificate *x509.Certificate) {
+				certificate.NotAfter = now.Add(-time.Minute)
+			},
+			leafNotAfter: validNotAfter,
+			wantError:    "expired at",
+		},
+		{
+			name:         "requested certificate already expired",
+			leafNotAfter: now,
+			wantError:    "is not after the current time",
+		},
+		{
+			name:         "requested certificate outlives CA",
+			leafNotAfter: validNotAfter.Add(time.Minute),
+			wantError:    "exceeds CA expiry",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caCert := &x509.Certificate{
+				Subject:               pkix.Name{CommonName: "test-ca"},
+				NotBefore:             now.Add(-time.Hour),
+				NotAfter:              validNotAfter,
+				KeyUsage:              x509.KeyUsageCertSign,
+				BasicConstraintsValid: true,
+				IsCA:                  true,
+			}
+			if tt.mutateCA != nil {
+				tt.mutateCA(caCert)
+			}
+			config := certpkg.NewCertConfig("test", nil, certutil.AltNames{}, &tt.leafNotAfter)
+			err := validateCAForLeaf(&caMaterial{cert: caCert, key: key}, config, now)
+			if tt.wantError == "" {
+				assert.NoError(t, err)
+				return
+			}
+			if assert.Error(t, err) {
+				assert.Contains(t, err.Error(), tt.wantError)
+			}
+		})
 	}
 }
 
@@ -664,9 +1620,10 @@ func TestParseInitConfig(t *testing.T) {
 		},
 	}
 
-	opt := &CommandInitOption{}
+	opt := &CommandInitOption{CertMode: CertModeRotate}
 	err := opt.parseInitConfig(cfg)
 	assert.NoError(t, err)
+	assert.Equal(t, CertModeRotate, opt.CertMode)
 	assert.Equal(t, "test-namespace", opt.Namespace)
 	assert.Equal(t, "/path/to/kubeconfig", opt.KubeConfig)
 	assert.Equal(t, "test-registry", opt.ImageRegistry)
@@ -710,6 +1667,192 @@ func TestParseInitConfig_MissingFields(t *testing.T) {
 	assert.Equal(t, "test-namespace", opt.Namespace)
 	assert.Empty(t, opt.KubeConfig)
 	assert.Empty(t, opt.KubeImageTag)
+}
+
+func buildTestCertAndKeyData(t *testing.T) map[string]string {
+	t.Helper()
+	return buildTestCertAndKeyDataWithLeafNotAfter(t, time.Now().Add(365*24*time.Hour).UTC())
+}
+
+func buildTestCertAndKeyDataWithLeafNotAfter(t *testing.T, leafNotAfter time.Time) map[string]string {
+	t.Helper()
+
+	rootCA, rootKey := newTestCA(t, "karmada")
+	frontProxyCA, frontProxyKey := newTestCA(t, "front-proxy-ca")
+	etcdCA, etcdKey := newTestCA(t, "etcd-ca")
+
+	certData := map[string]string{}
+	setTestCertAndKeyData(t, certData, globaloptions.CaCertAndKeyName, rootCA, rootKey)
+	setTestCertAndKeyData(t, certData, options.FrontProxyCaCertAndKeyName, frontProxyCA, frontProxyKey)
+	setTestCertAndKeyData(t, certData, options.EtcdCaCertAndKeyName, etcdCA, etcdKey)
+	setTestLeafCertAndKeyData(t, certData, options.KarmadaCertAndKeyName, rootCA, rootKey, certpkg.NewCertConfig("system:admin", []string{"system:masters"}, certutil.AltNames{}, &leafNotAfter))
+	setTestLeafCertAndKeyData(t, certData, options.ApiserverCertAndKeyName, rootCA, rootKey, certpkg.NewCertConfig("karmada-apiserver", []string{}, certutil.AltNames{}, &leafNotAfter))
+	setTestLeafCertAndKeyData(t, certData, options.FrontProxyClientCertAndKeyName, frontProxyCA, frontProxyKey, certpkg.NewCertConfig("front-proxy-client", []string{}, certutil.AltNames{}, &leafNotAfter))
+	setTestLeafCertAndKeyData(t, certData, options.EtcdServerCertAndKeyName, etcdCA, etcdKey, certpkg.NewCertConfig("karmada-etcd-server", []string{}, certutil.AltNames{}, &leafNotAfter))
+	setTestLeafCertAndKeyData(t, certData, options.EtcdClientCertAndKeyName, etcdCA, etcdKey, certpkg.NewCertConfig("karmada-etcd-client", []string{}, certutil.AltNames{}, &leafNotAfter))
+	return certData
+}
+
+func newTestCA(t *testing.T, commonName string) (*x509.Certificate, crypto.Signer) {
+	t.Helper()
+	caCert, caKey, err := certpkg.NewCACertAndKey(commonName)
+	assert.NoError(t, err)
+	return caCert, *caKey
+}
+
+func replaceTestRootCAWithValidity(t *testing.T, certData map[string]string, notBefore, notAfter time.Time) {
+	t.Helper()
+	rootKey, err := certpkg.NewPrivateKey(x509.ECDSA)
+	assert.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "karmada"},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, rootKey.Public(), rootKey)
+	assert.NoError(t, err)
+	rootCA, err := x509.ParseCertificate(certDER)
+	assert.NoError(t, err)
+	setTestCertAndKeyData(t, certData, globaloptions.CaCertAndKeyName, rootCA, rootKey)
+
+	leafNotAfter := time.Now().Add(time.Hour).UTC()
+	karmadaConfig := certpkg.NewCertConfig("system:admin", []string{"system:masters"}, certutil.AltNames{}, &leafNotAfter)
+	karmadaConfig.PublicKeyAlgorithm = x509.ECDSA
+	setTestLeafCertAndKeyData(t, certData, options.KarmadaCertAndKeyName, rootCA, rootKey, karmadaConfig)
+	apiserverConfig := certpkg.NewCertConfig("karmada-apiserver", []string{}, certutil.AltNames{}, &leafNotAfter)
+	apiserverConfig.PublicKeyAlgorithm = x509.ECDSA
+	setTestLeafCertAndKeyData(t, certData, options.ApiserverCertAndKeyName, rootCA, rootKey, apiserverConfig)
+}
+
+func setTestCertAndKeyData(t *testing.T, certData map[string]string, name string, certificate *x509.Certificate, key crypto.Signer) {
+	t.Helper()
+	keyPEM, err := certpkg.EncodePrivateKeyPEM(key)
+	assert.NoError(t, err)
+	certData[certFileName(name)] = string(certpkg.EncodeCertPEM(certificate))
+	certData[keyFileName(name)] = string(keyPEM)
+}
+
+func setTestLeafCertAndKeyData(t *testing.T, certData map[string]string, name string, caCert *x509.Certificate, caKey crypto.Signer, certConfig *certpkg.CertsConfig) {
+	t.Helper()
+	leafCert, leafKey, err := certpkg.NewCertAndKey(caCert, caKey, certConfig)
+	assert.NoError(t, err)
+	setTestCertAndKeyData(t, certData, name, leafCert, leafKey)
+}
+
+func replaceTestLeafCertAndKeyData(t *testing.T, certData map[string]string, name, caName string, altNames certutil.AltNames) {
+	t.Helper()
+	existingCert, err := certpkg.LoadCertificatePEM([]byte(certData[certFileName(name)]))
+	assert.NoError(t, err)
+	caCert, caKey, err := certpkg.LoadCertAndKeyPEM([]byte(certData[certFileName(caName)]), []byte(certData[keyFileName(caName)]))
+	assert.NoError(t, err)
+	notAfter := time.Now().Add(365 * 24 * time.Hour).UTC()
+	certConfig := certpkg.NewCertConfig(existingCert.Subject.CommonName, existingCert.Subject.Organization, altNames, &notAfter)
+	certConfig.Usages = slices.Clone(existingCert.ExtKeyUsage)
+	setTestLeafCertAndKeyData(t, certData, name, caCert, caKey, certConfig)
+}
+
+func buildExistingRotateSecrets(namespace string, certData map[string]string) []runtime.Object {
+	karmadaCertData := map[string]string{}
+	maps.Copy(karmadaCertData, certData)
+	etcdCertData := map[string]string{
+		certFileName(options.EtcdCaCertAndKeyName):     certData[certFileName(options.EtcdCaCertAndKeyName)],
+		keyFileName(options.EtcdCaCertAndKeyName):      certData[keyFileName(options.EtcdCaCertAndKeyName)],
+		certFileName(options.EtcdServerCertAndKeyName): certData[certFileName(options.EtcdServerCertAndKeyName)],
+		keyFileName(options.EtcdServerCertAndKeyName):  certData[keyFileName(options.EtcdServerCertAndKeyName)],
+	}
+
+	objects := []runtime.Object{
+		testSecret(namespace, globaloptions.KarmadaCertsName, karmadaCertData),
+		testSecret(namespace, etcdCertName, etcdCertData),
+		testSecret(namespace, webhookCertsName, map[string]string{
+			"tls.crt": certData[certFileName(options.KarmadaCertAndKeyName)],
+			"tls.key": certData[keyFileName(options.KarmadaCertAndKeyName)],
+		}),
+	}
+
+	for _, name := range karmadaConfigList {
+		objects = append(objects, testSecret(namespace, name, map[string]string{util.KarmadaConfigFieldName: "old-config"}))
+	}
+	return objects
+}
+
+func buildExistingExternalEtcdRotateSecrets(namespace string, certData map[string]string) []runtime.Object {
+	objects := buildExistingRotateSecrets(namespace, certData)
+	for _, object := range objects {
+		secret := object.(*corev1.Secret)
+		if secret.Name != etcdCertName {
+			continue
+		}
+		delete(secret.StringData, certFileName(options.EtcdServerCertAndKeyName))
+		delete(secret.StringData, keyFileName(options.EtcdServerCertAndKeyName))
+		delete(secret.Data, certFileName(options.EtcdServerCertAndKeyName))
+		delete(secret.Data, keyFileName(options.EtcdServerCertAndKeyName))
+	}
+	return objects
+}
+
+func writeTestFile(t *testing.T, dir, name, data string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	assert.NoError(t, os.WriteFile(path, []byte(data), 0600))
+	return path
+}
+
+func loadTestCertFromData(t *testing.T, certData map[string]string, name string) *x509.Certificate {
+	t.Helper()
+	certificate, err := certpkg.LoadCertificatePEM([]byte(certData[certFileName(name)]))
+	assert.NoError(t, err)
+	return certificate
+}
+
+func loadTestCertFromSecret(t *testing.T, secret *corev1.Secret, name string) *x509.Certificate {
+	t.Helper()
+	certificate, err := certpkg.LoadCertificatePEM([]byte(secret.StringData[certFileName(name)]))
+	assert.NoError(t, err)
+	return certificate
+}
+
+func testSecret(namespace, name string, data map[string]string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: data,
+		Data:       stringMapToByteMap(data),
+	}
+}
+
+func stringMapToByteMap(data map[string]string) map[string][]byte {
+	result := map[string][]byte{}
+	for key, value := range data {
+		result[key] = []byte(value)
+	}
+	return result
+}
+
+func assertNoInstallResourceActions(t *testing.T, actions []k8stesting.Action) {
+	t.Helper()
+	for _, action := range actions {
+		switch action.GetResource().Resource {
+		case "deployments", "statefulsets", "services":
+			t.Fatalf("unexpected %s action for %s during certificate rotation", action.GetVerb(), action.GetResource().Resource)
+		}
+	}
+}
+
+func assertNoSecretUpdateActions(t *testing.T, actions []k8stesting.Action) {
+	t.Helper()
+	for _, action := range actions {
+		if action.GetResource().Resource == "secrets" && action.GetVerb() == "update" {
+			t.Fatalf("unexpected secret update action during failed certificate rotation")
+		}
+	}
 }
 
 // parseDuration parses a duration string and returns the corresponding time.Duration value.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds certificate rotation to `karmadactl init` through `--cert-mode=rotate`.

Rotation reuses existing CA material to renew init-managed leaf certificates, refreshes a matching local admin kubeconfig, and updates existing certificate/config Secrets. The default `install` path is unchanged. Root CAs, Secret metadata, and `karmada.key` (the ServiceAccount signing key) are preserved.

Operators must reuse options consistent with the original installation. External etcd CA and client credentials are preserved and must be rotated separately. Restart the affected components after rotation.

**Which issue(s) this PR fixes**:

Fixes #7693

**Special notes for your reviewer**:

- Safety/scope: rotation validates CA/key usage and lifetime, preflights target Secrets, and rejects missing or mismatched state and etcd mode changes. It does not rotate CAs or external-etcd credentials, update `caBundle` fields, or restart workloads. Secret writes are sequential; reruns converge after a partial API timeout.
- Validation: `go test ./pkg/karmadactl/... ./cmd/karmadactl/... ./cmd/kubectl-karmada/... -count=1`, cmdinit lint, and flag/import verifiers passed locally. Focused tests cover identity guards and partial-update rerun convergence; earlier kind validation confirmed expired-leaf recovery after restart.
- AI assistance: Codex helped inspect the code and draft tests/text; I reviewed the changes and validation results.

**Does this PR introduce a user-facing change?**:

```release-note
`karmadactl init`: Added `--cert-mode=rotate` to renew init-managed leaf certificates. External etcd CA and client credentials are preserved and must be rotated separately. Restart the affected components after rotation.
```