### PR TITLE
Handle nodes without addresses during init

### DIFF
--- a/operator/pkg/util/endpoint.go
+++ b/operator/pkg/util/endpoint.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/url"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
@@ -49,8 +50,11 @@ func formatURL(host, port string) *url.URL {
 // GetAPIServiceIP returns a valid node IP address.
 func GetAPIServiceIP(clientset clientset.Interface) (string, error) {
 	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-	if err != nil || len(nodes.Items) == 0 {
-		return "", fmt.Errorf("there are no nodes in cluster, err: %w", err)
+	if err != nil {
+		return "", fmt.Errorf("failed to list nodes, err: %w", err)
+	}
+	if len(nodes.Items) == 0 {
+		return "", fmt.Errorf("there are no nodes in cluster")
 	}
 
 	var (
@@ -63,10 +67,24 @@ func GetAPIServiceIP(clientset clientset.Interface) (string, error) {
 		ls := labels.Set(node.GetLabels())
 
 		if masterLabel.AsSelector().Matches(ls) || controlplaneLabel.AsSelector().Matches(ls) {
-			if ip := netutils.ParseIPSloppy(node.Status.Addresses[0].Address); ip != nil {
-				return ip.String(), nil
+			if ip := getValidNodeIP(node.Status.Addresses); ip != "" {
+				return ip, nil
 			}
 		}
 	}
-	return nodes.Items[0].Status.Addresses[0].Address, nil
+	for _, node := range nodes.Items {
+		if ip := getValidNodeIP(node.Status.Addresses); ip != "" {
+			return ip, nil
+		}
+	}
+	return "", fmt.Errorf("there are no valid node IPs in cluster")
+}
+
+func getValidNodeIP(addresses []corev1.NodeAddress) string {
+	for _, address := range addresses {
+		if ip := netutils.ParseIPSloppy(address.Address); ip != nil {
+			return ip.String()
+		}
+	}
+	return ""
 }

--- a/operator/pkg/util/endpoint_test.go
+++ b/operator/pkg/util/endpoint_test.go
@@ -83,6 +83,20 @@ func TestGetAPIServiceIP(t *testing.T) {
 			errMsg:  "there are no nodes in cluster",
 		},
 		{
+			name:   "GetAPIServiceIP_WithNoNodeAddresses_FailedToGetAPIServiceIP",
+			client: fakeclientset.NewClientset(),
+			prep: func(client clientset.Interface) error {
+				_, err := client.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+					},
+				}, metav1.CreateOptions{})
+				return err
+			},
+			wantErr: true,
+			errMsg:  "there are no valid node IPs in cluster",
+		},
+		{
 			name:   "GetAPIServiceIP_WithoutMasterNode_WorkerNodeAPIServiceIPReturned",
 			client: fakeclientset.NewClientset(),
 			prep: func(client clientset.Interface) error {

--- a/pkg/karmadactl/cmdinit/kubernetes/node.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/node.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,9 +53,13 @@ func (i *CommandInitOption) getKarmadaAPIServerIP() error {
 		klog.Warning("The kubernetes cluster does not have a Master role.")
 	} else {
 		for _, v := range masterNodes.Items {
-			i.KarmadaAPIServerIP = append(i.KarmadaAPIServerIP, utils.StringToNetIP(v.Status.Addresses[0].Address))
+			if ip := getNodeIP(v.Status.Addresses); ip != nil {
+				i.KarmadaAPIServerIP = append(i.KarmadaAPIServerIP, ip)
+			}
 		}
-		return nil
+		if len(i.KarmadaAPIServerIP) != 0 {
+			return nil
+		}
 	}
 
 	klog.Info("Randomly select 3 Node IPs in the kubernetes cluster.")
@@ -63,15 +68,27 @@ func (i *CommandInitOption) getKarmadaAPIServerIP() error {
 		return err
 	}
 
-	for number := range 3 {
-		if number >= len(nodes.Items) {
+	for _, node := range nodes.Items {
+		if len(i.KarmadaAPIServerIP) >= 3 {
 			break
 		}
-		i.KarmadaAPIServerIP = append(i.KarmadaAPIServerIP, utils.StringToNetIP(nodes.Items[number].Status.Addresses[0].Address))
+		if ip := getNodeIP(node.Status.Addresses); ip != nil {
+			i.KarmadaAPIServerIP = append(i.KarmadaAPIServerIP, ip)
+		}
 	}
 
 	if len(i.KarmadaAPIServerIP) == 0 {
 		return fmt.Errorf("karmada apiserver ip is empty")
+	}
+	return nil
+}
+
+// getNodeIP returns the first parseable IP address from the node address list.
+func getNodeIP(addresses []corev1.NodeAddress) net.IP {
+	for _, address := range addresses {
+		if ip := net.ParseIP(address.Address); ip != nil {
+			return ip
+		}
 	}
 	return nil
 }

--- a/pkg/karmadactl/cmdinit/kubernetes/node_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/node_test.go
@@ -27,11 +27,13 @@ import (
 
 func TestCommandInitOption_getKarmadaAPIServerIP(t *testing.T) {
 	tests := []struct {
-		name    string
-		option  CommandInitOption
-		nodes   []string
-		labels  map[string]string
-		wantErr bool
+		name          string
+		option        CommandInitOption
+		nodes         []string
+		labels        map[string]string
+		addresses     []corev1.NodeAddress
+		nodeAddresses [][]corev1.NodeAddress
+		wantErr       bool
 	}{
 		{
 			name: "KarmadaAPIServerAdvertiseAddress is not empty",
@@ -62,6 +64,31 @@ func TestCommandInitOption_getKarmadaAPIServerIP(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "node without addresses",
+			option: CommandInitOption{
+				KubeClientSet: fake.NewClientset(),
+			},
+			nodes:     []string{"node1"},
+			labels:    map[string]string{},
+			addresses: []corev1.NodeAddress{},
+			wantErr:   true,
+		},
+		{
+			name: "skip nodes without addresses",
+			option: CommandInitOption{
+				KubeClientSet: fake.NewClientset(),
+			},
+			nodes:  []string{"node1", "node2", "node3", "node4"},
+			labels: map[string]string{},
+			nodeAddresses: [][]corev1.NodeAddress{
+				{},
+				{},
+				{},
+				{{Address: "127.0.0.4"}},
+			},
+			wantErr: false,
+		},
+		{
 			name: "no nodes",
 			option: CommandInitOption{
 				KubeClientSet: fake.NewClientset(),
@@ -71,16 +98,22 @@ func TestCommandInitOption_getKarmadaAPIServerIP(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for _, v := range tt.nodes {
+			addresses := tt.addresses
+			if addresses == nil {
+				addresses = []corev1.NodeAddress{{Address: "127.0.0.1"}}
+			}
+			for i, v := range tt.nodes {
+				nodeAddresses := addresses
+				if len(tt.nodeAddresses) > i {
+					nodeAddresses = tt.nodeAddresses[i]
+				}
 				_, err := tt.option.KubeClientSet.CoreV1().Nodes().Create(context.Background(), &corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   v,
 						Labels: tt.labels,
 					},
 					Status: corev1.NodeStatus{
-						Addresses: []corev1.NodeAddress{
-							{Address: "127.0.0.1"},
-						},
+						Addresses: nodeAddresses,
 					},
 				}, metav1.CreateOptions{})
 				if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR prevents init paths from panicking when Kubernetes nodes exist but do not have `status.addresses`.

Found issues:
- `operator/pkg/util.GetAPIServiceIP` indexed `node.Status.Addresses[0]` for control-plane and fallback nodes.
- `karmadactl init` indexed `Status.Addresses[0]` when deriving Karmada API server IPs.

Fixes:
- Operator init now scans node addresses and returns a clear error when no valid node IP exists.
- `karmadactl init` skips nodes without addresses and returns the existing empty-IP error if none are usable.
- Added regression tests for nodes with empty address lists.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

Verified:
- `gofmt -l operator/pkg/util/endpoint.go operator/pkg/util/endpoint_test.go pkg/karmadactl/cmdinit/kubernetes/node.go pkg/karmadactl/cmdinit/kubernetes/node_test.go`
- `git diff --check`
- `go test ./operator/pkg/util -run TestGetAPIServiceIP -count=1`
  - `ok github.com/karmada-io/karmada/operator/pkg/util`
- `go test ./pkg/karmadactl/cmdinit/kubernetes -run TestCommandInitOption_getKarmadaAPIServerIP -count=1`
  - `ok github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/kubernetes`

Not completed locally:
- `make verify`: local Windows shell does not have working `make`/bash setup.
- Full touched package tests hit existing local environment failures: blocked external network request and denied writes under `\tmp`.

No performance benchmark was run. The change adds in-memory guards over already-listed nodes and does not add Kubernetes API calls.

**Does this PR introduce a user-facing change?**:

```release-note
operator/karmadactl: Fixed init panic when selected Kubernetes nodes have no status addresses.
```