### PR TITLE
multiclusterservice: index cluster event lookups

### DIFF
--- a/pkg/controllers/multiclusterservice/mcs_controller.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller.go
@@ -58,6 +58,11 @@ import (
 // ControllerName is the controller name that will be used when reporting events and metrics.
 const ControllerName = "multiclusterservice-controller"
 
+const (
+	multiClusterServiceClusterIndexKey = "spec.clusterNames"
+	allClustersIndexValue              = "*"
+)
+
 // MCSController is to sync MultiClusterService.
 type MCSController struct {
 	client.Client
@@ -528,6 +533,10 @@ func (c *MCSController) updateMultiClusterServiceStatus(ctx context.Context, mcs
 
 // SetupWithManager creates a controller and register to controller manager.
 func (c *MCSController) SetupWithManager(mgr controllerruntime.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &networkingv1alpha1.MultiClusterService{}, multiClusterServiceClusterIndexKey, multiClusterServiceClusterIndexValues); err != nil {
+		return err
+	}
+
 	mcsPredicateFunc := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			mcs := e.Object.(*networkingv1alpha1.MultiClusterService)
@@ -628,24 +637,48 @@ func (c *MCSController) clusterMapFunc() handler.MapFunc {
 		}
 
 		klog.V(4).InfoS("Begin to sync mcs with cluster", "cluster", clusterName)
-		mcsList := &networkingv1alpha1.MultiClusterServiceList{}
-		if err := c.Client.List(ctx, mcsList, &client.ListOptions{}); err != nil {
-			klog.ErrorS(err, "Failed to list MultiClusterService")
-			return nil
-		}
-
+		requestSet := make(map[types.NamespacedName]struct{})
 		var requests []reconcile.Request
-		for index := range mcsList.Items {
-			if need, err := c.needSyncMultiClusterService(&mcsList.Items[index], clusterName); err != nil || !need {
-				continue
+		for _, indexValue := range []string{clusterName, allClustersIndexValue} {
+			mcsList := &networkingv1alpha1.MultiClusterServiceList{}
+			if err := c.Client.List(ctx, mcsList, client.MatchingFields{multiClusterServiceClusterIndexKey: indexValue}); err != nil {
+				klog.ErrorS(err, "Failed to list indexed MultiClusterServices", "cluster", clusterName, "indexValue", indexValue)
+				return nil
 			}
 
-			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mcsList.Items[index].Namespace,
-				Name: mcsList.Items[index].Name}})
+			for index := range mcsList.Items {
+				namespacedName := types.NamespacedName{Namespace: mcsList.Items[index].Namespace, Name: mcsList.Items[index].Name}
+				if _, exists := requestSet[namespacedName]; exists {
+					continue
+				}
+
+				requestSet[namespacedName] = struct{}{}
+				requests = append(requests, reconcile.Request{NamespacedName: namespacedName})
+			}
 		}
 
 		return requests
 	}
+}
+
+func multiClusterServiceClusterIndexValues(obj client.Object) []string {
+	mcs, ok := obj.(*networkingv1alpha1.MultiClusterService)
+	if !ok || !helper.MultiClusterServiceCrossClusterEnabled(mcs) {
+		return nil
+	}
+
+	indexValues := sets.New[string]()
+	for _, providerCluster := range mcs.Spec.ProviderClusters {
+		indexValues.Insert(providerCluster.Name)
+	}
+	for _, consumerCluster := range mcs.Spec.ConsumerClusters {
+		indexValues.Insert(consumerCluster.Name)
+	}
+	if len(mcs.Spec.ProviderClusters) == 0 || len(mcs.Spec.ConsumerClusters) == 0 {
+		indexValues.Insert(allClustersIndexValue)
+	}
+
+	return sets.List(indexValues)
 }
 
 func (c *MCSController) needSyncMultiClusterService(mcs *networkingv1alpha1.MultiClusterService, clusterName string) (bool, error) {

--- a/pkg/controllers/multiclusterservice/mcs_controller_test.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller_test.go
@@ -964,6 +964,56 @@ func TestNeedSyncMultiClusterService(t *testing.T) {
 	}
 }
 
+func TestMultiClusterServiceClusterIndexValues(t *testing.T) {
+	tests := []struct {
+		name           string
+		object         client.Object
+		expectedValues []string
+	}{
+		{
+			name: "Cross-cluster MCS with provider and consumer clusters",
+			object: &networkingv1alpha1.MultiClusterService{
+				Spec: networkingv1alpha1.MultiClusterServiceSpec{
+					Types:            []networkingv1alpha1.ExposureType{networkingv1alpha1.ExposureType("CrossCluster")},
+					ProviderClusters: []networkingv1alpha1.ClusterSelector{{Name: "cluster1"}},
+					ConsumerClusters: []networkingv1alpha1.ClusterSelector{{Name: "cluster2"}},
+				},
+			},
+			expectedValues: []string{"cluster1", "cluster2"},
+		},
+		{
+			name: "Cross-cluster MCS with all providers",
+			object: &networkingv1alpha1.MultiClusterService{
+				Spec: networkingv1alpha1.MultiClusterServiceSpec{
+					Types:            []networkingv1alpha1.ExposureType{networkingv1alpha1.ExposureType("CrossCluster")},
+					ConsumerClusters: []networkingv1alpha1.ClusterSelector{{Name: "cluster2"}},
+				},
+			},
+			expectedValues: []string{allClustersIndexValue, "cluster2"},
+		},
+		{
+			name: "Non cross-cluster MCS is not indexed",
+			object: &networkingv1alpha1.MultiClusterService{
+				Spec: networkingv1alpha1.MultiClusterServiceSpec{
+					Types: []networkingv1alpha1.ExposureType{networkingv1alpha1.ExposureType("LoadBalancer")},
+				},
+			},
+			expectedValues: nil,
+		},
+		{
+			name:           "Non-MCS object is ignored",
+			object:         &corev1.Pod{},
+			expectedValues: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.expectedValues, multiClusterServiceClusterIndexValues(tt.object))
+		})
+	}
+}
+
 // Helper Functions
 
 // Helper function to create fake Cluster objects based on the MCS spec
@@ -997,7 +1047,11 @@ func setupScheme() *runtime.Scheme {
 // Helper function to create a new MCSController with a fake client
 func newFakeController(objs ...runtime.Object) *MCSController {
 	s := setupScheme()
-	fakeClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(objs...).
+		WithIndex(&networkingv1alpha1.MultiClusterService{}, multiClusterServiceClusterIndexKey, multiClusterServiceClusterIndexValues).
+		Build()
 	return &MCSController{
 		Client:        fakeClient,
 		EventRecorder: record.NewFakeRecorder(100),


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Adds a field index for cross-cluster MultiClusterService membership so cluster events query only relevant MCS objects instead of listing the full MCS set.

**Which issue(s) this PR fixes**:
Fixes #6530

**Special notes for your reviewer**:
`make verify` is currently blocked in this checkout by pre-existing workspace drift: the repo-local `_go` toolchain cache is traversed by `hack/verify-gofmt.sh`, and later verify scripts also detect existing generated/vendor drift unrelated to this controller change.

## Summary
- add a cluster membership index for cross-cluster MultiClusterService objects
- use indexed lookups plus a wildcard bucket for MCS objects that target all clusters
- keep request deduplication local to the cluster event handler

## Linked Issue
Fixes #6530

## What Changed
- register a `MultiClusterService` field index during controller setup
- replace the full-list scan in `clusterMapFunc()` with indexed `MatchingFields` queries
- add unit coverage for the index extractor and update the fake client to use the same index

## Verification
- `go test ./pkg/controllers/multiclusterservice -count=1` — passed
- `go test ./pkg/controllers/multiclusterservice -run TestClusterMapFunc -count=1` — passed
- `go test ./pkg/controllers/multiclusterservice -run TestMultiClusterServiceClusterIndexValues -count=1` — passed
- `go test ./pkg/controllers/multiclusterservice -run TestNeedSyncMultiClusterService -count=1` — not run: covered by the full package test instead
- `make test` — passed
- `make verify` — failed: repo-local `_go` cache is treated as source by `hack/verify-gofmt.sh`, and this checkout also has existing generated/vendor drift unrelated to the MCS change
- `find . -not ( ( -wholename './output' -o -wholename './.git' -o -wholename './_output' -o -wholename './_go' -o -wholename '*/third_party/*' -o -wholename '*/vendor/*' \) -prune \) -name '*.go' | xargs gofmt -d -s` — passed

## Scope
- only `pkg/controllers/multiclusterservice` implementation and tests were changed

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```