### PR TITLE
fix: remove unnecessary kube.getResourceQuantity() for memory in FlinkDeployment interpreter

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
@@ -76,7 +76,7 @@ spec:
         end
     componentResource:
       luaScript: |
-        local kube = require("kube")
+
 
         local function isempty(s)
           return s == nil or s == ''
@@ -169,7 +169,7 @@ spec:
             jm_requires.resourceRequest.cpu = jm_cpu
           end
           if jm_memory ~= nil then
-            jm_requires.resourceRequest.memory = kube.getResourceQuantity(jm_memory)
+            jm_requires.resourceRequest.memory = jm_memory
           end
           apply_pod_template(pt_spec, jm_requires)
 
@@ -203,7 +203,7 @@ spec:
             tm_requires.resourceRequest.cpu = tm_cpu
           end
           if tm_memory ~= nil then
-            tm_requires.resourceRequest.memory = kube.getResourceQuantity(tm_memory)
+            tm_requires.resourceRequest.memory = tm_memory
           end
           apply_pod_template(pt_spec, tm_requires)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR removes the unnecessary `kube.getResourceQuantity()` conversion for memory values in the `GetComponents` function of the FlinkDeployment resource interpreter customization.

Currently, memory string values are converted using `kube.getResourceQuantity()`:

```lua
jm_requires.resourceRequest.memory = kube.getResourceQuantity(jm_memory)
tm_requires.resourceRequest.memory = kube.getResourceQuantity(tm_memory)
```

`kube.getResourceQuantity()` converts the memory string (e.g., `"100m"`) into a float (`0.1`) via `resource.MustParse().AsApproximateFloat64()`. While the current Lua-Go-JSON round-trip happens to preserve the value correctly for most cases (since `json.Unmarshal(0.1)` into `resource.Quantity` results in `"100m"`), this intermediate float conversion is:

1. **Unnecessary** — `cpu` is already assigned as a raw string on the same code path (`jm_requires.resourceRequest.cpu = jm_cpu`), so memory should be handled consistently.
2. **Fragile** — relying on float-to-Quantity round-trip correctness adds an unnecessary risk of precision issues.
3. **Confusing** — converting to a float and back makes the code harder to reason about.

The fix simply assigns the memory string directly, matching the existing pattern used for `cpu`:

```lua
jm_requires.resourceRequest.memory = jm_memory
tm_requires.resourceRequest.memory = tm_memory
```

> **Note:** The `replicaResource` section still correctly uses `kube.getResourceQuantity()` for **numeric comparison** purposes only (to determine `math.max`), and then assigns the original string. That usage is correct and is left unchanged.

**Which issue(s) this PR fixes**:

Fixes #7643

**Special notes for your reviewer**:
-This PR mainly improves the readability of the code.
-Issue #7643 — we had previously discussed this issue; please refer to the conversation.

**Does this PR introduce a user-facing change?**:
No
