### PR TITLE
feat: add dependencyInterpretation for MPIJob resource customization

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/customizations.yaml
@@ -219,3 +219,29 @@ spec:
 
           return status
         end
+    dependencyInterpretation:
+      luaScript: >
+        local kube = require("kube")
+        function GetDependencies(desiredObj)
+          local refs = {}
+
+          if desiredObj.spec == nil or desiredObj.spec.mpiReplicaSpecs == nil then
+            return refs
+          end
+
+          -- Iterate all MPIJob replica types
+          local replicaTypes = {"Launcher", "Worker"}
+          for _, replicaType in ipairs(replicaTypes) do
+            local spec = desiredObj.spec.mpiReplicaSpecs[replicaType]
+            if spec ~= nil and spec.template ~= nil then
+              local deps = kube.getPodDependencies(spec.template, desiredObj.metadata.namespace)
+              if deps ~= nil then
+                for _, dep in ipairs(deps) do
+                  table.insert(refs, dep)
+                end
+              end
+            end
+          end
+
+          return refs
+        end

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/customizations.yaml
@@ -229,10 +229,7 @@ spec:
             return refs
           end
 
-          -- Iterate all MPIJob replica types
-          local replicaTypes = {"Launcher", "Worker"}
-          for _, replicaType in ipairs(replicaTypes) do
-            local spec = desiredObj.spec.mpiReplicaSpecs[replicaType]
+          for _, spec in pairs(desiredObj.spec.mpiReplicaSpecs) do
             if spec ~= nil and spec.template ~= nil then
               local deps = kube.getPodDependencies(spec.template, desiredObj.metadata.namespace)
               if deps ~= nil then

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/testdata/interpretdependency-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/testdata/interpretdependency-test.yaml
@@ -1,0 +1,161 @@
+# test case for interpreting dependency of MPIJob
+# case1. MPIJob with multiple dependencies from both Launcher and Worker
+# case2. MPIJob with empty mpiReplicaSpecs
+# case3. MPIJob with default ServiceAccount (should not be included)
+# case4. MPIJob with envFrom for ConfigMap and Secret
+
+name: "MPIJob with multiple dependencies from both Launcher and Worker"
+description: "Test interpreting dependency of MPIJob with multiple dependencies from both replicas"
+desiredObj:
+  apiVersion: kubeflow.org/v2beta1
+  kind: MPIJob
+  metadata:
+    name: mpijob-multi-deps
+    namespace: default
+  spec:
+    mpiReplicaSpecs:
+      Launcher:
+        replicas: 1
+        template:
+          spec:
+            serviceAccountName: mpijob-service-account
+            containers:
+              - image: mpioperator/mpi-pi:latest
+                name: launcher
+                env:
+                  - name: CONFIG_DATA
+                    valueFrom:
+                      configMapKeyRef:
+                        name: mpijob-config
+                        key: config
+                volumeMounts:
+                  - mountPath: "/train"
+                    name: training-data
+            volumes:
+              - name: training-data
+                persistentVolumeClaim:
+                  claimName: training-data-pvc
+      Worker:
+        replicas: 2
+        template:
+          spec:
+            serviceAccountName: mpijob-service-account
+            containers:
+              - image: mpioperator/mpi-pi:latest
+                name: worker
+                env:
+                  - name: SECRET_DATA
+                    valueFrom:
+                      secretKeyRef:
+                        name: mpijob-secret
+                        key: secret
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: ServiceAccount
+      name: mpijob-service-account
+      namespace: default
+    - apiVersion: v1
+      kind: ConfigMap
+      name: mpijob-config
+      namespace: default
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: training-data-pvc
+      namespace: default
+    - apiVersion: v1
+      kind: Secret
+      name: mpijob-secret
+      namespace: default
+
+---
+name: "MPIJob with empty mpiReplicaSpecs"
+description: "Test interpreting dependency of MPIJob when mpiReplicaSpecs is empty"
+desiredObj:
+  apiVersion: kubeflow.org/v2beta1
+  kind: MPIJob
+  metadata:
+    name: mpijob-empty-specs
+    namespace: default
+  spec:
+    mpiReplicaSpecs: {}
+operation: InterpretDependency
+output:
+  dependencies: []
+
+---
+name: "MPIJob with default ServiceAccount (should not be included)"
+description: "Test interpreting dependency of MPIJob with default ServiceAccount"
+desiredObj:
+  apiVersion: kubeflow.org/v2beta1
+  kind: MPIJob
+  metadata:
+    name: mpijob-default-sa
+    namespace: default
+  spec:
+    mpiReplicaSpecs:
+      Launcher:
+        replicas: 1
+        template:
+          spec:
+            serviceAccountName: default
+            containers:
+              - image: mpioperator/mpi-pi:latest
+                name: launcher
+      Worker:
+        replicas: 2
+        template:
+          spec:
+            serviceAccountName: default
+            containers:
+              - image: mpioperator/mpi-pi:latest
+                name: worker
+operation: InterpretDependency
+output:
+  dependencies: []
+
+---
+name: "MPIJob with envFrom for ConfigMap and Secret"
+description: "Test interpreting dependency of MPIJob with envFrom referencing ConfigMap and Secret"
+desiredObj:
+  apiVersion: kubeflow.org/v2beta1
+  kind: MPIJob
+  metadata:
+    name: mpijob-envfrom
+    namespace: default
+  spec:
+    mpiReplicaSpecs:
+      Launcher:
+        replicas: 1
+        template:
+          spec:
+            containers:
+              - image: mpioperator/mpi-pi:latest
+                name: launcher
+                envFrom:
+                  - configMapRef:
+                      name: mpijob-config
+                  - secretRef:
+                      name: mpijob-secret
+      Worker:
+        replicas: 2
+        template:
+          spec:
+            containers:
+              - image: mpioperator/mpi-pi:latest
+                name: worker
+                envFrom:
+                  - configMapRef:
+                      name: mpijob-config
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: ConfigMap
+      name: mpijob-config
+      namespace: default
+    - apiVersion: v1
+      kind: Secret
+      name: mpijob-secret
+      namespace: default


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

MPIJob's resource customization has no dependencyInterpretation, so ConfigMaps, Secrets, ServiceAccounts and PVCs referenced from its pod templates are not propagated with the job. Add one mirroring the TFJob script over spec.mpiReplicaSpecs (Launcher and Worker), with testdata like the existing kinds.

**Which issue(s) this PR fixes**:

Fixes #7720

**Special notes for your reviewer**:

Test cases follow the TFJob interpretdependency-test.yaml conventions and pass in TestThirdPartyCustomizationsFile.

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-controller-manager`: MPIJob dependencies (ConfigMaps, Secrets, ServiceAccounts, PVCs referenced by pod templates) now propagate with the job via the built-in resource interpreter.
```