### PR TITLE
Add schedulingGates support to Karmada operator CRD components

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -1165,6 +1165,24 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
+                          schedulingGates:
+                            description: |-
+                              SchedulingGates to apply to the pods for this component.
+                              SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                              PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                            items:
+                              description: PodSchedulingGate is associated to a Pod
+                                to guard its scheduling.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the scheduling gate.
+                                    Each scheduling gate must have a unique name field.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
                           serverCertSANs:
                             description: ServerCertSANs sets extra Subject Alternative
                               Names for the etcd server signing cert.
@@ -4625,6 +4643,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       serviceAnnotations:
                         additionalProperties:
                           type: string
@@ -7325,6 +7361,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -8475,6 +8529,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -9598,6 +9670,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -10721,6 +10811,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -11852,6 +11960,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -12975,6 +13101,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -14098,6 +14242,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -15267,6 +15429,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -1165,6 +1165,24 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
+                          schedulingGates:
+                            description: |-
+                              SchedulingGates to apply to the pods for this component.
+                              SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                              PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                            items:
+                              description: PodSchedulingGate is associated to a Pod
+                                to guard its scheduling.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the scheduling gate.
+                                    Each scheduling gate must have a unique name field.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
                           serverCertSANs:
                             description: ServerCertSANs sets extra Subject Alternative
                               Names for the etcd server signing cert.
@@ -4625,6 +4643,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       serviceAnnotations:
                         additionalProperties:
                           type: string
@@ -7325,6 +7361,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -8475,6 +8529,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -9598,6 +9670,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -10721,6 +10811,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -11852,6 +11960,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -12975,6 +13101,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -14098,6 +14242,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:
@@ -15267,6 +15429,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates to apply to the pods for this component.
+                          SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+                          PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tolerations:
                         description: Tolerations to apply to the pods for this component.
                         items:

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -699,6 +699,12 @@ type CommonSettings struct {
 	// Affinity to apply to the pods for this component.
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+
+	// SchedulingGates to apply to the pods for this component.
+	// SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+	// This field is only available on Kubernetes v1.26+.
+	// +optional
+	SchedulingGates []corev1.PodSchedulingGate `json:"schedulingGates,omitempty"`
 }
 
 // Image allows to customize the image used for components.

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -702,7 +702,7 @@ type CommonSettings struct {
 
 	// SchedulingGates to apply to the pods for this component.
 	// SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
-	// This field is only available on Kubernetes v1.26+.
+	// PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
 	// +optional
 	SchedulingGates []corev1.PodSchedulingGate `json:"schedulingGates,omitempty"`
 }

--- a/operator/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -111,6 +111,11 @@ func (in *CommonSettings) DeepCopyInto(out *CommonSettings) {
 		*out = new(v1.Affinity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SchedulingGates != nil {
+		in, out := &in.SchedulingGates, &out.SchedulingGates
+		*out = make([]v1.PodSchedulingGate, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/operator/pkg/controlplane/apiserver/apiserver.go
+++ b/operator/pkg/controlplane/apiserver/apiserver.go
@@ -88,7 +88,8 @@ func installKarmadaAPIServer(client clientset.Interface, cfg *operatorv1alpha1.K
 		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithExtraVolumeMounts(cfg.ExtraVolumeMounts).
 		WithExtraVolumes(cfg.ExtraVolumes).WithSidecarContainers(cfg.SidecarContainers).WithResources(cfg.Resources).
-		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(apiserverDeployment)
+		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).
+		WithSchedulingGates(cfg.CommonSettings.SchedulingGates).ForDeployment(apiserverDeployment)
 
 	if apiserverDeployment, err = apiclient.CreateOrUpdateDeployment(client, apiserverDeployment); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", apiserverDeployment.Name, err)
@@ -166,7 +167,8 @@ func installKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operator
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
 		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).
-		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(aggregatedAPIServerDeployment)
+		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).
+		WithSchedulingGates(cfg.CommonSettings.SchedulingGates).ForDeployment(aggregatedAPIServerDeployment)
 
 	if aggregatedAPIServerDeployment, err = apiclient.CreateOrUpdateDeployment(client, aggregatedAPIServerDeployment); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", aggregatedAPIServerDeployment.Name, err)

--- a/operator/pkg/controlplane/controlplane.go
+++ b/operator/pkg/controlplane/controlplane.go
@@ -149,7 +149,8 @@ func getKubeControllerManagerManifest(name, namespace string, cfg *operatorv1alp
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).
 		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithLabels(cfg.Labels).WithExtraArgs(cfg.ExtraArgs).WithResources(cfg.Resources).
-		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(kcm)
+		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).
+		WithSchedulingGates(cfg.CommonSettings.SchedulingGates).ForDeployment(kcm)
 	return kcm, nil
 }
 
@@ -180,7 +181,8 @@ func getKarmadaControllerManagerManifest(name, namespace string, featureGates ma
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
 		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).
-		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(kcm)
+		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).
+		WithSchedulingGates(cfg.CommonSettings.SchedulingGates).ForDeployment(kcm)
 	return kcm, nil
 }
 
@@ -212,7 +214,8 @@ func getKarmadaSchedulerManifest(name, namespace string, featureGates map[string
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
 		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).
-		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(scheduler)
+		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).
+		WithSchedulingGates(cfg.CommonSettings.SchedulingGates).ForDeployment(scheduler)
 	return scheduler, nil
 }
 
@@ -244,7 +247,8 @@ func getKarmadaDeschedulerManifest(name, namespace string, featureGates map[stri
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
 		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).
-		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(descheduler)
+		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).
+		WithSchedulingGates(cfg.CommonSettings.SchedulingGates).ForDeployment(descheduler)
 
 	return descheduler, nil
 }

--- a/operator/pkg/controlplane/etcd/etcd.go
+++ b/operator/pkg/controlplane/etcd/etcd.go
@@ -97,7 +97,7 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
 		WithPriorityClassName(cfg.PriorityClassName).WithResources(cfg.Resources).
-		WithTolerations(cfg.Tolerations).WithAffinity(cfg.Affinity).WithSchedulingGates(cfg.SchedulingGates).
+		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).WithSchedulingGates(cfg.CommonSettings.SchedulingGates).
 		WithVolumeData(cfg.VolumeData).ForStatefulSet(etcdStatefulSet)
 
 	if etcdStatefulSet, err = apiclient.CreateOrUpdateStatefulSet(client, etcdStatefulSet); err != nil {

--- a/operator/pkg/controlplane/etcd/etcd.go
+++ b/operator/pkg/controlplane/etcd/etcd.go
@@ -97,7 +97,8 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
 		WithPriorityClassName(cfg.PriorityClassName).WithResources(cfg.Resources).
-		WithTolerations(cfg.Tolerations).WithAffinity(cfg.Affinity).WithVolumeData(cfg.VolumeData).ForStatefulSet(etcdStatefulSet)
+		WithTolerations(cfg.Tolerations).WithAffinity(cfg.Affinity).WithSchedulingGates(cfg.SchedulingGates).
+		WithVolumeData(cfg.VolumeData).ForStatefulSet(etcdStatefulSet)
 
 	if etcdStatefulSet, err = apiclient.CreateOrUpdateStatefulSet(client, etcdStatefulSet); err != nil {
 		return fmt.Errorf("error when creating Etcd statefulset, err: %w", err)

--- a/operator/pkg/controlplane/metricsadapter/metricsadapter.go
+++ b/operator/pkg/controlplane/metricsadapter/metricsadapter.go
@@ -70,7 +70,8 @@ func installKarmadaMetricAdapter(client clientset.Interface, cfg *operatorv1alph
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
 		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithResources(cfg.Resources).
-		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(metricAdapter)
+		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).
+		WithSchedulingGates(cfg.CommonSettings.SchedulingGates).ForDeployment(metricAdapter)
 
 	if metricAdapter, err = apiclient.CreateOrUpdateDeployment(client, metricAdapter); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", metricAdapter.Name, err)

--- a/operator/pkg/controlplane/search/search.go
+++ b/operator/pkg/controlplane/search/search.go
@@ -76,7 +76,8 @@ func installKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.Karm
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
 		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithResources(cfg.Resources).
-		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(searchDeployment)
+		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).
+		WithSchedulingGates(cfg.CommonSettings.SchedulingGates).ForDeployment(searchDeployment)
 
 	if searchDeployment, err = apiclient.CreateOrUpdateDeployment(client, searchDeployment); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", searchDeployment.Name, err)

--- a/operator/pkg/controlplane/webhook/webhook.go
+++ b/operator/pkg/controlplane/webhook/webhook.go
@@ -71,7 +71,8 @@ func installKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.Kar
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
 		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).
-		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(webhookDeployment)
+		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).
+		WithSchedulingGates(cfg.CommonSettings.SchedulingGates).ForDeployment(webhookDeployment)
 
 	if webhookDeployment, err = apiclient.CreateOrUpdateDeployment(client, webhookDeployment); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", webhookDeployment.Name, err)

--- a/operator/pkg/generated/applyconfigurations/operator/v1alpha1/commonsettings.go
+++ b/operator/pkg/generated/applyconfigurations/operator/v1alpha1/commonsettings.go
@@ -59,6 +59,10 @@ type CommonSettingsApplyConfiguration struct {
 	Tolerations []corev1.TolerationApplyConfiguration `json:"tolerations,omitempty"`
 	// Affinity to apply to the pods for this component.
 	Affinity *corev1.AffinityApplyConfiguration `json:"affinity,omitempty"`
+	// SchedulingGates to apply to the pods for this component.
+	// SchedulingGates can be used to delay Pod scheduling until certain conditions are met.
+	// PodSchedulingGate is GA since Kubernetes v1.30 (earlier versions may require PodSchedulingReadiness).
+	SchedulingGates []v1.PodSchedulingGate `json:"schedulingGates,omitempty"`
 }
 
 // CommonSettingsApplyConfiguration constructs a declarative configuration of the CommonSettings type for use with
@@ -169,5 +173,15 @@ func (b *CommonSettingsApplyConfiguration) WithTolerations(values ...*corev1.Tol
 // If called multiple times, the Affinity field is set to the value of the last call.
 func (b *CommonSettingsApplyConfiguration) WithAffinity(value *corev1.AffinityApplyConfiguration) *CommonSettingsApplyConfiguration {
 	b.Affinity = value
+	return b
+}
+
+// WithSchedulingGates adds the given value to the SchedulingGates field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SchedulingGates field.
+func (b *CommonSettingsApplyConfiguration) WithSchedulingGates(values ...v1.PodSchedulingGate) *CommonSettingsApplyConfiguration {
+	for i := range values {
+		b.SchedulingGates = append(b.SchedulingGates, values[i])
+	}
 	return b
 }

--- a/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadaaggregatedapiserver.go
+++ b/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadaaggregatedapiserver.go
@@ -163,6 +163,16 @@ func (b *KarmadaAggregatedAPIServerApplyConfiguration) WithAffinity(value *corev
 	return b
 }
 
+// WithSchedulingGates adds the given value to the SchedulingGates field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SchedulingGates field.
+func (b *KarmadaAggregatedAPIServerApplyConfiguration) WithSchedulingGates(values ...v1.PodSchedulingGate) *KarmadaAggregatedAPIServerApplyConfiguration {
+	for i := range values {
+		b.CommonSettingsApplyConfiguration.SchedulingGates = append(b.CommonSettingsApplyConfiguration.SchedulingGates, values[i])
+	}
+	return b
+}
+
 // WithExtraArgs puts the entries into the ExtraArgs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the ExtraArgs field,

--- a/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadaapiserver.go
+++ b/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadaapiserver.go
@@ -199,6 +199,16 @@ func (b *KarmadaAPIServerApplyConfiguration) WithAffinity(value *corev1.Affinity
 	return b
 }
 
+// WithSchedulingGates adds the given value to the SchedulingGates field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SchedulingGates field.
+func (b *KarmadaAPIServerApplyConfiguration) WithSchedulingGates(values ...v1.PodSchedulingGate) *KarmadaAPIServerApplyConfiguration {
+	for i := range values {
+		b.CommonSettingsApplyConfiguration.SchedulingGates = append(b.CommonSettingsApplyConfiguration.SchedulingGates, values[i])
+	}
+	return b
+}
+
 // WithServiceSubnet sets the ServiceSubnet field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ServiceSubnet field is set to the value of the last call.

--- a/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadacontrollermanager.go
+++ b/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadacontrollermanager.go
@@ -176,6 +176,16 @@ func (b *KarmadaControllerManagerApplyConfiguration) WithAffinity(value *corev1.
 	return b
 }
 
+// WithSchedulingGates adds the given value to the SchedulingGates field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SchedulingGates field.
+func (b *KarmadaControllerManagerApplyConfiguration) WithSchedulingGates(values ...v1.PodSchedulingGate) *KarmadaControllerManagerApplyConfiguration {
+	for i := range values {
+		b.CommonSettingsApplyConfiguration.SchedulingGates = append(b.CommonSettingsApplyConfiguration.SchedulingGates, values[i])
+	}
+	return b
+}
+
 // WithControllers adds the given value to the Controllers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Controllers field.

--- a/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadadescheduler.go
+++ b/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadadescheduler.go
@@ -157,6 +157,16 @@ func (b *KarmadaDeschedulerApplyConfiguration) WithAffinity(value *corev1.Affini
 	return b
 }
 
+// WithSchedulingGates adds the given value to the SchedulingGates field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SchedulingGates field.
+func (b *KarmadaDeschedulerApplyConfiguration) WithSchedulingGates(values ...v1.PodSchedulingGate) *KarmadaDeschedulerApplyConfiguration {
+	for i := range values {
+		b.CommonSettingsApplyConfiguration.SchedulingGates = append(b.CommonSettingsApplyConfiguration.SchedulingGates, values[i])
+	}
+	return b
+}
+
 // WithExtraArgs puts the entries into the ExtraArgs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the ExtraArgs field,

--- a/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadametricsadapter.go
+++ b/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadametricsadapter.go
@@ -157,6 +157,16 @@ func (b *KarmadaMetricsAdapterApplyConfiguration) WithAffinity(value *corev1.Aff
 	return b
 }
 
+// WithSchedulingGates adds the given value to the SchedulingGates field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SchedulingGates field.
+func (b *KarmadaMetricsAdapterApplyConfiguration) WithSchedulingGates(values ...v1.PodSchedulingGate) *KarmadaMetricsAdapterApplyConfiguration {
+	for i := range values {
+		b.CommonSettingsApplyConfiguration.SchedulingGates = append(b.CommonSettingsApplyConfiguration.SchedulingGates, values[i])
+	}
+	return b
+}
+
 // WithExtraArgs puts the entries into the ExtraArgs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the ExtraArgs field,

--- a/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadascheduler.go
+++ b/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadascheduler.go
@@ -161,6 +161,16 @@ func (b *KarmadaSchedulerApplyConfiguration) WithAffinity(value *corev1.Affinity
 	return b
 }
 
+// WithSchedulingGates adds the given value to the SchedulingGates field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SchedulingGates field.
+func (b *KarmadaSchedulerApplyConfiguration) WithSchedulingGates(values ...v1.PodSchedulingGate) *KarmadaSchedulerApplyConfiguration {
+	for i := range values {
+		b.CommonSettingsApplyConfiguration.SchedulingGates = append(b.CommonSettingsApplyConfiguration.SchedulingGates, values[i])
+	}
+	return b
+}
+
 // WithExtraArgs puts the entries into the ExtraArgs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the ExtraArgs field,

--- a/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadasearch.go
+++ b/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadasearch.go
@@ -157,6 +157,16 @@ func (b *KarmadaSearchApplyConfiguration) WithAffinity(value *corev1.AffinityApp
 	return b
 }
 
+// WithSchedulingGates adds the given value to the SchedulingGates field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SchedulingGates field.
+func (b *KarmadaSearchApplyConfiguration) WithSchedulingGates(values ...v1.PodSchedulingGate) *KarmadaSearchApplyConfiguration {
+	for i := range values {
+		b.CommonSettingsApplyConfiguration.SchedulingGates = append(b.CommonSettingsApplyConfiguration.SchedulingGates, values[i])
+	}
+	return b
+}
+
 // WithExtraArgs puts the entries into the ExtraArgs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the ExtraArgs field,

--- a/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadawebhook.go
+++ b/operator/pkg/generated/applyconfigurations/operator/v1alpha1/karmadawebhook.go
@@ -157,6 +157,16 @@ func (b *KarmadaWebhookApplyConfiguration) WithAffinity(value *corev1.AffinityAp
 	return b
 }
 
+// WithSchedulingGates adds the given value to the SchedulingGates field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SchedulingGates field.
+func (b *KarmadaWebhookApplyConfiguration) WithSchedulingGates(values ...v1.PodSchedulingGate) *KarmadaWebhookApplyConfiguration {
+	for i := range values {
+		b.CommonSettingsApplyConfiguration.SchedulingGates = append(b.CommonSettingsApplyConfiguration.SchedulingGates, values[i])
+	}
+	return b
+}
+
 // WithExtraArgs puts the entries into the ExtraArgs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the ExtraArgs field,

--- a/operator/pkg/generated/applyconfigurations/operator/v1alpha1/kubecontrollermanager.go
+++ b/operator/pkg/generated/applyconfigurations/operator/v1alpha1/kubecontrollermanager.go
@@ -197,6 +197,16 @@ func (b *KubeControllerManagerApplyConfiguration) WithAffinity(value *corev1.Aff
 	return b
 }
 
+// WithSchedulingGates adds the given value to the SchedulingGates field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SchedulingGates field.
+func (b *KubeControllerManagerApplyConfiguration) WithSchedulingGates(values ...v1.PodSchedulingGate) *KubeControllerManagerApplyConfiguration {
+	for i := range values {
+		b.CommonSettingsApplyConfiguration.SchedulingGates = append(b.CommonSettingsApplyConfiguration.SchedulingGates, values[i])
+	}
+	return b
+}
+
 // WithControllers adds the given value to the Controllers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Controllers field.

--- a/operator/pkg/generated/applyconfigurations/operator/v1alpha1/localetcd.go
+++ b/operator/pkg/generated/applyconfigurations/operator/v1alpha1/localetcd.go
@@ -150,6 +150,16 @@ func (b *LocalEtcdApplyConfiguration) WithAffinity(value *corev1.AffinityApplyCo
 	return b
 }
 
+// WithSchedulingGates adds the given value to the SchedulingGates field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SchedulingGates field.
+func (b *LocalEtcdApplyConfiguration) WithSchedulingGates(values ...v1.PodSchedulingGate) *LocalEtcdApplyConfiguration {
+	for i := range values {
+		b.CommonSettingsApplyConfiguration.SchedulingGates = append(b.CommonSettingsApplyConfiguration.SchedulingGates, values[i])
+	}
+	return b
+}
+
 // WithVolumeData sets the VolumeData field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the VolumeData field is set to the value of the last call.

--- a/operator/pkg/util/patcher/pather.go
+++ b/operator/pkg/util/patcher/pather.go
@@ -48,6 +48,7 @@ type Patcher struct {
 	resources         corev1.ResourceRequirements
 	tolerations       []corev1.Toleration
 	affinity          *corev1.Affinity
+	schedulingGates   []corev1.PodSchedulingGate
 }
 
 // NewPatcher returns a patcher.
@@ -127,6 +128,12 @@ func (p *Patcher) WithAffinity(affinity *corev1.Affinity) *Patcher {
 	return p
 }
 
+// WithSchedulingGates sets schedulingGates to the patcher.
+func (p *Patcher) WithSchedulingGates(schedulingGates []corev1.PodSchedulingGate) *Patcher {
+	p.schedulingGates = schedulingGates
+	return p
+}
+
 // ForDeployment patches the deployment manifest.
 func (p *Patcher) ForDeployment(deployment *appsv1.Deployment) {
 	deployment.Labels = labels.Merge(deployment.Labels, p.labels)
@@ -141,6 +148,9 @@ func (p *Patcher) ForDeployment(deployment *appsv1.Deployment) {
 	}
 	if len(p.tolerations) > 0 {
 		deployment.Spec.Template.Spec.Tolerations = p.tolerations
+	}
+	if len(p.schedulingGates) > 0 {
+		deployment.Spec.Template.Spec.SchedulingGates = p.schedulingGates
 	}
 
 	if p.resources.Size() > 0 {
@@ -192,6 +202,9 @@ func (p *Patcher) ForStatefulSet(sts *appsv1.StatefulSet) {
 	}
 	if len(p.tolerations) > 0 {
 		sts.Spec.Template.Spec.Tolerations = p.tolerations
+	}
+	if len(p.schedulingGates) > 0 {
+		sts.Spec.Template.Spec.SchedulingGates = p.schedulingGates
 	}
 
 	if p.volume != nil {

--- a/operator/pkg/util/patcher/pather_test.go
+++ b/operator/pkg/util/patcher/pather_test.go
@@ -255,6 +255,63 @@ func TestPatchForDeployment(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "PatchForDeployment_WithSchedulingGates_Patched",
+			patcher: &Patcher{
+				schedulingGates: []corev1.PodSchedulingGate{
+					{
+						Name: "example.com/scheduling-gate",
+					},
+				},
+			},
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "test",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "nginx:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-deployment",
+					Namespace:   "test",
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels:      map[string]string{},
+							Annotations: map[string]string{},
+						},
+						Spec: corev1.PodSpec{
+							SchedulingGates: []corev1.PodSchedulingGate{
+								{
+									Name: "example.com/scheduling-gate",
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "nginx:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -502,6 +559,64 @@ func TestPatchForStatefulSet(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "PatchForStatefulSet_WithSchedulingGates_Patched",
+			patcher: &Patcher{
+				schedulingGates: []corev1.PodSchedulingGate{
+					{
+						Name: "example.com/scheduling-gate",
+					},
+				},
+			},
+			statefulSet: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-statefulset",
+					Namespace: "test",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "nginx:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-statefulset",
+					Namespace:   "test",
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels:      map[string]string{},
+							Annotations: map[string]string{},
+						},
+						Spec: corev1.PodSpec{
+							SchedulingGates: []corev1.PodSchedulingGate{
+								{
+									Name: "example.com/scheduling-gate",
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "nginx:latest",
 								},
 							},
 						},

--- a/pkg/karmadactl/cmdinit/config/types.go
+++ b/pkg/karmadactl/cmdinit/config/types.go
@@ -272,6 +272,10 @@ type CommonSettings struct {
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty" yaml:"affinity,omitempty"`
 
+	// SchedulingGates defines pod scheduling gates to delay scheduling
+	// +optional
+	SchedulingGates []corev1.PodSchedulingGate `json:"schedulingGates,omitempty" yaml:"schedulingGates,omitempty"`
+
 	// ExtraArgs are additional command line for the Component pods.
 	// An argument name in this list is the flag name as it appears on the command line except without
 	// leading dash(es). Extra arguments will override existing default arguments. Duplicate extra arguments are allowed.


### PR DESCRIPTION
## Description:
Add schedulingGates field to CommonSettings so all Karmada control plane components can configure Pod scheduling gates, enabling users to delay Pod scheduling until specific cluster-level conditions are met.
## Background
PodSchedulingGate (GA since Kubernetes v1.30) allows delaying Pod scheduling until external conditions are satisfied. In resource-constrained environments, users may need to create Pods ahead of time while preventing scheduling until sufficient resources become available. This avoids unnecessary scheduler retries and allows external resource managers to coordinate workload admission.
Currently, the Karmada operator CRD does not accept or propagate schedulingGates configuration to any of its 10 control plane component types (KarmadaAPIServer, KarmadaAggregatedAPIServer, KubeControllerManager, KarmadaControllerManager, KarmadaScheduler, KarmadaDescheduler, KarmadaWebhook, KarmadaSearch, KarmadaMetricsAdapter, LocalEtcd).
## How it works
Users can now specify schedulingGates in the commonSettings of any component in the Karmada CR:
apiVersion: operator.karmada.io/v1alpha1
kind: Karmada
metadata:
  name: karmada
spec:
  components:
    karmadaAPIServer:
      commonSettings:
        schedulingGates:
          - name: "scheduling.karmada.io/prepared"
The Patcher translates these into podSpec.schedulingGates on the generated Deployments/StatefulSets, delaying scheduling until the gate is removed by an external controller.
#7768 