### PR TITLE
test: add regression test for allocatable modeling after unavailable node 

### DIFF
--- a/pkg/controllers/status/cluster_status_controller_test.go
+++ b/pkg/controllers/status/cluster_status_controller_test.go
@@ -950,6 +950,62 @@ func TestGetAllocatableModelings(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "should continue calculating models after an unavailable node",
+			pods: []*corev1.Pod{
+				{
+					Spec: corev1.PodSpec{
+						NodeName: "node-2",
+						Containers: []corev1.Container{{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    *resource.NewMilliQuantity(10, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(10*1024*1024, resource.BinarySI),
+								},
+							},
+						}},
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				},
+			},
+			nodes: []*corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Status: corev1.NodeStatus{Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewMilliQuantity(4000, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.BinarySI),
+					corev1.ResourcePods:   *resource.NewQuantity(1, resource.DecimalSI),
+				}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}, Status: corev1.NodeStatus{Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewMilliQuantity(4000, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.BinarySI),
+					corev1.ResourcePods:   *resource.NewQuantity(1, resource.DecimalSI),
+				}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-3"}, Status: corev1.NodeStatus{Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewMilliQuantity(4000, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.BinarySI),
+					corev1.ResourcePods:   *resource.NewQuantity(1, resource.DecimalSI),
+				}}},
+			},
+			cluster: &clusterv1alpha1.Cluster{Spec: clusterv1alpha1.ClusterSpec{ResourceModels: []clusterv1alpha1.ResourceModel{
+				{
+					Grade: 0,
+					Ranges: []clusterv1alpha1.ResourceModelRange{
+						{Name: corev1.ResourceCPU, Min: *resource.NewMilliQuantity(0, resource.DecimalSI), Max: *resource.NewQuantity(2, resource.DecimalSI)},
+						{Name: corev1.ResourceMemory, Min: *resource.NewQuantity(0, resource.BinarySI), Max: *resource.NewQuantity(1024*1024*1024, resource.BinarySI)},
+					},
+				},
+				{
+					Grade: 1,
+					Ranges: []clusterv1alpha1.ResourceModelRange{
+						{Name: corev1.ResourceCPU, Min: *resource.NewQuantity(2, resource.DecimalSI), Max: *resource.NewQuantity(16, resource.DecimalSI)},
+						{Name: corev1.ResourceMemory, Min: *resource.NewQuantity(1024*1024*1024, resource.BinarySI), Max: *resource.NewQuantity(64*1024*1024*1024, resource.BinarySI)},
+					},
+				},
+			}}},
+			expect: []clusterv1alpha1.AllocatableModeling{
+				{Grade: 0, Count: 0},
+				{Grade: 1, Count: 2},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug                                                                                                                       
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Adds a regression test for the issue where `getAllocatableModelings` stops processing nodes after encountering a node with no    available pod capacity.

 - The first node has available capacity.
 - The second node has exhausted its allocatable pod capacity, causing `getNodeAvailable` to return `nil`.
 - The third node has available capacity.

The test verifies that both available nodes are included in `AllocatableModelings`. This documents the expected behavior and    
prevents the issue from recurring after the production fix is applied.

**Which issue(s) this PR fixes**:
`Part of #7757 `
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
This PR intentionally contains only the regression testcase; the production fix has be submitted separately.
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
 

