### PR TITLE
fix: prune consecutive auto-generated ServiceAccount token secrets

### DIFF
--- a/pkg/resourceinterpreter/default/native/prune/prune.go
+++ b/pkg/resourceinterpreter/default/native/prune/prune.go
@@ -173,12 +173,17 @@ func removeServiceAccountIrrelevantField(workload *unstructured.Unstructured) er
 	// If 'secrets' exists in ServiceAccount, remove the automatic generation secrets (e.g. default-token-xxx)
 	if exist && len(secrets) > 0 {
 		tokenPrefix := fmt.Sprintf("%s-token-", workload.GetName())
-		for idx := 0; idx < len(secrets); idx++ {
-			if strings.HasPrefix(secrets[idx].(map[string]any)["name"].(string), tokenPrefix) {
-				secrets = append(secrets[:idx], secrets[idx+1:]...)
+		retained := make([]any, 0, len(secrets))
+		for _, secret := range secrets {
+			entry, ok := secret.(map[string]any)
+			if ok {
+				if name, ok := entry["name"].(string); ok && strings.HasPrefix(name, tokenPrefix) {
+					continue
+				}
 			}
+			retained = append(retained, secret)
 		}
-		_ = unstructured.SetNestedSlice(workload.Object, secrets, "secrets")
+		_ = unstructured.SetNestedSlice(workload.Object, retained, "secrets")
 	}
 	return nil
 }

--- a/pkg/resourceinterpreter/default/native/prune/prune_test.go
+++ b/pkg/resourceinterpreter/default/native/prune/prune_test.go
@@ -214,7 +214,53 @@ func TestRemoveIrrelevantField(t *testing.T) {
 				maps, _ := obj.([]any)
 
 				for _, m := range maps {
-					if m.(map[string]any)["name"] == resource {
+					entry, ok := m.(map[string]any)
+					if !ok {
+						continue
+					}
+					if name, ok := entry["name"].(string); ok && name == resource {
+						return true
+					}
+				}
+				return false
+			},
+		},
+		{
+			name: "remove token secrets while tolerating malformed secret entries",
+			workload: &unstructured.Unstructured{
+				Object: map[string]any{
+					"kind": util.ServiceAccountKind,
+					"metadata": map[string]any{
+						"name": "foo",
+					},
+					"secrets": []any{
+						"malformed-non-map-entry",
+						map[string]any{
+							"kind": "Secret",
+						},
+						map[string]any{
+							"name": "foo-token-ccccc",
+						},
+						map[string]any{
+							"name": "foo-dockercfg-mmmmm",
+						},
+					},
+				},
+			},
+			extraHooks:              nil,
+			unexpectedFields:        []field{{"secrets"}},
+			unexpectedResource:      "foo-token-ccccc",
+			shouldNotRemoveFields:   []field{{"secrets"}},
+			shouldNotRemoveResource: "foo-dockercfg-mmmmm",
+			containsFunc: func(obj any, resource string) bool {
+				maps, _ := obj.([]any)
+
+				for _, m := range maps {
+					entry, ok := m.(map[string]any)
+					if !ok {
+						continue
+					}
+					if name, ok := entry["name"].(string); ok && name == resource {
 						return true
 					}
 				}

--- a/pkg/resourceinterpreter/default/native/prune/prune_test.go
+++ b/pkg/resourceinterpreter/default/native/prune/prune_test.go
@@ -185,6 +185,43 @@ func TestRemoveIrrelevantField(t *testing.T) {
 			},
 		},
 		{
+			name: "remove consecutive serviceaccount token secrets",
+			workload: &unstructured.Unstructured{
+				Object: map[string]any{
+					"kind": util.ServiceAccountKind,
+					"metadata": map[string]any{
+						"name": "foo",
+					},
+					"secrets": []any{
+						map[string]any{
+							"name": "foo-token-aaaaa",
+						},
+						map[string]any{
+							"name": "foo-token-bbbbb",
+						},
+						map[string]any{
+							"name": "foo-dockercfg-zdr2j",
+						},
+					},
+				},
+			},
+			extraHooks:              nil,
+			unexpectedFields:        []field{{"secrets"}},
+			unexpectedResource:      "foo-token-bbbbb",
+			shouldNotRemoveFields:   []field{{"secrets"}},
+			shouldNotRemoveResource: "foo-dockercfg-zdr2j",
+			containsFunc: func(obj any, resource string) bool {
+				maps, _ := obj.([]any)
+
+				for _, m := range maps {
+					if m.(map[string]any)["name"] == resource {
+						return true
+					}
+				}
+				return false
+			},
+		},
+		{
 			name: "remove service-account token secret irrelevant fields",
 			workload: &unstructured.Unstructured{
 				Object: map[string]any{

--- a/pkg/resourceinterpreter/default/native/prune/prune_test.go
+++ b/pkg/resourceinterpreter/default/native/prune/prune_test.go
@@ -46,6 +46,7 @@ type test struct {
 	containsFunc            func(any, string) bool
 }
 
+//nolint:gocyclo
 func TestRemoveIrrelevantField(t *testing.T) {
 	var tests = []*test{
 		{


### PR DESCRIPTION

# PR description

## What type of PR is this?

/kind bug

## What this PR does / why we need it

`removeServiceAccountIrrelevantField` strips auto-generated `<sa-name>-token-*` secrets from a ServiceAccount before it is propagated to member clusters. It removed matching entries in place while advancing the loop index, so when two or more token secrets were listed consecutively, the entry that shifted into the freed slot was skipped. Those leftover token secrets were then propagated to member clusters.

This PR rebuilds the `secrets` slice by filtering out the token secrets, which removes all matches regardless of ordering. It also switches the entry/name type assertions to the comma-ok form so a malformed `secrets` entry no longer panics the interpreter.

## Which issue this PR fixes

Fixes #7698

## Special notes for your reviewer

Added a regression test case (`remove consecutive serviceaccount token secrets`) with two adjacent `foo-token-*` secrets. It fails on the previous implementation and passes with this change. Existing prune tests remain green.

## Does this PR introduce a user-facing change?

```release-note
`karmada-controller-manager`: Fixed the issue that consecutive auto-generated ServiceAccount token secrets were not pruned and could be propagated to member clusters.
```

