### PR TITLE
docs: fix broken TOC anchor and dead internal link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,6 @@ Welcome to Karmada!
 -   [Contributor Workflow](#contributor-workflow)
     -   [Creating Pull Requests](#creating-pull-requests)
     -   [Code Review](#code-review)
-    -   [Testing](#testing)
 
 # Before you get started
 
@@ -60,7 +59,7 @@ labels for issues that should not need deep knowledge of the system.
 We can help new contributors who wish to work on such issues.
 
 Another good way to contribute is to find a documentation improvement, such as a missing/broken link.
-Please see [Contributing](#contributing) below for the workflow.
+Please see [Contributor Workflow](#contributor-workflow) below for the workflow.
 
 #### Work on an issue
 


### PR DESCRIPTION
## What type of PR is this?
/kind documentation

## What this PR does / why we need it
Two issues in CONTRIBUTING.md:

1. The Table of Contents has a `[Testing](#testing)` entry, but no `## Testing` heading exists in the document — the link is broken.

2. Line 63 has `[Contributing](#contributing)` which is a useless self-link that points back to the document's own title. It should point to the `## Contributor Workflow` section, which describes the actual PR workflow.

## Which issue(s) this PR fixes
Fixes #7644

## Does this PR introduce a user-facing change?
No

Signed-off-by: Goutham Annem <gouthemannem@gmail.com>