### PR TITLE
Reduce Node.js 20 usage in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,12 +89,7 @@ jobs:
       run: |
         mv ./charts/karmada/_crds ./charts/karmada/crds
     - name: Tar the crds
-      uses: a7ul/tar-action@ed9cbd44fc9276db29ea2fb1f8adf3d7e0691589 # v1.2.0
-      with:
-        command: c
-        cwd: ./charts/karmada/
-        files: crds
-        outPath: crds.tar.gz
+      run: tar -czf crds.tar.gz -C ./charts/karmada crds
     - name: generate crds hash
       id: hash
       run: |


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Reduces remaining GitHub Actions dependencies on the deprecated Node.js 20 runtime by:

- Replacing the unmaintained `a7ul/tar-action` CRD archive step with the runner's native `tar` command.
- Updating `fossas/fossa-action` from v1.9.0 to the pinned v2.0.0 commit, whose action metadata uses Node.js 24.

**Which issue(s) this PR fixes**:
Fixes #7702

**Special notes for your reviewer**:
The replacement `tar -czf crds.tar.gz -C ./charts/karmada crds` preserves the previous archive location and contents: `crds.tar.gz` is created at the workflow workspace root and contains entries under `crds/`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Test Report**:
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/fossa.yml .github/workflows/release.yml`
- `git diff --check`
- Audited workflow action metadata and found no remaining `runs.using: node20` entries among fetched workflow actions.
- Validated the replacement tar command creates a non-empty archive containing `crds/` entries.
- `make verify` was attempted with Go 1.26.4; after fixing local `GOROOT` and `PATH`, it reached `golangci-lint run` but did not complete locally after several quiet minutes, so it was stopped.
