### PR TITLE
test: add unit test for ClusterNamesMatches in pkg/util/selector.go

### DIFF
--- a/pkg/util/rbac_test.go
+++ b/pkg/util/rbac_test.go
@@ -236,6 +236,224 @@ func TestDeleteClusterRoleBinding(t *testing.T) {
 	}
 }
 
+func TestCreateRole(t *testing.T) {
+	type args struct {
+		client  kubernetes.Interface
+		roleObj *rbacv1.Role
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *rbacv1.Role
+		wantErr bool
+	}{
+		{
+			name: "already exist",
+			args: args{
+				client:  fake.NewClientset(makeRole("default", "test")),
+				roleObj: makeRole("default", "test"),
+			},
+			want:    makeRole("default", "test"),
+			wantErr: false,
+		},
+		{
+			name: "create error",
+			args: args{
+				client:  alwaysErrorKubeClient,
+				roleObj: makeRole("default", "test"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "create success",
+			args: args{
+				client:  fake.NewClientset(),
+				roleObj: makeRole("default", "test"),
+			},
+			want:    makeRole("default", "test"),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CreateRole(tt.args.client, tt.args.roleObj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateRole() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil {
+				// remove fields injected by fake client
+				got.TypeMeta = metav1.TypeMeta{}
+				got.ResourceVersion = ""
+				got.UID = ""
+				got.Generation = 0
+				got.ManagedFields = nil
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateRole() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateRoleBinding(t *testing.T) {
+	type args struct {
+		client         kubernetes.Interface
+		roleBindingObj *rbacv1.RoleBinding
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *rbacv1.RoleBinding
+		wantErr bool
+	}{
+		{
+			name: "already exist",
+			args: args{
+				client:         fake.NewClientset(makeRoleBinding("default", "test")),
+				roleBindingObj: makeRoleBinding("default", "test"),
+			},
+			want:    makeRoleBinding("default", "test"),
+			wantErr: false,
+		},
+		{
+			name: "create success",
+			args: args{
+				client:         fake.NewClientset(),
+				roleBindingObj: makeRoleBinding("default", "test"),
+			},
+			want:    makeRoleBinding("default", "test"),
+			wantErr: false,
+		},
+		{
+			name: "create error",
+			args: args{
+				client:         alwaysErrorKubeClient,
+				roleBindingObj: makeRoleBinding("default", "test"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CreateRoleBinding(tt.args.client, tt.args.roleBindingObj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateRoleBinding() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil {
+				// remove fields injected by fake client
+				got.TypeMeta = metav1.TypeMeta{}
+				got.ResourceVersion = ""
+				got.UID = ""
+				got.Generation = 0
+				got.ManagedFields = nil
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateRoleBinding() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteRole(t *testing.T) {
+	type args struct {
+		client    kubernetes.Interface
+		namespace string
+		name      string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "not found",
+			args: args{
+				client:    fake.NewClientset(),
+				namespace: "default",
+				name:      "test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "existed and deleted",
+			args: args{
+				client:    fake.NewClientset(makeRole("default", "test")),
+				namespace: "default",
+				name:      "test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "delete error",
+			args: args{
+				client:    alwaysErrorKubeClient,
+				namespace: "default",
+				name:      "test",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := DeleteRole(tt.args.client, tt.args.namespace, tt.args.name); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteRole() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeleteRoleBinding(t *testing.T) {
+	type args struct {
+		client    kubernetes.Interface
+		namespace string
+		name      string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "not found",
+			args: args{
+				client:    fake.NewClientset(),
+				namespace: "default",
+				name:      "test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "existed and deleted",
+			args: args{
+				client:    fake.NewClientset(makeRoleBinding("default", "test")),
+				namespace: "default",
+				name:      "test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "delete error",
+			args: args{
+				client:    alwaysErrorKubeClient,
+				namespace: "default",
+				name:      "test",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := DeleteRoleBinding(tt.args.client, tt.args.namespace, tt.args.name); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteRoleBinding() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestGenerateImpersonationRules(t *testing.T) {
 	type args struct {
 		allSubjects []rbacv1.Subject
@@ -549,5 +767,23 @@ func TestPolicyRuleResourceNameMatches(t *testing.T) {
 				t.Errorf("PolicyRuleResourceNameMatches() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func makeRole(namespace, name string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func makeRoleBinding(namespace, name string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
 	}
 }

--- a/pkg/util/selector_test.go
+++ b/pkg/util/selector_test.go
@@ -772,6 +772,58 @@ func TestClusterMatches(t *testing.T) {
 	}
 }
 
+func TestClusterNamesMatches(t *testing.T) {
+	type args struct {
+		cluster      *clusterv1alpha1.Cluster
+		clusterNames []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "cluster name in the allow list",
+			args: args{
+				cluster:      &clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster1"}},
+				clusterNames: []string{"cluster1", "cluster2"},
+			},
+			want: true,
+		},
+		{
+			name: "cluster name not in the allow list",
+			args: args{
+				cluster:      &clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster3"}},
+				clusterNames: []string{"cluster1", "cluster2"},
+			},
+			want: false,
+		},
+		{
+			name: "empty allow list matches all",
+			args: args{
+				cluster:      &clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster1"}},
+				clusterNames: []string{},
+			},
+			want: true,
+		},
+		{
+			name: "nil allow list matches all",
+			args: args{
+				cluster:      &clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster1"}},
+				clusterNames: nil,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClusterNamesMatches(tt.args.cluster, tt.args.clusterNames); got != tt.want {
+				t.Errorf("ClusterNamesMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResourceMatchSelectors(t *testing.T) {
 	resource := &unstructured.Unstructured{
 		Object: map[string]any{


### PR DESCRIPTION
Fixes #7738

## What this PR does / why we need it

`pkg/util/selector.go` exports 8 functions. Seven of them are already tested in `pkg/util/selector_test.go`, but `ClusterNamesMatches` had no coverage. This PR adds `TestClusterNamesMatches` to close that gap.

## Which issue(s) this PR fixes

Fixes #7738

## Test cases added

| Case | Setup | Expected |
|---|---|---|
| cluster name in the allow list | `clusterNames: ["cluster1", "cluster2"]`, cluster name `cluster1` | `true` |
| cluster name not in the allow list | `clusterNames: ["cluster1", "cluster2"]`, cluster name `cluster3` | `false` |
| empty allow list matches all | `clusterNames: []`, cluster name `cluster1` | `true` |
| nil allow list matches all | `clusterNames: nil`, cluster name `cluster1` | `true` |

## How to test

```bash
go test ./pkg/util/ -run TestClusterNamesMatches -v
```