### PR TITLE
test: add unit tests for BuildRoleBindingSubjects and BuildClusterRoleReference in pkg/util/clusterrole.go

### DIFF
--- a/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo_test.go
+++ b/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -111,7 +112,72 @@ users:
 			},
 			wantErr: false,
 		},
-		// TODO: Update ConfigMap if it exists.
+		{
+			name:    "CreateBootstrapConfigMapIfNotExists_ConfigMapAlreadyExists_ConfigMapUpdated",
+			client: fakeclientset.NewClientset(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bootstrapapi.ConfigMapClusterInfo,
+					Namespace: metav1.NamespacePublic,
+				},
+				Data: map[string]string{
+					bootstrapapi.KubeConfigKey: "stale-kubeconfig-data",
+				},
+			}),
+			cfgFile: filepath.Join(os.TempDir(), "config-update-temp.txt"),
+			prep: func(cfgFile string) error {
+				caKarmadaCert, err := certs.NewCertificateAuthority(certs.KarmadaCertAdmin())
+				if err != nil {
+					return fmt.Errorf("NewCertificateAuthority() returned an error: %v", err)
+				}
+
+				cfg := fmt.Sprintf(
+					`apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: %s
+    server: https://test-cluster:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+kind: Config
+preferences: {}
+users:
+- name: test-user
+  user:
+    client-certificate-data: %s
+    client-key-data: %s
+`,
+					base64.StdEncoding.EncodeToString(caKarmadaCert.CertData()),
+					base64.StdEncoding.EncodeToString(caKarmadaCert.CertData()),
+					base64.StdEncoding.EncodeToString(caKarmadaCert.KeyData()),
+				)
+
+				return os.WriteFile(cfgFile, []byte(cfg), 0600)
+			},
+			cleanup: func(cfgFile string) error {
+				return os.Remove(cfgFile)
+			},
+			verify: func(c kubernetes.Interface) error {
+				configMap, err := c.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(
+					context.TODO(), bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to get configmap %s: %v", bootstrapapi.ConfigMapClusterInfo, err)
+				}
+				kubeconfig, ok := configMap.Data[bootstrapapi.KubeConfigKey]
+				if !ok {
+					return fmt.Errorf("expected key %s in configmap data", bootstrapapi.KubeConfigKey)
+				}
+				if kubeconfig == "stale-kubeconfig-data" {
+					return fmt.Errorf("configmap was not updated: still contains stale data")
+				}
+				return nil
+			},
+			wantErr: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo_test.go
+++ b/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo_test.go
@@ -113,7 +113,7 @@ users:
 			wantErr: false,
 		},
 		{
-			name:    "CreateBootstrapConfigMapIfNotExists_ConfigMapAlreadyExists_ConfigMapUpdated",
+			name: "CreateBootstrapConfigMapIfNotExists_ConfigMapAlreadyExists_ConfigMapUpdated",
 			client: fakeclientset.NewClientset(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapapi.ConfigMapClusterInfo,
@@ -124,58 +124,11 @@ users:
 				},
 			}),
 			cfgFile: filepath.Join(os.TempDir(), "config-update-temp.txt"),
-			prep: func(cfgFile string) error {
-				caKarmadaCert, err := certs.NewCertificateAuthority(certs.KarmadaCertAdmin())
-				if err != nil {
-					return fmt.Errorf("NewCertificateAuthority() returned an error: %v", err)
-				}
-
-				cfg := fmt.Sprintf(
-					`apiVersion: v1
-clusters:
-- cluster:
-    certificate-authority-data: %s
-    server: https://test-cluster:6443
-  name: test-cluster
-contexts:
-- context:
-    cluster: test-cluster
-    user: test-user
-  name: test-context
-current-context: test-context
-kind: Config
-preferences: {}
-users:
-- name: test-user
-  user:
-    client-certificate-data: %s
-    client-key-data: %s
-`,
-					base64.StdEncoding.EncodeToString(caKarmadaCert.CertData()),
-					base64.StdEncoding.EncodeToString(caKarmadaCert.CertData()),
-					base64.StdEncoding.EncodeToString(caKarmadaCert.KeyData()),
-				)
-
-				return os.WriteFile(cfgFile, []byte(cfg), 0600)
-			},
+			prep:    prepConfigFileForUpdate,
 			cleanup: func(cfgFile string) error {
 				return os.Remove(cfgFile)
 			},
-			verify: func(c kubernetes.Interface) error {
-				configMap, err := c.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(
-					context.TODO(), bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
-				if err != nil {
-					return fmt.Errorf("failed to get configmap %s: %v", bootstrapapi.ConfigMapClusterInfo, err)
-				}
-				kubeconfig, ok := configMap.Data[bootstrapapi.KubeConfigKey]
-				if !ok {
-					return fmt.Errorf("expected key %s in configmap data", bootstrapapi.KubeConfigKey)
-				}
-				if kubeconfig == "stale-kubeconfig-data" {
-					return fmt.Errorf("configmap was not updated: still contains stale data")
-				}
-				return nil
-			},
+			verify:  verifyConfigMapUpdated,
 			wantErr: false,
 		},
 	}
@@ -260,6 +213,57 @@ func TestCreateClusterInfoRBACRules(t *testing.T) {
 			}
 		})
 	}
+}
+
+func prepConfigFileForUpdate(cfgFile string) error {
+	caKarmadaCert, err := certs.NewCertificateAuthority(certs.KarmadaCertAdmin())
+	if err != nil {
+		return fmt.Errorf("NewCertificateAuthority() returned an error: %v", err)
+	}
+
+	cfg := fmt.Sprintf(
+		`apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: %s
+    server: https://test-cluster:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+kind: Config
+preferences: {}
+users:
+- name: test-user
+  user:
+    client-certificate-data: %s
+    client-key-data: %s
+`,
+		base64.StdEncoding.EncodeToString(caKarmadaCert.CertData()),
+		base64.StdEncoding.EncodeToString(caKarmadaCert.CertData()),
+		base64.StdEncoding.EncodeToString(caKarmadaCert.KeyData()),
+	)
+
+	return os.WriteFile(cfgFile, []byte(cfg), 0600)
+}
+
+func verifyConfigMapUpdated(c kubernetes.Interface) error {
+	configMap, err := c.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(
+		context.TODO(), bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get configmap %s: %v", bootstrapapi.ConfigMapClusterInfo, err)
+	}
+	kubeconfig, ok := configMap.Data[bootstrapapi.KubeConfigKey]
+	if !ok {
+		return fmt.Errorf("expected key %s in configmap data", bootstrapapi.KubeConfigKey)
+	}
+	if kubeconfig == "stale-kubeconfig-data" {
+		return fmt.Errorf("configmap was not updated: still contains stale data")
+	}
+	return nil
 }
 
 func verifyKubeAdminKubeConfig(client kubernetes.Interface) error {

--- a/pkg/util/clusterrole_test.go
+++ b/pkg/util/clusterrole_test.go
@@ -219,3 +219,55 @@ func makeClusterRoleBinding(name string) *rbacv1.ClusterRoleBinding {
 		},
 	}
 }
+
+func TestBuildRoleBindingSubjects(t *testing.T) {
+	tests := []struct {
+		name               string
+		serviceAccountName string
+		serviceAccountNS   string
+		want               []rbacv1.Subject
+	}{
+		{
+			name:               "returns single ServiceAccount subject",
+			serviceAccountName: "my-sa",
+			serviceAccountNS:   "my-ns",
+			want: []rbacv1.Subject{
+				{Kind: rbacv1.ServiceAccountKind, Name: "my-sa", Namespace: "my-ns"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildRoleBindingSubjects(tt.serviceAccountName, tt.serviceAccountNS)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BuildRoleBindingSubjects() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildClusterRoleReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		roleName string
+		want     rbacv1.RoleRef
+	}{
+		{
+			name:     "returns ClusterRole RoleRef",
+			roleName: "my-role",
+			want: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "my-role",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildClusterRoleReference(tt.roleName)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BuildClusterRoleReference() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds `TestBuildRoleBindingSubjects` and `TestBuildClusterRoleReference` to `pkg/util/clusterrole_test.go`.

These are the only two exported functions in `clusterrole.go` without test coverage (`EnsureClusterRoleExist` and `EnsureClusterRoleBindingExist` are already tested).

Fixes #7749