### PR TITLE
chore(ci): reduce Node.js 20 deprecation warnings in workflows Release1.16

### DIFF
--- a/.github/workflows/dockerhub-released-chart.yml
+++ b/.github/workflows/dockerhub-released-chart.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USER_NAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -46,11 +46,11 @@ jobs:
         with:
           cosign-release: 'v2.2.3'
       - name: install QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: install Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USER_NAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         path: _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz
     - name: Uploading assets...
       if: ${{ !env.ACT }}
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
       with:
         files: |
           _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz
@@ -89,12 +89,7 @@ jobs:
       run: |
         mv ./charts/karmada/_crds ./charts/karmada/crds
     - name: Tar the crds
-      uses: a7ul/tar-action@v1.2.0
-      with:
-        command: c
-        cwd: ./charts/karmada/
-        files: crds
-        outPath: crds.tar.gz
+      run: tar -czf crds.tar.gz -C ./charts/karmada crds #
     - name: generate crds hash
       id: hash
       run: |
@@ -102,7 +97,7 @@ jobs:
         # base64 -w0 encodes to base64 and outputs on a single line.
         echo "hashes=$(sha256sum crds.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
     - name: Uploading crd assets...
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
       with:
         files: |
           crds.tar.gz
@@ -133,7 +128,7 @@ jobs:
       run: make package-chart
     - name: Uploading assets...
       if: ${{ !env.ACT }}
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
       with:
         files: |
           _output/charts/karmada-chart-${{ github.ref_name }}.tgz
@@ -184,7 +179,7 @@ jobs:
         # base64 -w0 encodes to base64 and outputs on a single line.
         echo "hashes=$(sha256sum sbom.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
     - name: Uploading sbom assets...
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
       with:
         files: |
           sbom.tar.gz


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Reduce dependency on the deprecated Node.js 20 runtime in GitHub Actions workflows. The following changes are made:

- Bump `aquasecurity/trivy-action` from `v0.35.0` (commit hash) to `v0.36.0` (tag) to remove Node.js 20 usage.
- Bump `softprops/action-gh-release` from `v2` to `v3.0.0` for the same reason.
- Replace `a7ul/tar-action@v1.2.0` with a direct `tar` command (`tar -czf crds.tar.gz -C ./charts/karmada crds`). The action is no longer maintained and still relies on Node.js 20; the built-in `tar` command is fully equivalent and removes the external dependency.

The `slsa-framework/slsa-github-generator` remains at `v2.1.0` because that is the latest version and still uses Node.js 20 internally. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/7702

**Does this PR introduce a user-facing change?**:
```release-note
NONE