### PR TITLE
fix: stop service export bootstrap poll on shutdown

### DIFF
--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -179,6 +179,7 @@ func (c *ServiceExportController) enqueueReportedEpsServiceExport() {
 	workList := &workv1alpha1.WorkList{}
 	ctx := c.Context
 	if ctx == nil {
+		klog.Warning("ServiceExportController.Context is nil, falling back to context.Background() which may cause goroutine leaks on shutdown")
 		ctx = context.Background()
 	}
 

--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -177,7 +177,12 @@ func (c *ServiceExportController) RunWorkQueue() {
 
 func (c *ServiceExportController) enqueueReportedEpsServiceExport() {
 	workList := &workv1alpha1.WorkList{}
-	err := wait.PollUntilContextCancel(context.TODO(), 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
+	ctx := c.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		err = c.List(ctx, workList, client.MatchingFields{
 			indexregistry.WorkIndexByFieldSuspendDispatching: "true",
 		})

--- a/pkg/controllers/mcs/service_export_controller_test.go
+++ b/pkg/controllers/mcs/service_export_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -190,6 +191,31 @@ func TestCleanEndpointSliceWork(t *testing.T) {
 			err := cleanEndpointSliceWork(ctx, c, work)
 			tt.verify(t, c, work, err)
 		})
+	}
+}
+
+func TestEnqueueReportedEpsServiceExportStopsOnControllerShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	controller := &ServiceExportController{
+		Client: &mockErrorClient{
+			Client:    fake.NewClientBuilder().WithScheme(newTestScheme()).Build(),
+			listError: fmt.Errorf("transient list failure"),
+		},
+		Context: ctx,
+	}
+
+	doneCh := make(chan struct{})
+	go func() {
+		controller.enqueueReportedEpsServiceExport()
+		close(doneCh)
+	}()
+
+	cancel()
+
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("enqueueReportedEpsServiceExport did not stop after controller context cancellation")
 	}
 }
 

--- a/pkg/controllers/mcs/service_export_controller_test.go
+++ b/pkg/controllers/mcs/service_export_controller_test.go
@@ -59,6 +59,7 @@ type mockErrorClient struct {
 	client.Client
 	getError    error
 	listError   error
+	listFunc    func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
 	deleteError error
 	updateError error
 }
@@ -71,6 +72,9 @@ func (e *mockErrorClient) Get(ctx context.Context, key types.NamespacedName, obj
 }
 
 func (e *mockErrorClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if e.listFunc != nil {
+		return e.listFunc(ctx, list, opts...)
+	}
 	if e.listError != nil {
 		return e.listError
 	}
@@ -216,6 +220,34 @@ func TestEnqueueReportedEpsServiceExportStopsOnControllerShutdown(t *testing.T) 
 	case <-doneCh:
 	case <-time.After(2 * time.Second):
 		t.Fatal("enqueueReportedEpsServiceExport did not stop after controller context cancellation")
+	}
+}
+
+func TestEnqueueReportedEpsServiceExportWithNilContext(t *testing.T) {
+	controller := &ServiceExportController{
+		Client: &mockErrorClient{
+			Client: fake.NewClientBuilder().WithScheme(newTestScheme()).Build(),
+			listFunc: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				workList, ok := list.(*workv1alpha1.WorkList)
+				if !ok {
+					t.Fatalf("expected WorkList, got %T", list)
+				}
+				workList.Items = nil
+				return nil
+			},
+		},
+	}
+
+	doneCh := make(chan struct{})
+	go func() {
+		controller.enqueueReportedEpsServiceExport()
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("enqueueReportedEpsServiceExport did not finish with nil controller context")
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind regression

**What this PR does / why we need it**:

## Summary
- stop the ServiceExport bootstrap polling loop when the controller context is canceled

## What Changed
- replace the detached `context.TODO()` poll context with `c.Context`, with a background fallback when the controller context is unset
- add a regression test that keeps `List` failing and verifies the bootstrap goroutine exits after controller shutdown

**Which issue(s) this PR fixes**:
Fixes #7729

**Special notes for your reviewer**:

## Verification
- `go test ./pkg/controllers/mcs -run TestEnqueueReportedEpsServiceExportStopsOnControllerShutdown -count=1` — passed
- `go test ./pkg/controllers/mcs -count=1` — passed
- `make test` — passed
- `make verify` — failed: repo script installed `golangci-lint` outside `PATH`
- `PATH="$HOME/go/bin:$PATH" make verify` — failed: verification reached codegen cleanup, then hit permission-denied errors removing the local `_go` toolchain cache created in this environment

## Scope
- unrelated repository files were not changed

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: Fixed the ServiceExport startup bootstrap loop so it stops retrying when the controller shuts down.
```
