### PR TITLE
fix: handle nil minReplicas in CronFederatedHPA scaling

### DIFF
--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
@@ -145,8 +145,9 @@ func (c *ScalingJob) ScaleFHPA(cronFHPA *autoscalingv1alpha1.CronFederatedHPA) e
 		fhpa.Spec.MaxReplicas = *c.rule.TargetMaxReplicas
 		update = true
 	}
-	if c.rule.TargetMinReplicas != nil && *fhpa.Spec.MinReplicas != *c.rule.TargetMinReplicas {
-		*fhpa.Spec.MinReplicas = *c.rule.TargetMinReplicas
+	if c.rule.TargetMinReplicas != nil && (fhpa.Spec.MinReplicas == nil || *fhpa.Spec.MinReplicas != *c.rule.TargetMinReplicas) {
+		targetMinReplicas := *c.rule.TargetMinReplicas
+		fhpa.Spec.MinReplicas = &targetMinReplicas
 		update = true
 	}
 

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job_test.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job_test.go
@@ -124,6 +124,31 @@ func TestScaleFHPA(t *testing.T) {
 			expectedErr:    false,
 		},
 		{
+			name: "Initialize Nil MinReplicas",
+			cronFHPA: &autoscalingv1alpha1.CronFederatedHPA{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cron-fhpa",
+					Namespace: "default",
+				},
+				Spec: autoscalingv1alpha1.CronFederatedHPASpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						Name: "test-fhpa",
+					},
+				},
+			},
+			existingFHPA: &autoscalingv1alpha1.FederatedHPA{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-fhpa",
+					Namespace: "default",
+				},
+			},
+			rule: autoscalingv1alpha1.CronFederatedHPARule{
+				TargetMinReplicas: new(int32(3)),
+			},
+			expectedUpdate: true,
+			expectedErr:    false,
+		},
+		{
 			name: "No Updates Needed",
 			cronFHPA: &autoscalingv1alpha1.CronFederatedHPA{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind regression

**What this PR does / why we need it**:

Prevents `CronFederatedHPA` from panicking when the target `FederatedHPA` omits `spec.minReplicas`. The controller now initializes `MinReplicas` when a target minimum is provided, and the regression test covers the nil-pointer path.

## Summary
- guard `ScaleFHPA` against a nil `FederatedHPA.Spec.MinReplicas`
- initialize `MinReplicas` from `targetMinReplicas` when needed
- add a regression test for the nil existing pointer case

**Which issue(s) this PR fixes**:
Fixes #7724

## Linked Issue
Fixes #7724

## What Changed
- updated `pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go` to avoid dereferencing a nil `MinReplicas` pointer
- added `Initialize Nil MinReplicas` coverage to `pkg/controllers/cronfederatedhpa/cronfederatedhpa_job_test.go`

## Verification
- `go test ./pkg/controllers/cronfederatedhpa -run TestScaleFHPA -count=1` — passed
- `make verify` — failed: `hack/update-codegen.sh` cleanup could not remove repo-local `_go` toolchain files on darwin because the downloaded toolchain cache was read-only
- `PATH="$(go env GOPATH)/bin:$PATH" make verify` — failed: same `_go` cleanup permission issue after verification steps completed
- `PATH="$(go env GOPATH)/bin:$PATH" GOTOOLCHAIN=local make verify` — failed: local non-auto toolchain is `go1.23.12`, but `go.mod` requires `>= 1.26.4`
- `make test` — passed

**Special notes for your reviewer**:

`make verify` reached and passed the substantive verification stages relevant to this change, including staticcheck, mock verification, gofmt, vendor, swagger docs, command-line flags, and CRD generation checks, before failing in temporary `_go` cleanup. No repository files were left modified by that failure.

## Scope
- only the CronFederatedHPA controller and its focused unit test were changed
- unrelated files were not modified

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: Fixed a CronFederatedHPA panic when the target FederatedHPA omitted `spec.minReplicas`.
```
