### PR TITLE
Fix CronFederatedHPA missing targetReplicas panic

### DIFF
--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
@@ -168,6 +168,10 @@ func (c *ScalingJob) ScaleFHPA(cronFHPA *autoscalingv1alpha1.CronFederatedHPA) e
 func (c *ScalingJob) ScaleWorkloads(cronFHPA *autoscalingv1alpha1.CronFederatedHPA) error {
 	ctx := context.Background()
 
+	if c.rule.TargetReplicas == nil {
+		return fmt.Errorf("targetReplicas cannot be nil if you want to scale %s", cronFHPA.Spec.ScaleTargetRef.Kind)
+	}
+
 	scaleClient := c.client.SubResource("scale")
 
 	targetGV, err := schema.ParseGroupVersion(cronFHPA.Spec.ScaleTargetRef.APIVersion)

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job_test.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job_test.go
@@ -189,6 +189,27 @@ func TestScaleFHPA(t *testing.T) {
 	}
 }
 
+func TestScaleWorkloadsNilTargetReplicas(t *testing.T) {
+	job := &ScalingJob{
+		client: fake.NewClientBuilder().Build(),
+		rule: autoscalingv1alpha1.CronFederatedHPARule{
+			Name: "missing-target-replicas",
+		},
+	}
+
+	cronFHPA := &autoscalingv1alpha1.CronFederatedHPA{
+		Spec: autoscalingv1alpha1.CronFederatedHPASpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind: "Deployment",
+			},
+		},
+	}
+
+	err := job.ScaleWorkloads(cronFHPA)
+
+	assert.EqualError(t, err, "targetReplicas cannot be nil if you want to scale Deployment")
+}
+
 func TestFindExecutionHistory(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

## Summary
- add a defensive nil check in `ScalingJob.ScaleWorkloads()` so invalid direct workload scaling rules return an error instead of panicking
- add a regression test for a missing `targetReplicas` rule

## Linked Issue
Fixes #7726

## What Changed
- return a clear error when direct workload scaling is requested without `targetReplicas`
- cover the nil `TargetReplicas` path in `cronfederatedhpa_job_test.go`

## Verification
- `go test ./pkg/controllers/cronfederatedhpa` — passed
- `make test` — passed
- `make verify` — not run cleanly: the target was executed twice; the first run failed because `golangci-lint` was installed into `~/go/bin` but that path was not on `PATH`, and the rerun progressed further but failed in repository verification cleanup/codegen with existing API-rule output and permission errors removing the generated local `_go` toolchain directory

## Scope
- only the CronFederatedHPA controller and its focused unit test were changed; unrelated files were not modified

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #7726

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->
- `make verify` did not complete successfully in this local environment for reasons described above.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```
