### PR TITLE
test: add unit tests for CreateRole, CreateRoleBinding, DeleteRole, DeleteRoleBinding

### DIFF
--- a/pkg/util/rbac_test.go
+++ b/pkg/util/rbac_test.go
@@ -236,6 +236,224 @@ func TestDeleteClusterRoleBinding(t *testing.T) {
 	}
 }
 
+func TestCreateRole(t *testing.T) {
+	type args struct {
+		client  kubernetes.Interface
+		roleObj *rbacv1.Role
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *rbacv1.Role
+		wantErr bool
+	}{
+		{
+			name: "already exist",
+			args: args{
+				client:  fake.NewClientset(makeRole("default", "test")),
+				roleObj: makeRole("default", "test"),
+			},
+			want:    makeRole("default", "test"),
+			wantErr: false,
+		},
+		{
+			name: "create error",
+			args: args{
+				client:  alwaysErrorKubeClient,
+				roleObj: makeRole("default", "test"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "create success",
+			args: args{
+				client:  fake.NewClientset(),
+				roleObj: makeRole("default", "test"),
+			},
+			want:    makeRole("default", "test"),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CreateRole(tt.args.client, tt.args.roleObj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateRole() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil {
+				// remove fields injected by fake client
+				got.TypeMeta = metav1.TypeMeta{}
+				got.ResourceVersion = ""
+				got.UID = ""
+				got.Generation = 0
+				got.ManagedFields = nil
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateRole() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateRoleBinding(t *testing.T) {
+	type args struct {
+		client         kubernetes.Interface
+		roleBindingObj *rbacv1.RoleBinding
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *rbacv1.RoleBinding
+		wantErr bool
+	}{
+		{
+			name: "already exist",
+			args: args{
+				client:         fake.NewClientset(makeRoleBinding("default", "test")),
+				roleBindingObj: makeRoleBinding("default", "test"),
+			},
+			want:    makeRoleBinding("default", "test"),
+			wantErr: false,
+		},
+		{
+			name: "create success",
+			args: args{
+				client:         fake.NewClientset(),
+				roleBindingObj: makeRoleBinding("default", "test"),
+			},
+			want:    makeRoleBinding("default", "test"),
+			wantErr: false,
+		},
+		{
+			name: "create error",
+			args: args{
+				client:         alwaysErrorKubeClient,
+				roleBindingObj: makeRoleBinding("default", "test"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CreateRoleBinding(tt.args.client, tt.args.roleBindingObj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateRoleBinding() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil {
+				// remove fields injected by fake client
+				got.TypeMeta = metav1.TypeMeta{}
+				got.ResourceVersion = ""
+				got.UID = ""
+				got.Generation = 0
+				got.ManagedFields = nil
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateRoleBinding() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteRole(t *testing.T) {
+	type args struct {
+		client    kubernetes.Interface
+		namespace string
+		name      string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "not found",
+			args: args{
+				client:    fake.NewClientset(),
+				namespace: "default",
+				name:      "test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "existed and deleted",
+			args: args{
+				client:    fake.NewClientset(makeRole("default", "test")),
+				namespace: "default",
+				name:      "test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "delete error",
+			args: args{
+				client:    alwaysErrorKubeClient,
+				namespace: "default",
+				name:      "test",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := DeleteRole(tt.args.client, tt.args.namespace, tt.args.name); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteRole() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeleteRoleBinding(t *testing.T) {
+	type args struct {
+		client    kubernetes.Interface
+		namespace string
+		name      string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "not found",
+			args: args{
+				client:    fake.NewClientset(),
+				namespace: "default",
+				name:      "test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "existed and deleted",
+			args: args{
+				client:    fake.NewClientset(makeRoleBinding("default", "test")),
+				namespace: "default",
+				name:      "test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "delete error",
+			args: args{
+				client:    alwaysErrorKubeClient,
+				namespace: "default",
+				name:      "test",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := DeleteRoleBinding(tt.args.client, tt.args.namespace, tt.args.name); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteRoleBinding() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestGenerateImpersonationRules(t *testing.T) {
 	type args struct {
 		allSubjects []rbacv1.Subject
@@ -549,5 +767,23 @@ func TestPolicyRuleResourceNameMatches(t *testing.T) {
 				t.Errorf("PolicyRuleResourceNameMatches() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func makeRole(namespace, name string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func makeRoleBinding(namespace, name string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
 	}
 }


### PR DESCRIPTION
Fixes #7739

## What type of PR is this?
/kind test

## What this PR does / why we need it

`pkg/util/rbac.go` exports namespace-scoped RBAC helpers (`CreateRole`, `CreateRoleBinding`, `DeleteRole`, `DeleteRoleBinding`) that had no unit test coverage. The cluster-scoped counterparts (`CreateClusterRole`, `CreateClusterRoleBinding`, `DeleteClusterRole`, `DeleteClusterRoleBinding`) were already covered.

This PR adds table-driven tests for all four missing functions following the same fake-client pattern already established in `pkg/util/rbac_test.go`, including helper functions `makeRole` and `makeRoleBinding`.

## Which issue(s) this PR fixes

Fixes #7739

## Does this PR introduce a user-facing change?

```release-note
NONE
```