### PR TITLE
test(e2e): wait for FlinkDeployment CRD cleanup

### DIFF
--- a/test/e2e/framework/customresourcedefine.go
+++ b/test/e2e/framework/customresourcedefine.go
@@ -118,6 +118,22 @@ func WaitCRDDisappearedOnClusters(clusters []string, crdName string) {
 	})
 }
 
+// WaitCRDDisappearedFromClusterStatus waits until the APIEnablements collected from member clusters
+// no longer report the specified CRD as enabled.
+func WaitCRDDisappearedFromClusterStatus(client karmada.Interface, clusters []string, crdAPIVersion, crdKind string) {
+	ginkgo.By(fmt.Sprintf("Check if crd(%s/%s) disappeared from cluster APIEnablements", crdAPIVersion, crdKind), func() {
+		gvk := schema.FromAPIVersionAndKind(crdAPIVersion, crdKind)
+		for _, clusterName := range clusters {
+			klog.Infof("Waiting for crd(%s/%s) disappeared from cluster(%s) APIEnablements", crdAPIVersion, crdKind, clusterName)
+			gomega.Eventually(func(g gomega.Gomega) (bool, error) {
+				cluster, err := FetchCluster(client, clusterName)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				return cluster.APIEnablement(gvk) != clusterv1alpha1.APIEnabled, nil
+			}, PollTimeout, PollInterval).Should(gomega.Equal(true))
+		}
+	})
+}
+
 // WaitCRDFitWith wait crd fit with util timeout
 func WaitCRDFitWith(client dynamic.Interface, crdName string, fit func(crd *apiextensionsv1.CustomResourceDefinition) bool) {
 	gomega.Eventually(func() bool {

--- a/test/e2e/suites/base/estimator_test.go
+++ b/test/e2e/suites/base/estimator_test.go
@@ -217,6 +217,9 @@ var _ = framework.SerialDescribe("[EstimatorAssumption] ResourceQuota plugin ass
 			ginkgo.DeferCleanup(func() {
 				framework.RemoveCRD(dynamicClient, flinkCRD.Name)
 				framework.WaitCRDDisappeared(dynamicClient, flinkCRD.Name)
+				framework.WaitCRDDisappearedOnClusters([]string{targetCluster}, flinkCRD.Name)
+				framework.WaitCRDDisappearedFromClusterStatus(karmadaClient, []string{targetCluster},
+					fmt.Sprintf("%s/%s", flinkCRD.Spec.Group, "v1beta1"), flinkCRD.Spec.Names.Kind)
 			})
 		})
 
@@ -390,6 +393,9 @@ var _ = framework.SerialDescribe("[EstimatorAssumption] NodeResource plugin assu
 			ginkgo.DeferCleanup(func() {
 				framework.RemoveCRD(dynamicClient, flinkCRD.Name)
 				framework.WaitCRDDisappeared(dynamicClient, flinkCRD.Name)
+				framework.WaitCRDDisappearedOnClusters([]string{targetCluster}, flinkCRD.Name)
+				framework.WaitCRDDisappearedFromClusterStatus(karmadaClient, []string{targetCluster},
+					fmt.Sprintf("%s/%s", flinkCRD.Spec.Group, "v1beta1"), flinkCRD.Spec.Names.Kind)
 			})
 		})
 	})

--- a/test/e2e/suites/base/federatedresourcequota_test.go
+++ b/test/e2e/suites/base/federatedresourcequota_test.go
@@ -534,6 +534,9 @@ var _ = framework.SerialDescribe("Multi-Components: FederatedResourceQuota enfor
 				ginkgo.DeferCleanup(func() {
 					framework.RemoveCRD(dynamicClient, flinkDeploymentCRD.Name)
 					framework.WaitCRDDisappeared(dynamicClient, flinkDeploymentCRD.Name)
+					framework.WaitCRDDisappearedOnClusters(framework.ClusterNames(), flinkDeploymentCRD.Name)
+					framework.WaitCRDDisappearedFromClusterStatus(karmadaClient, framework.ClusterNames(),
+						fmt.Sprintf("%s/%s", flinkDeploymentCRD.Spec.Group, "v1beta1"), flinkDeploymentCRD.Spec.Names.Kind)
 				})
 			})
 

--- a/test/e2e/suites/base/schedule_multi_template_test.go
+++ b/test/e2e/suites/base/schedule_multi_template_test.go
@@ -95,6 +95,9 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 				ginkgo.DeferCleanup(func() {
 					framework.RemoveCRD(dynamicClient, flinkDeploymentCRD.Name)
 					framework.WaitCRDDisappeared(dynamicClient, flinkDeploymentCRD.Name)
+					framework.WaitCRDDisappearedOnClusters(framework.ClusterNames(), flinkDeploymentCRD.Name)
+					framework.WaitCRDDisappearedFromClusterStatus(karmadaClient, framework.ClusterNames(),
+						fmt.Sprintf("%s/%s", flinkDeploymentCRD.Spec.Group, "v1beta1"), flinkDeploymentCRD.Spec.Names.Kind)
 				})
 			})
 		})


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

This PR tightens the cleanup boundary for e2e cases that create and delete the shared FlinkDeployment CRD `flinkdeployments.flink.apache.org`.

The previous cleanup waited for the CRD to disappear from the Karmada control plane, but member-cluster CRD deletion and `Cluster.Status.APIEnablements` collection are asynchronous. A later FlinkDeployment e2e case can therefore observe stale APIEnablements, continue before the freshly propagated CRD is really ready, and then time out while waiting for the FlinkDeployment `ResourceBinding`.

This PR adds a small e2e helper that waits until the target clusters no longer report the FlinkDeployment GVK as enabled in `Cluster.Status.APIEnablements`, and uses it together with the existing member-cluster CRD disappearance wait in all FlinkDeployment CRD cleanup paths.

**Which issue(s) this PR fixes**:

Fixes #7719

**Special notes for your reviewer**:

Scope:

- e2e test cleanup only.
- No scheduler, estimator, API, controller, or production behavior changes.

Validation:

- `git diff --check`
- `go test ./test/e2e/framework ./test/e2e/suites/base -run '^$' -count=0`
- Fork push CI for `ranxi2001:test/flinkdeployment-crd-cleanup` at commit `1240559dd34cc0eedd0ec6cffe97b5c0076660dc`:
  - Chart: https://github.com/ranxi2001/karmada/actions/runs/29006012662 (passed)
  - CLI: https://github.com/ranxi2001/karmada/actions/runs/29006012583 (passed)
  - Operator: https://github.com/ranxi2001/karmada/actions/runs/29006012840 (passed)
  - CI Workflow: https://github.com/ranxi2001/karmada/actions/runs/29006012630 (passed)

The first CI Workflow attempt passed lint, codegen, compile, unit test, and e2e v1.35/v1.36. It failed only in e2e v1.34 after the test environment hit `etcdserver: request timed out` and repeated Karmada/member API `connection refused` errors. The failed v1.34 job was rerun and passed in attempt 2, so the final fork push CI result is green.

Related evidence is tracked in #7719, including the #7697 PR CI failure and the #7728 post-merge master push failure.

AI assistance: I used Codex to inspect the failed CI logs, compare the existing e2e cleanup helpers, and prepare this PR text. I reviewed and validated the final code changes.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
