### PR TITLE
karmadactl: use os.ReadFile in FileToBytes to avoid partial reads

### DIFF
--- a/pkg/karmadactl/cmdinit/utils/format.go
+++ b/pkg/karmadactl/cmdinit/utils/format.go
@@ -85,25 +85,7 @@ func InternetIP() (net.IP, error) {
 // FileToBytes File Conversion Bytes
 func FileToBytes(path, name string) ([]byte, error) {
 	filename := filepath.Join(path, name)
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	stats, err := file.Stat()
-	if err != nil {
-		return nil, err
-	}
-
-	data := make([]byte, stats.Size())
-
-	_, err = file.Read(data)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return os.ReadFile(filename)
 }
 
 // BytesToFile Bytes Conversion File

--- a/pkg/karmadactl/cmdinit/utils/format_test.go
+++ b/pkg/karmadactl/cmdinit/utils/format_test.go
@@ -167,8 +167,29 @@ func TestFileToBytes(t *testing.T) {
 			want:    []byte("hello, world"),
 			wantErr: false,
 		},
+		{
+			// Regression test: FileToBytes must read the entire file rather than
+			// relying on a single Read call to fill the buffer, since io.Reader
+			// does not guarantee that. A multi-megabyte file exercises this path.
+			name:      "large content is read in full, not truncated",
+			createtmp: true,
+			args: args{
+				path: "a-not-exits-path-" + randString(),
+				name: "a-not-exit-file-" + randString() + ".txt",
+			},
+			wantErr: false,
+		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
+		if tt.name == "large content is read in full, not truncated" {
+			content := make([]byte, 5*1024*1024)
+			for j := range content {
+				content[j] = byte(j % 251)
+			}
+			tt.tempcontent = string(content)
+			tt.want = content
+		}
 		if tt.createtmp {
 			err := os.Mkdir(tt.args.path, 0755)
 			if err != nil {
@@ -193,7 +214,16 @@ func TestFileToBytes(t *testing.T) {
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FileToBytes() = %v, want %v", got, tt.want)
+				if len(got) != len(tt.want) {
+					t.Errorf("FileToBytes() length = %d, want length %d", len(got), len(tt.want))
+					return
+				}
+				for j := range got {
+					if got[j] != tt.want[j] {
+						t.Errorf("FileToBytes() content mismatch at byte %d: got %d, want %d (lengths match at %d, so this is not a truncation)", j, got[j], tt.want[j], len(got))
+						return
+					}
+				}
 			}
 		})
 		if tt.createtmp {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`FileToBytes` in `pkg/karmadactl/cmdinit/utils/format.go` read component `.crt`/`.key` files using a single `file.Read` call and ignored the returned byte count. `io.Reader` doesn't guarantee the buffer is filled in one call, so this could silently produce truncated cert/key data with no error. This PR replaces the manual `Open`/`Stat`/`Read` with `os.ReadFile`, which reads the file reliably and simplifies the function.

**Which issue(s) this PR fixes**:
Fixes #7765

**Special notes for your reviewer**:

Added a regression test that reads back a 5MB file and asserts the exact content, exercising a path that a single small-buffer `Read` call would be more likely to only partially satisfy. `gofmt`, `go vet`, `go build`, the package tests, and the import-aliases check all pass.

**Does this PR introduce a user-facing change?**:

```release-note
`karmadactl`: Fixed the issue that `FileToBytes` could silently return truncated file contents by using `os.ReadFile` instead of a single `file.Read` call.
```
