### PR TITLE
ci: update GitHub runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci-image-scanning-on-schedule.yml
+++ b/.github/workflows/ci-image-scanning-on-schedule.yml
@@ -11,7 +11,7 @@ jobs:
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     name: image-scanning
     if: ${{ github.repository == 'karmada-io/karmada' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-image-scanning.yaml
+++ b/.github/workflows/ci-image-scanning.yaml
@@ -13,7 +13,7 @@ jobs:
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     name: image-scanning
     if: ${{ github.repository == 'karmada-io/karmada' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-performance-compare.yaml
+++ b/.github/workflows/ci-performance-compare.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   base-performance-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     steps:
@@ -68,7 +68,7 @@ jobs:
           path: ${{ github.workspace }}/base-metrics/
           
   target-performance-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     steps:
@@ -129,7 +129,7 @@ jobs:
     
   compare-performance:
     needs: [base-performance-test, target-performance-test]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci-schedule-compatibility.yaml
+++ b/.github/workflows/ci-schedule-compatibility.yaml
@@ -12,7 +12,7 @@ jobs:
     name: e2e test
     # prevent job running from forked repository
     if: ${{ github.repository == 'karmada-io/karmada' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       # max-parallel limits the max number of jobs running at the same time.
       # We set it to 5 to avoid too many jobs running at the same time, causing the CI to fail because of resource limitations.

--- a/.github/workflows/ci-schedule.yml
+++ b/.github/workflows/ci-schedule.yml
@@ -12,7 +12,7 @@ jobs:
     name: e2e test
     # prevent job running from forked repository
     if: ${{ github.repository == 'karmada-io/karmada' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       # max-parallel limits the max number of jobs running at the same time.
       # We set it to 5 to avoid too many jobs running at the same time, causing the CI to fail because of resource limitations.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -35,7 +35,7 @@ jobs:
         run: hack/verify-import-aliases.sh
   codegen:
     name: codegen
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -58,7 +58,7 @@ jobs:
   build:
     name: compile
     needs: codegen # rely on codegen successful completion
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -75,7 +75,7 @@ jobs:
   test:
     name: unit test
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       GOTESTSUM_ENABLED: enabled
     steps:
@@ -104,7 +104,7 @@ jobs:
   e2e:
     name: e2e test
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dockerhub-latest-chart.yml
+++ b/.github/workflows/dockerhub-latest-chart.yml
@@ -13,7 +13,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/karmada' && github.ref == 'refs/heads/master' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -28,7 +28,7 @@ jobs:
           - karmada-search
           - karmada-operator
           - karmada-metrics-adapter
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/dockerhub-released-chart.yml
+++ b/.github/workflows/dockerhub-released-chart.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   publish-chart-to-dockerhub:
     name: publish to DockerHub
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # prevent job running from forked repository, otherwise
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -28,7 +28,7 @@ jobs:
           - karmada-search
           - karmada-operator
           - karmada-metrics-adapter
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -16,7 +16,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/karmada' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/installation-chart.yaml
+++ b/.github/workflows/installation-chart.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   test-on-kubernetes-matrix:
     name: Test on Kubernetes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/installation-cli.yaml
+++ b/.github/workflows/installation-cli.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   test-on-kubernetes-matrix:
     name: Test on Kubernetes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/installation-operator.yaml
+++ b/.github/workflows/installation-operator.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   test-on-kubernetes-matrix:
     name: Test on Kubernetes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write  # for softprops/action-gh-release to create GitHub release
     name: release kubectl-karmada
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         target:
@@ -47,7 +47,7 @@ jobs:
           _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz.sha256
   generate-subject-for-cli-provenance:
     needs: [release-assests]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:
@@ -82,7 +82,7 @@ jobs:
     name: release crds
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Rename the crds directory
@@ -124,7 +124,7 @@ jobs:
     name: Release charts
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Making helm charts
@@ -163,7 +163,7 @@ jobs:
     name: Release sbom
     outputs:
       hashes: ${{ steps.sbom-hash.outputs.hashes}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Generate sbom for karmada file system
@@ -211,7 +211,7 @@ jobs:
     # 2. running on the forked repository would open a PR to publish an inaccurate version of karmada in repo kubernetes-sigs/krew-index.
     if: ${{ github.repository == 'karmada-io/karmada' }}
     name: Update krew-index
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: get latest tag
       id: get-latest-tag

--- a/.github/workflows/swr-latest-image.yml
+++ b/.github/workflows/swr-latest-image.yml
@@ -12,7 +12,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/karmada' && github.ref == 'refs/heads/master' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/swr-released-image.yml
+++ b/.github/workflows/swr-released-image.yml
@@ -12,7 +12,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/karmada' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/update-helm-index.yml
+++ b/.github/workflows/update-helm-index.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   get-helm-versions:
     name: Get Helm Versions
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     outputs:
       versions: ${{ steps.get-versions.outputs.versions }}
@@ -52,7 +52,7 @@ jobs:
       pull-requests: write
     needs: get-helm-versions
     if: needs.get-helm-versions.outputs.should_run == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}
       VERSIONS: ${{ needs.get-helm-versions.outputs.versions }}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR updates GitHub-hosted Ubuntu runners from `ubuntu-22.04` to `ubuntu-24.04` across the workflow files under `.github/workflows`.

GitHub Actions runner-images has announced that `ubuntu-22.04` will begin deprecation on September 17, 2026 and become fully unsupported on April 17, 2027:

https://github.com/actions/runner-images/issues/14254

`ubuntu-24.04` is the current GA Ubuntu runner image, while `ubuntu-26.04` is still in preview. This keeps Karmada on a fixed Ubuntu runner label instead of switching to `ubuntu-latest`, so workflow environments remain explicit and predictable.

This follows the same repository-wide runner image update pattern as #3699.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

Changed files:

- Updated all `runs-on: ubuntu-22.04` labels under `.github/workflows` to `runs-on: ubuntu-24.04`.
- No workflow logic, job matrix, action version, script, or test command was changed.

Validation:

- `git grep -n "ubuntu-22.04" HEAD -- .github/workflows || true`
- `git diff --check upstream/master...HEAD`
- Parsed all `.github/workflows/*.yml` and `.github/workflows/*.yaml` with Python `yaml.safe_load`

Fork push CI on `ranxi2001/karmada:chore/update-github-runner-ubuntu-24`, implementation commit `0f62fd62b05802961447601da9000403139b600d`:

- `CI Workflow`: passed, including lint, codegen, compile, unit test, and e2e tests on Kubernetes v1.34.0, v1.35.0, and v1.36.1
- `Chart`: passed on Kubernetes v1.34.0, v1.35.0, and v1.36.1
- `CLI`: passed on Kubernetes v1.34.0, v1.35.0, and v1.36.1
- `Operator`: passed on Kubernetes v1.34.0, v1.35.0, and v1.36.1
- `FOSSA`: skipped by workflow condition
- `image-scanning`: skipped by workflow condition

The latest PR head `de3b6be675bbf8ad12f91052f7d0fb53c5b592a5` is a signed-off empty commit used only to retrigger pull request CI after an isolated e2e failure; it does not change the diff.

This PR was prepared with AI assistance.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
