### PR TITLE
fix: close response body on early returns in aggregated request handler

### DIFF
--- a/pkg/registry/cluster/storage/aggregate.go
+++ b/pkg/registry/cluster/storage/aggregate.go
@@ -257,6 +257,7 @@ func requestWithoutResourceNameHandlerFunc(
 					klog.Errorf("failed to do request for cluster %s: %v", cluster.Name, err)
 					return
 				}
+				defer resp.Body.Close()
 				if resp.StatusCode != http.StatusOK {
 					klog.Warningf("get resource not ok with cluster %s: %d", cluster.Name, resp.StatusCode)
 					return
@@ -273,7 +274,6 @@ func requestWithoutResourceNameHandlerFunc(
 					responseHeader: resp.Header,
 				})
 				locker.Unlock()
-				_ = resp.Body.Close()
 			}(&cluster)
 		}
 		wg.Wait()


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

The per-cluster goroutine in `requestWithoutResourceNameHandlerFunc` only closes `resp.Body` on the full success path. A non-200 status or a body read error returns early and leaks the connection, once per unhealthy member cluster per aggregated request.

## Which issue(s) this PR fixes

None (self-found)

## Special notes for your reviewer

None.

## Does this PR introduce a user-facing change?

No.