### PR TITLE
test: add unit test for DeleteSecret in pkg/util/secret.go

### DIFF
--- a/pkg/util/secret_test.go
+++ b/pkg/util/secret_test.go
@@ -194,6 +194,45 @@ func TestPatchSecret(t *testing.T) {
 	}
 }
 
+func TestDeleteSecret(t *testing.T) {
+	type args struct {
+		client    kubernetes.Interface
+		namespace string
+		name      string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "delete existing secret",
+			args: args{
+				client:    fake.NewClientset(makeSecret("test")),
+				namespace: metav1.NamespaceDefault,
+				name:      "test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "delete non-existent secret",
+			args: args{
+				client:    fake.NewClientset(),
+				namespace: metav1.NamespaceDefault,
+				name:      "test",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := DeleteSecret(tt.args.client, tt.args.namespace, tt.args.name); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteSecret() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func makeSecret(name string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #7737

## What this PR does / why we need it

`pkg/util/secret.go` exposes four exported functions. Three of them (`GetSecret`, `CreateSecret`, `PatchSecret`) are already tested in `pkg/util/secret_test.go`. This PR closes the gap by adding `TestDeleteSecret` for the fourth function.

## Which issue(s) this PR fixes

Fixes #7737

## Test cases added

| Case | Setup | Expected |
|---|---|---|
| delete existing secret | fake client pre-seeded with the secret | no error |
| delete non-existent secret | empty fake client | no error (not-found is swallowed per the function contract) |

## How to test

```bash
go test ./pkg/util/ -run TestDeleteSecret -v
```