### PR TITLE
Fix operator endpoint discovery on empty node addresses

### DIFF
--- a/operator/pkg/util/endpoint.go
+++ b/operator/pkg/util/endpoint.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/url"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
@@ -63,10 +64,27 @@ func GetAPIServiceIP(clientset clientset.Interface) (string, error) {
 		ls := labels.Set(node.GetLabels())
 
 		if masterLabel.AsSelector().Matches(ls) || controlplaneLabel.AsSelector().Matches(ls) {
-			if ip := netutils.ParseIPSloppy(node.Status.Addresses[0].Address); ip != nil {
-				return ip.String(), nil
+			if ip := getValidNodeAddress(node.Status.Addresses); ip != "" {
+				return ip, nil
 			}
 		}
 	}
-	return nodes.Items[0].Status.Addresses[0].Address, nil
+
+	for _, node := range nodes.Items {
+		if ip := getValidNodeAddress(node.Status.Addresses); ip != "" {
+			return ip, nil
+		}
+	}
+
+	return "", fmt.Errorf("there are no nodes with valid addresses in cluster")
+}
+
+func getValidNodeAddress(addresses []corev1.NodeAddress) string {
+	for _, address := range addresses {
+		if ip := netutils.ParseIPSloppy(address.Address); ip != nil {
+			return ip.String()
+		}
+	}
+
+	return ""
 }

--- a/operator/pkg/util/endpoint_test.go
+++ b/operator/pkg/util/endpoint_test.go
@@ -66,22 +66,13 @@ func TestGetControlPlaneEndpoint(t *testing.T) {
 	}
 }
 
-func TestGetAPIServiceIP(t *testing.T) {
+func TestGetAPIServiceIPSuccess(t *testing.T) {
 	tests := []struct {
 		name             string
 		client           clientset.Interface
 		prep             func(clientset.Interface) error
 		wantAPIServiceIP string
-		wantErr          bool
-		errMsg           string
 	}{
-		{
-			name:    "GetAPIServiceIP_WithNoNodesInTheCluster_FailedToGetAPIServiceIP",
-			client:  fakeclientset.NewClientset(),
-			prep:    func(clientset.Interface) error { return nil },
-			wantErr: true,
-			errMsg:  "there are no nodes in cluster",
-		},
 		{
 			name:   "GetAPIServiceIP_WithoutMasterNode_WorkerNodeAPIServiceIPReturned",
 			client: fakeclientset.NewClientset(),
@@ -109,7 +100,6 @@ func TestGetAPIServiceIP(t *testing.T) {
 				}
 				return nil
 			},
-			wantErr:          false,
 			wantAPIServiceIP: "192.168.1.2",
 		},
 		{
@@ -155,8 +145,44 @@ func TestGetAPIServiceIP(t *testing.T) {
 				}
 				return nil
 			},
-			wantErr:          false,
 			wantAPIServiceIP: "192.168.1.1",
+		},
+		{
+			name:   "GetAPIServiceIP_WithControlPlaneNodeWithoutAddresses_WorkerNodeAPIServiceIPReturned",
+			client: fakeclientset.NewClientset(),
+			prep: func(client clientset.Interface) error {
+				nodes := []*corev1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+							Labels: map[string]string{
+								"node-role.kubernetes.io/control-plane": "",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-2",
+						},
+						Status: corev1.NodeStatus{
+							Addresses: []corev1.NodeAddress{
+								{
+									Type:    corev1.NodeInternalIP,
+									Address: "192.168.1.2",
+								},
+							},
+						},
+					},
+				}
+				for _, node := range nodes {
+					_, err := client.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+					if err != nil {
+						return fmt.Errorf("failed to create node %s: %v", node.Name, err)
+					}
+				}
+				return nil
+			},
+			wantAPIServiceIP: "192.168.1.2",
 		},
 	}
 	for _, test := range tests {
@@ -165,17 +191,70 @@ func TestGetAPIServiceIP(t *testing.T) {
 				t.Errorf("failed to prep before getting API service IP: %v", err)
 			}
 			apiServiceIP, err := GetAPIServiceIP(test.client)
-			if err == nil && test.wantErr {
-				t.Errorf("expected an error, but got none")
-			}
-			if err != nil && !test.wantErr {
+			if err != nil {
 				t.Errorf("unexpected error, got: %v", err)
-			}
-			if err != nil && test.wantErr && !strings.Contains(err.Error(), test.errMsg) {
-				t.Errorf("expected error message %s to be in %s", test.errMsg, err.Error())
 			}
 			if apiServiceIP != test.wantAPIServiceIP {
 				t.Errorf("expected API service IP %s, but got %s", test.wantAPIServiceIP, apiServiceIP)
+			}
+		})
+	}
+}
+
+func TestGetAPIServiceIPErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		client clientset.Interface
+		prep   func(clientset.Interface) error
+		errMsg string
+	}{
+		{
+			name:   "GetAPIServiceIP_WithNoNodesInTheCluster_FailedToGetAPIServiceIP",
+			client: fakeclientset.NewClientset(),
+			prep:   func(clientset.Interface) error { return nil },
+			errMsg: "there are no nodes in cluster",
+		},
+		{
+			name:   "GetAPIServiceIP_WithNodesWithoutAddresses_ReturnsError",
+			client: fakeclientset.NewClientset(),
+			prep: func(client clientset.Interface) error {
+				nodes := []*corev1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+							Labels: map[string]string{
+								"node-role.kubernetes.io/control-plane": "",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-2",
+						},
+					},
+				}
+				for _, node := range nodes {
+					_, err := client.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+					if err != nil {
+						return fmt.Errorf("failed to create node %s: %v", node.Name, err)
+					}
+				}
+				return nil
+			},
+			errMsg: "there are no nodes with valid addresses in cluster",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.prep(test.client); err != nil {
+				t.Errorf("failed to prep before getting API service IP: %v", err)
+			}
+			_, err := GetAPIServiceIP(test.client)
+			if err == nil {
+				t.Fatalf("expected an error, but got none")
+			}
+			if !strings.Contains(err.Error(), test.errMsg) {
+				t.Errorf("expected error message %s to be in %s", test.errMsg, err.Error())
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind regression

**What this PR does / why we need it**:

## Summary
- avoid panics in `operator/pkg/util.GetAPIServiceIP()` when listed nodes have empty `status.addresses`
- skip nodes without a parseable address and return a handled error when no valid node address exists
- add regression coverage for empty-address control-plane and worker-node cases

## Linked Issue
Fixes #7735

## What Changed
- replaced direct `Addresses[0]` indexing with address scanning in `operator/pkg/util/endpoint.go`
- added regression tests for empty-address nodes and split API service IP tests to satisfy repo linting

## Verification
- `go test ./operator/pkg/util -run 'TestGet(APIServiceIP|ControlPlaneEndpoint)'` — passed
- `make verify` — not passed: repo verification scripts assume `golangci-lint` remains on `PATH` after GOPATH changes and also recreate `_go/` toolchain/cache content that fails cleanup in this environment
- `make test` — not completed: started successfully and exercised the repo-wide unit suite, then was manually interrupted after an extended run due execution time constraints in this session

## Scope
- only `operator/pkg/util/endpoint.go` and `operator/pkg/util/endpoint_test.go` were changed for this fix

**Which issue(s) this PR fixes**:
Fixes #7735

**Special notes for your reviewer**:
The local `make verify` failure here was environmental rather than caused by the changed operator package. The focused operator package tests for this fix passed locally.

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-operator`: Fixed a panic in API service endpoint discovery when candidate nodes have empty `status.addresses`.
```
