### PR TITLE
operator: reject invalid NodePort kubeconfig endpoints

### DIFF
--- a/operator/pkg/tasks/init/upload.go
+++ b/operator/pkg/tasks/init/upload.go
@@ -76,7 +76,10 @@ func runUploadAdminKubeconfig(r workflow.RunData) error {
 		if err != nil {
 			return err
 		}
-		nodePort := getNodePortFromAPIServerService(service)
+		nodePort, err := getNodePortFromAPIServerService(service)
+		if err != nil {
+			return err
+		}
 		endpoint = fmt.Sprintf("https://%s:%d", data.ControlplaneAddress(), nodePort)
 	case corev1.ServiceTypeLoadBalancer:
 		service, err := apiclient.GetService(data.RemoteClient(), util.KarmadaAPIServerName(data.GetName()), data.GetNamespace())
@@ -125,18 +128,22 @@ func runUploadAdminKubeconfig(r workflow.RunData) error {
 	return nil
 }
 
-func getNodePortFromAPIServerService(service *corev1.Service) int32 {
-	var nodePort int32
-	if service.Spec.Type == corev1.ServiceTypeNodePort {
-		for _, port := range service.Spec.Ports {
-			if port.Name != "client" {
-				continue
-			}
-			nodePort = port.NodePort
-		}
+func getNodePortFromAPIServerService(service *corev1.Service) (int32, error) {
+	if service.Spec.Type != corev1.ServiceTypeNodePort {
+		return 0, fmt.Errorf("service (%s/%s) is not a NodePort service", service.Namespace, service.Name)
 	}
 
-	return nodePort
+	for _, port := range service.Spec.Ports {
+		if port.Name != "client" {
+			continue
+		}
+		if port.NodePort == 0 {
+			return 0, fmt.Errorf("service (%s/%s) has no valid client NodePort", service.Namespace, service.Name)
+		}
+		return port.NodePort, nil
+	}
+
+	return 0, fmt.Errorf("service (%s/%s) has no client NodePort", service.Namespace, service.Name)
 }
 
 func getLoadbalancerAddress(ingress []corev1.LoadBalancerIngress) string {

--- a/operator/pkg/tasks/init/upload_test.go
+++ b/operator/pkg/tasks/init/upload_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/clientcmd"
@@ -179,7 +180,7 @@ func TestRunUploadAdminKubeconfig(t *testing.T) {
 				RemoteClientConnector: fakeclientset.NewClientset(),
 				ControlplaneAddr:      controlPlaneAddress,
 			},
-			endpoingExpected: fmt.Sprintf("https://%s:0", controlPlaneAddress),
+			endpoingExpected: fmt.Sprintf("https://%s:32443", controlPlaneAddress),
 			prep: func(rd workflow.RunData) error {
 				// Create a certificate authority to generate the Karmada admin kubeconfig.
 				if err := createCA(rd); err != nil {
@@ -195,6 +196,15 @@ func TestRunUploadAdminKubeconfig(t *testing.T) {
 					return fmt.Errorf("failed to install karmada api server: %v", err)
 				}
 
+				service, err := client.CoreV1().Services(namespace).Get(context.TODO(), apiServerComponentName, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to get karmada api server service: %v", err)
+				}
+				service.Spec.Ports[0].NodePort = 32443
+				if _, err := client.CoreV1().Services(namespace).Update(context.TODO(), service, metav1.UpdateOptions{}); err != nil {
+					return fmt.Errorf("failed to update karmada api server service: %v", err)
+				}
+
 				return nil
 			},
 			verify: func(rd workflow.RunData, endpoint string) error {
@@ -207,27 +217,132 @@ func TestRunUploadAdminKubeconfig(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "WithKarmadaAPIServerNodePortServiceType_MissingClientPort_ReturnsError",
+			runData: &TestInitData{
+				Name:      name,
+				Namespace: namespace,
+				ComponentsUnits: &operatorv1alpha1.KarmadaComponents{
+					KarmadaAPIServer: &operatorv1alpha1.KarmadaAPIServer{
+						ServiceType: corev1.ServiceTypeNodePort,
+					},
+				},
+				RemoteClientConnector: fakeclientset.NewClientset(),
+				ControlplaneAddr:      controlPlaneAddress,
+			},
+			prep: func(rd workflow.RunData) error {
+				if err := createCA(rd); err != nil {
+					return err
+				}
+
+				data := rd.(*TestInitData)
+				service := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      apiServerComponentName,
+						Namespace: namespace,
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeNodePort,
+						Ports: []corev1.ServicePort{
+							{
+								Name:     "metrics",
+								NodePort: 32444,
+							},
+						},
+					},
+				}
+				_, err := data.RemoteClient().CoreV1().Services(namespace).Create(context.TODO(), service, metav1.CreateOptions{})
+				return err
+			},
+			verify: func(rd workflow.RunData, _ string) error {
+				data := rd.(*TestInitData)
+				client := data.RemoteClient().(*fakeclientset.Clientset)
+				return verifySecretNotCreated(client, name, namespace)
+			},
+			wantErr: true,
+			errMsg:  fmt.Sprintf("service (%s/%s) has no client NodePort", namespace, apiServerComponentName),
+		},
+		{
+			name: "WithKarmadaAPIServerNodePortServiceType_ZeroClientNodePort_ReturnsError",
+			runData: &TestInitData{
+				Name:      name,
+				Namespace: namespace,
+				ComponentsUnits: &operatorv1alpha1.KarmadaComponents{
+					KarmadaAPIServer: &operatorv1alpha1.KarmadaAPIServer{
+						ServiceType: corev1.ServiceTypeNodePort,
+					},
+				},
+				RemoteClientConnector: fakeclientset.NewClientset(),
+				ControlplaneAddr:      controlPlaneAddress,
+			},
+			prep: func(rd workflow.RunData) error {
+				if err := createCA(rd); err != nil {
+					return err
+				}
+
+				data := rd.(*TestInitData)
+				service := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      apiServerComponentName,
+						Namespace: namespace,
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeNodePort,
+						Ports: []corev1.ServicePort{
+							{
+								Name:     "client",
+								NodePort: 0,
+							},
+						},
+					},
+				}
+				_, err := data.RemoteClient().CoreV1().Services(namespace).Create(context.TODO(), service, metav1.CreateOptions{})
+				return err
+			},
+			verify: func(rd workflow.RunData, _ string) error {
+				data := rd.(*TestInitData)
+				client := data.RemoteClient().(*fakeclientset.Clientset)
+				return verifySecretNotCreated(client, name, namespace)
+			},
+			wantErr: true,
+			errMsg:  fmt.Sprintf("service (%s/%s) has no valid client NodePort", namespace, apiServerComponentName),
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if err := test.prep(test.runData); err != nil {
-				t.Errorf("failed tp prep uploading admin kubeconfig: %v", err)
-			}
-			err := runUploadAdminKubeconfig(test.runData)
-			if err == nil && test.wantErr {
-				t.Errorf("expected error, but got none")
-			}
-			if err != nil && !test.wantErr {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if err != nil && test.wantErr && !strings.Contains(err.Error(), test.errMsg) {
-				t.Errorf("expected %s error msg to contain %s", err.Error(), test.errMsg)
-			}
-			if err := test.verify(test.runData, test.endpoingExpected); err != nil {
-				t.Errorf("failed to run upload admin kubeconfig task: %v", err)
-			}
+			runUploadAdminKubeconfigTestCase(t, test)
 		})
+	}
+}
+
+func runUploadAdminKubeconfigTestCase(t *testing.T, test struct {
+	name             string
+	runData          workflow.RunData
+	endpoingExpected string
+	prep             func(workflow.RunData) error
+	verify           func(workflow.RunData, string) error
+	wantErr          bool
+	errMsg           string
+}) {
+	t.Helper()
+
+	if err := test.prep(test.runData); err != nil {
+		t.Fatalf("failed tp prep uploading admin kubeconfig: %v", err)
+	}
+
+	err := runUploadAdminKubeconfig(test.runData)
+	switch {
+	case err == nil && test.wantErr:
+		t.Fatal("expected error, but got none")
+	case err != nil && !test.wantErr:
+		t.Fatalf("unexpected error: %v", err)
+	case err != nil && test.wantErr && !strings.Contains(err.Error(), test.errMsg):
+		t.Fatalf("expected %s error msg to contain %s", err.Error(), test.errMsg)
+	}
+
+	if err := test.verify(test.runData, test.endpoingExpected); err != nil {
+		t.Fatalf("failed to run upload admin kubeconfig task: %v", err)
 	}
 }
 
@@ -280,6 +395,19 @@ func verifySecret(client *fakeclientset.Clientset, karmadaInstanceName, namespac
 	}
 
 	return nil
+}
+
+func verifySecretNotCreated(client *fakeclientset.Clientset, karmadaInstanceName, namespace string) error {
+	secretName := util.AdminKarmadaConfigSecretName(karmadaInstanceName)
+	_, err := client.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get %s secret in %s namespace: %v", secretName, namespace, err)
+	}
+
+	return fmt.Errorf("expected %s secret not to be created in %s namespace", secretName, namespace)
 }
 
 // createCA creates a new certificate authority and append it to the cert store.


### PR DESCRIPTION
/kind bug

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

## Summary
- reject NodePort API server Services that do not expose a valid `client` NodePort when generating the admin kubeconfig
- stop writing kubeconfig secrets with unusable `https://<host>:0` endpoints
- add focused tests for valid, missing-client, and zero-NodePort Service definitions

## What Changed
- `runUploadAdminKubeconfig()` now returns an error when the API server Service lacks a usable `client` NodePort
- `getNodePortFromAPIServerService()` now validates service type, port presence, and non-zero NodePort values
- `upload_test.go` now verifies both successful NodePort handling and failing paths that must not create secrets

**Which issue(s) this PR fixes**:
Fixes #7744

**Special notes for your reviewer**:

## Verification
- `go test ./operator/pkg/tasks/init -run TestRunUploadAdminKubeconfig -count=1` — passed
- `make test` — passed
- `export PATH="$(go env GOPATH)/bin:$PATH" && make verify` — failed: repository verify scripts reached `_go/` toolchain cleanup and hit local `Permission denied` errors while removing cached toolchain files in the worktree; staticcheck and earlier verify stages passed before that environment failure

## Scope
- only `operator/pkg/tasks/init/upload.go` and `operator/pkg/tasks/init/upload_test.go` were changed

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
