### PR TITLE
Release1.18: Reduce dependency on deprecated Node.js 20 runtime in GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,12 +89,7 @@ jobs:
       run: |
         mv ./charts/karmada/_crds ./charts/karmada/crds
     - name: Tar the crds
-      uses: a7ul/tar-action@ed9cbd44fc9276db29ea2fb1f8adf3d7e0691589 # v1.2.0
-      with:
-        command: c
-        cwd: ./charts/karmada/
-        files: crds
-        outPath: crds.tar.gz
+      run: tar -czf crds.tar.gz -C ./charts/karmada crds 
     - name: generate crds hash
       id: hash
       run: |


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Update GitHub Actions to use Node.js 24 runtime instead of the deprecated Node.js 20.
Tar the crds -> tar -czf crds.tar.gz -C ./charts/karmada crds #

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/7702

Fixes NONE


**Special notes for your reviewer**:
 NONE

**Does this PR introduce a user-facing change?**:
 NONE

