### PR TITLE
fix: skip only saturated nodes during cluster resource modeling

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -664,7 +664,7 @@ func getAllocatableModelings(cluster *clusterv1alpha1.Cluster, nodes []*corev1.N
 	for _, node := range nodes {
 		nodeAvailable := getNodeAvailable(node.Status.Allocatable.DeepCopy(), nodePodResourcesMap[node.Name])
 		if nodeAvailable == nil {
-			break
+			continue
 		}
 		modelingSummary.AddToResourceSummary(modeling.NewClusterResourceNode(nodeAvailable))
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
In `getAllocatableModelings()`, when a saturated node (no available pod slots) is encountered, the loop uses `break` instead of `continue`. This halts the entire node iteration, silently dropping all subsequent healthy nodes from the cluster resource model.
This PR changes `break` to `continue` so only the saturated node is skipped and all remaining nodes are correctly modeled.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #7757 

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->
- All existing unit tests pass.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
1. `karmada-controller-manager`: Fixed an issue where a saturated node would cause the cluster resource modeling to skip all subsequent healthy nodes, leading to incomplete `AllocatableModelings` and underestimated cluster capacity.

