### PR TITLE
chore(ci): reduce Node.js 20 deprecation warnings in workflows

### DIFF
--- a/.github/workflows/ci-image-scanning-on-schedule.yml
+++ b/.github/workflows/ci-image-scanning-on-schedule.yml
@@ -47,7 +47,7 @@ jobs:
           export REGISTRY="docker.io/karmada"
           make image-${{ matrix.target }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.35.0
         env:
           ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
@@ -59,7 +59,7 @@ jobs:
           cache: false
           output: '${{ matrix.target }}:${{ matrix.karmada-version }}.trivy-results.sarif'
       - name: display scan results
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.35.0
         env:
           TRIVY_SKIP_DB_UPDATE: true # Avoid updating the vulnerability db as it was cached in the previous step.
         with:

--- a/.github/workflows/dockerhub-released-chart.yml
+++ b/.github/workflows/dockerhub-released-chart.yml
@@ -15,18 +15,18 @@ jobs:
     if: ${{ github.repository == 'karmada-io/karmada' }}
     steps:
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # fetch-depth:
           # 0 indicates all history for all branches and tags.
           # for `git describe --tags` in Makefile.
           fetch-depth: 0
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
       - name: login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USER_NAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -31,26 +31,26 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # fetch-depth:
           # 0 indicates all history for all branches and tags.
           # for `git describe --tags` in Makefile.
           fetch-depth: 0
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: 'v2.2.3'
       - name: install QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: install Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USER_NAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         path: _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz
     - name: Uploading assets...
       if: ${{ !env.ACT }}
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
       with:
         files: |
           _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz
@@ -89,12 +89,7 @@ jobs:
       run: |
         mv ./charts/karmada/_crds ./charts/karmada/crds
     - name: Tar the crds
-      uses: a7ul/tar-action@v1.2.0
-      with:
-        command: c
-        cwd: ./charts/karmada/
-        files: crds
-        outPath: crds.tar.gz
+      run: tar -czf crds.tar.gz -C ./charts/karmada crds 
     - name: generate crds hash
       id: hash
       run: |
@@ -102,7 +97,7 @@ jobs:
         # base64 -w0 encodes to base64 and outputs on a single line.
         echo "hashes=$(sha256sum crds.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
     - name: Uploading crd assets...
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
       with:
         files: |
           crds.tar.gz
@@ -133,7 +128,7 @@ jobs:
       run: make package-chart
     - name: Uploading assets...
       if: ${{ !env.ACT }}
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
       with:
         files: |
           _output/charts/karmada-chart-${{ github.ref_name }}.tgz
@@ -167,7 +162,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Generate sbom for karmada file system
-      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: 'fs'
         format: 'spdx'
@@ -184,7 +179,7 @@ jobs:
         # base64 -w0 encodes to base64 and outputs on a single line.
         echo "hashes=$(sha256sum sbom.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
     - name: Uploading sbom assets...
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
       with:
         files: |
           sbom.tar.gz


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR reduces dependency on the deprecated Node.js 20 runtime in GitHub Actions workflows, as warned by GitHub. The following changes are made:

- Bump `aquasecurity/trivy-action` from v0.35.0 (commit hash) to v0.36.0 (tag) to remove Node.js 20 usage.
- Bump `softprops/action-gh-release` from v2 to v3.0.1 for the same reason.
- Replace `a7ul/tar-action@v1.2.0` with a direct `tar` command (`tar -czf crds.tar.gz -C ./charts/karmada crds`). The action is no longer maintained and still relies on Node.js 20; the built-in `tar` command is fully equivalent and removes the external dependency.

The `slsa-framework/slsa-github-generator` remains at v2.1.0 because that is currently the latest version and still uses Node.js 20 internally. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/7702

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE

