### PR TITLE
fix: handle deployments without command in patcher

### DIFF
--- a/operator/pkg/util/patcher/pather.go
+++ b/operator/pkg/util/patcher/pather.go
@@ -150,26 +150,28 @@ func (p *Patcher) ForDeployment(deployment *appsv1.Deployment) {
 	if len(p.extraArgs) != 0 || len(p.featureGates) != 0 {
 		// It's considered the first container is the karmada component by default.
 		baseArguments := deployment.Spec.Template.Spec.Containers[0].Command
-		argsMap := parseArgumentListToMap(baseArguments)
+		if len(baseArguments) != 0 {
+			argsMap := parseArgumentListToMap(baseArguments)
 
-		overrideArgs := map[string]string{}
+			overrideArgs := map[string]string{}
 
-		// merge featureGates and build to an argument.
-		if len(p.featureGates) != 0 {
-			baseFeatureGates := map[string]bool{}
+			// merge featureGates and build to an argument.
+			if len(p.featureGates) != 0 {
+				baseFeatureGates := map[string]bool{}
 
-			if argument, ok := argsMap["feature-gates"]; ok {
-				baseFeatureGates = parseFeatrueGatesArgumentToMap(argument)
+				if argument, ok := argsMap["feature-gates"]; ok {
+					baseFeatureGates = parseFeatrueGatesArgumentToMap(argument)
+				}
+				overrideArgs["feature-gates"] = buildFeatureGatesArgumentFromMap(baseFeatureGates, p.featureGates)
 			}
-			overrideArgs["feature-gates"] = buildFeatureGatesArgumentFromMap(baseFeatureGates, p.featureGates)
+
+			maps.Copy(overrideArgs, p.extraArgs)
+
+			// the first argument is most often the binary name
+			command := []string{baseArguments[0]}
+			command = append(command, buildArgumentListFromMap(argsMap, overrideArgs)...)
+			deployment.Spec.Template.Spec.Containers[0].Command = command
 		}
-
-		maps.Copy(overrideArgs, p.extraArgs)
-
-		// the first argument is most often the binary name
-		command := []string{baseArguments[0]}
-		command = append(command, buildArgumentListFromMap(argsMap, overrideArgs)...)
-		deployment.Spec.Template.Spec.Containers[0].Command = command
 	}
 	deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, p.sidecarContainers...)
 	// Add extra volumes and volume mounts

--- a/operator/pkg/util/patcher/pather_test.go
+++ b/operator/pkg/util/patcher/pather_test.go
@@ -181,6 +181,58 @@ func TestPatchForDeployment(t *testing.T) {
 			},
 		},
 		{
+			name: "PatchForDeployment_WithExtraArgsAndEmptyCommand_Patched",
+			patcher: &Patcher{
+				extraArgs: map[string]string{
+					"some-arg": "some-value",
+				},
+			},
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "test",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "nginx:latest",
+									Args:  []string{"run", "--existing=1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-deployment",
+					Namespace:   "test",
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels:      map[string]string{},
+							Annotations: map[string]string{},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "nginx:latest",
+									Args:  []string{"run", "--existing=1"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "PatchForDeployment_WithExtraVolumesAndVolumeMounts_Patched",
 			patcher: &Patcher{
 				extraVolumes: []corev1.Volume{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`Patcher.ForDeployment` currently assumes the first container has a non-empty `Command` when applying `extraArgs` or `featureGates`, and indexes `baseArguments[0]` unconditionally.

This PR hardens that path for deployments that rely on the image entrypoint and leave `Command` empty. When `Command` is present, the patcher keeps the existing behavior and preserves the first command element as the binary name. When `Command` is empty, the command-argument merge is skipped so the patcher does not panic and does not reinterpret arbitrary Kubernetes `Args`.

A regression case is added to the existing `TestPatchForDeployment` table.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

Local checks run:

- `go test ./operator/pkg/util/patcher -run 'TestPatchForDeployment/PatchForDeployment_WithExtraArgsAndEmptyCommand_Patched' -count=1 -v`
- `go test ./operator/pkg/util/patcher -count=1`
- `gofmt -l operator/pkg/util/patcher/pather.go operator/pkg/util/patcher/pather_test.go`
- `git diff --check`

`mingw32-make test` is not usable in this Windows shell; it fails before Go tests at `mkdir -p ./_output/coverage/`. A previous `hack/verify-all.sh` run in MSYS bash failed on unrelated `pkg/util/lifted/doc.go` generated-doc drift.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```