### PR TITLE
karmadactl: tolerate standard control-plane taints for hostPath etcd

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/node.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/node.go
@@ -30,6 +30,29 @@ import (
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
 )
 
+var defaultEtcdTolerations = []corev1.Toleration{
+	{
+		Key:      "node-role.kubernetes.io/master",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	},
+	{
+		Key:      "node-role.kubernetes.io/master",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoExecute,
+	},
+	{
+		Key:      "node-role.kubernetes.io/control-plane",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	},
+	{
+		Key:      "node-role.kubernetes.io/control-plane",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoExecute,
+	},
+}
+
 func (i *CommandInitOption) getKarmadaAPIServerIP() error {
 	if i.KarmadaAPIServerAdvertiseAddress != "" {
 		i.KarmadaAPIServerIP = append(i.KarmadaAPIServerIP, utils.StringToNetIP(i.KarmadaAPIServerAdvertiseAddress))
@@ -105,6 +128,35 @@ func nodeStatus(nodeConditions []corev1.NodeCondition) bool {
 	return true
 }
 
+func tolerationToleratesTaint(toleration corev1.Toleration, taint corev1.Taint) bool {
+	if toleration.Operator != corev1.TolerationOpExists {
+		return false
+	}
+	if toleration.Key != "" && toleration.Key != taint.Key {
+		return false
+	}
+	if toleration.Effect != "" && toleration.Effect != taint.Effect {
+		return false
+	}
+	return true
+}
+
+func tolerationsTolerateTaints(tolerations []corev1.Toleration, taints []corev1.Taint) bool {
+	for _, taint := range taints {
+		tolerated := false
+		for _, toleration := range tolerations {
+			if tolerationToleratesTaint(toleration, taint) {
+				tolerated = true
+				break
+			}
+		}
+		if !tolerated {
+			return false
+		}
+	}
+	return true
+}
+
 // AddNodeSelectorLabels When EtcdStorageMode is hostPath, and EtcdNodeSelectorLabels is empty.
 // Select a healthy node to add labels, and schedule etcd to that node
 func (i *CommandInitOption) AddNodeSelectorLabels() error {
@@ -116,7 +168,7 @@ func (i *CommandInitOption) AddNodeSelectorLabels() error {
 	var etcdNodeName string
 	var etcdSelectorLabels map[string]string
 	for _, v := range nodes.Items {
-		if v.Spec.Taints != nil {
+		if !tolerationsTolerateTaints(defaultEtcdTolerations, v.Spec.Taints) {
 			continue
 		}
 

--- a/pkg/karmadactl/cmdinit/kubernetes/node_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/node_test.go
@@ -207,7 +207,7 @@ func TestCommandInitOption_AddNodeSelectorLabels(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "there is taint node",
+			name: "there is control-plane tainted node",
 			option: CommandInitOption{
 				KubeClientSet: fake.NewClientset(),
 			},
@@ -215,6 +215,24 @@ func TestCommandInitOption_AddNodeSelectorLabels(t *testing.T) {
 			spec: corev1.NodeSpec{
 				Taints: []corev1.Taint{
 					{
+						Key:    "node-role.kubernetes.io/control-plane",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "there is incompatible tainted node",
+			option: CommandInitOption{
+				KubeClientSet: fake.NewClientset(),
+			},
+			status: corev1.ConditionTrue,
+			spec: corev1.NodeSpec{
+				Taints: []corev1.Taint{
+					{
+						Key:    "dedicated",
+						Value:  "gpu",
 						Effect: corev1.TaintEffectNoSchedule,
 					},
 				},

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
@@ -263,6 +263,7 @@ func (i *CommandInitOption) makeETCDStatefulSet() *appsv1.StatefulSet {
 	}
 
 	if i.EtcdStorageMode == "hostPath" {
+		podSpec.Tolerations = append([]corev1.Toleration{}, defaultEtcdTolerations...)
 		if i.EtcdNodeSelectorLabelsMap != nil {
 			podSpec.NodeSelector = i.EtcdNodeSelectorLabelsMap
 		} else {

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset_test.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package kubernetes
 
-import "testing"
+import (
+	"slices"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 func TestCommandInitIOption_etcdVolume(t *testing.T) {
 	tests := []struct {
@@ -64,6 +69,63 @@ func TestCommandInitIOption_etcdVolume(t *testing.T) {
 			_, got := tt.opt.etcdVolume()
 			if (got == nil) != tt.claimIsNil {
 				t.Error(tt.errorMsg)
+			}
+		})
+	}
+}
+
+func TestCommandInitIOption_makeETCDStatefulSet_HostPathTolerations(t *testing.T) {
+	opt := &CommandInitOption{
+		EtcdStorageMode: etcdStorageModeHostPath,
+		Namespace:       "karmada",
+	}
+	etcd := opt.makeETCDStatefulSet()
+
+	if len(etcd.Spec.Template.Spec.Tolerations) != len(defaultEtcdTolerations) {
+		t.Fatalf("CommandInitOption.makeETCDStatefulSet() tolerations = %d, want %d", len(etcd.Spec.Template.Spec.Tolerations), len(defaultEtcdTolerations))
+	}
+
+	for _, expected := range defaultEtcdTolerations {
+		if !slices.Contains(etcd.Spec.Template.Spec.Tolerations, expected) {
+			t.Fatalf("CommandInitOption.makeETCDStatefulSet() missing toleration %+v", expected)
+		}
+	}
+
+	pvcOpt := &CommandInitOption{
+		EtcdStorageMode:          etcdStorageModePVC,
+		Namespace:                "karmada",
+		EtcdPersistentVolumeSize: "1Gi",
+	}
+	if pvc := pvcOpt.makeETCDStatefulSet(); len(pvc.Spec.Template.Spec.Tolerations) != 0 {
+		t.Fatalf("CommandInitOption.makeETCDStatefulSet() PVC tolerations = %v, want none", pvc.Spec.Template.Spec.Tolerations)
+	}
+}
+
+func TestTolerationsTolerateTaints(t *testing.T) {
+	tests := []struct {
+		name        string
+		taints      []corev1.Taint
+		tolerations []corev1.Toleration
+		want        bool
+	}{
+		{
+			name:        "control-plane taints are tolerated",
+			taints:      []corev1.Taint{{Key: "node-role.kubernetes.io/control-plane", Effect: corev1.TaintEffectNoSchedule}},
+			tolerations: defaultEtcdTolerations,
+			want:        true,
+		},
+		{
+			name:        "mixed custom taints are not tolerated",
+			taints:      []corev1.Taint{{Key: "node-role.kubernetes.io/control-plane", Effect: corev1.TaintEffectNoSchedule}, {Key: "dedicated", Value: "gpu", Effect: corev1.TaintEffectNoSchedule}},
+			tolerations: defaultEtcdTolerations,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tolerationsTolerateTaints(tt.tolerations, tt.taints); got != tt.want {
+				t.Fatalf("tolerationsTolerateTaints() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
/kind bug
/kind regression

**What type of PR is this?**

/kind bug
/kind regression

**What this PR does / why we need it**:

HostPath etcd bootstrap in `karmadactl init` currently rejects any tainted node during automatic node selection. That breaks bootstrap on clusters where only healthy control-plane nodes are available and those nodes carry the standard `master` or `control-plane` taints. This change makes hostPath etcd tolerate those standard taints and only auto-select nodes whose taints are actually tolerated by the generated etcd pod.

## Summary
- allow hostPath etcd auto-selection to keep healthy nodes with standard `master` and `control-plane` taints
- add matching default tolerations to the generated hostPath etcd StatefulSet
- cover tainted-but-usable and tainted-incompatible nodes in unit tests

**Which issue(s) this PR fixes**:
Fixes #7752

**Special notes for your reviewer**:

## What Changed
- `AddNodeSelectorLabels()` now filters nodes by whether all taints are tolerated by the default hostPath etcd tolerations instead of rejecting any taint outright.
- HostPath etcd StatefulSets now include default tolerations for `node-role.kubernetes.io/master` and `node-role.kubernetes.io/control-plane` with `NoSchedule` and `NoExecute` effects.
- Tests now cover standard control-plane taints, incompatible custom taints, and the generated hostPath tolerations.

## Verification
- `go test ./pkg/karmadactl/cmdinit/kubernetes -count=1` — passed
- `make test` — passed
- `make verify` — not run to completion: all verification substeps completed, but the script exits non-zero during cleanup because a generated local `_go` toolchain cache contains read-only files and `rm` fails with `Permission denied`

## Scope
- Changes are limited to the `karmadactl init` hostPath etcd bootstrap path and its unit tests.

**Does this PR introduce a user-facing change?**:
```release-note
`karmadactl init --etcd-storage-mode hostPath` now tolerates standard control-plane taints when auto-selecting a node for local etcd bootstrap.
```
