### PR TITLE
operator: avoid nil pointer panic when deployment creation fails

### DIFF
--- a/operator/pkg/controlplane/apiserver/apiserver.go
+++ b/operator/pkg/controlplane/apiserver/apiserver.go
@@ -91,7 +91,7 @@ func installKarmadaAPIServer(client clientset.Interface, cfg *operatorv1alpha1.K
 		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(apiserverDeployment)
 
 	if apiserverDeployment, err = apiclient.CreateOrUpdateDeployment(client, apiserverDeployment); err != nil {
-		return fmt.Errorf("error when creating deployment for %s, err: %w", apiserverDeployment.Name, err)
+		return fmt.Errorf("error when creating deployment for %s, err: %w", util.KarmadaAPIServerName(name), err)
 	}
 
 	ownerRef := *metav1.NewControllerRef(apiserverDeployment, DeploymentGVK)
@@ -169,7 +169,7 @@ func installKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operator
 		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(aggregatedAPIServerDeployment)
 
 	if aggregatedAPIServerDeployment, err = apiclient.CreateOrUpdateDeployment(client, aggregatedAPIServerDeployment); err != nil {
-		return fmt.Errorf("error when creating deployment for %s, err: %w", aggregatedAPIServerDeployment.Name, err)
+		return fmt.Errorf("error when creating deployment for %s, err: %w", util.KarmadaAggregatedAPIServerName(name), err)
 	}
 
 	ownerRef := *metav1.NewControllerRef(aggregatedAPIServerDeployment, DeploymentGVK)

--- a/operator/pkg/controlplane/apiserver/apiserver_test.go
+++ b/operator/pkg/controlplane/apiserver/apiserver_test.go
@@ -19,10 +19,14 @@ package apiserver
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	coretesting "k8s.io/client-go/testing"
 
@@ -96,6 +100,51 @@ func TestEnsureKarmadaAPIServer(t *testing.T) {
 
 	if pdbCount != 1 {
 		t.Errorf("expected 1 PDB action, but got %d", pdbCount)
+	}
+}
+
+// TestEnsureKarmadaAPIServer_CreateDeploymentError verifies that a deployment
+// creation failure (e.g. rejected by the API server due to an invalid spec)
+// is returned as a wrapped error instead of causing a nil pointer panic.
+func TestEnsureKarmadaAPIServer_CreateDeploymentError(t *testing.T) {
+	var replicas int32 = 3
+	image := "karmada-apiserver-image"
+	imagePullPolicy := corev1.PullIfNotPresent
+	annotations := map[string]string{"annotationKey": "annotationValue"}
+	labels := map[string]string{"labelKey": "labelValue"}
+	name := "karmada-apiserver"
+	namespace := "test-namespace"
+	serviceSubnet := "10.96.0.0/12"
+
+	cfg := &operatorv1alpha1.KarmadaComponents{
+		KarmadaAPIServer: &operatorv1alpha1.KarmadaAPIServer{
+			CommonSettings: operatorv1alpha1.CommonSettings{
+				Image:           operatorv1alpha1.Image{ImageTag: image},
+				Replicas:        new(replicas),
+				Annotations:     annotations,
+				Labels:          labels,
+				Resources:       corev1.ResourceRequirements{},
+				ImagePullPolicy: imagePullPolicy,
+			},
+			ServiceSubnet: new(serviceSubnet),
+			ExtraArgs:     map[string]string{"cmd1": "arg1", "cmd2": "arg2"},
+		},
+		Etcd: &operatorv1alpha1.Etcd{
+			Local: &operatorv1alpha1.LocalEtcd{},
+		},
+	}
+
+	fakeClient := fakeclientset.NewClientset()
+	fakeClient.PrependReactor("create", "deployments", func(coretesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInvalid(schema.GroupKind{Group: "apps", Kind: "Deployment"}, util.KarmadaAPIServerName(name), nil)
+	})
+
+	err := EnsureKarmadaAPIServer(fakeClient, cfg, name, namespace, map[string]bool{})
+	if err == nil {
+		t.Fatalf("expected an error, but got nil")
+	}
+	if !strings.Contains(err.Error(), util.KarmadaAPIServerName(name)) {
+		t.Errorf("expected error to reference deployment name %q, got: %v", util.KarmadaAPIServerName(name), err)
 	}
 }
 

--- a/operator/pkg/controlplane/apiserver/apiserver_test.go
+++ b/operator/pkg/controlplane/apiserver/apiserver_test.go
@@ -146,6 +146,9 @@ func TestEnsureKarmadaAPIServer_CreateDeploymentError(t *testing.T) {
 	if !strings.Contains(err.Error(), util.KarmadaAPIServerName(name)) {
 		t.Errorf("expected error to reference deployment name %q, got: %v", util.KarmadaAPIServerName(name), err)
 	}
+	if !apierrors.IsInvalid(err) {
+		t.Errorf("expected the wrapped error to preserve the underlying Invalid error, got: %v", err)
+	}
 }
 
 func TestEnsureKarmadaAggregatedAPIServer(t *testing.T) {

--- a/operator/pkg/controlplane/metricsadapter/metricsadapter.go
+++ b/operator/pkg/controlplane/metricsadapter/metricsadapter.go
@@ -73,7 +73,7 @@ func installKarmadaMetricAdapter(client clientset.Interface, cfg *operatorv1alph
 		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(metricAdapter)
 
 	if metricAdapter, err = apiclient.CreateOrUpdateDeployment(client, metricAdapter); err != nil {
-		return fmt.Errorf("error when creating deployment for %s, err: %w", metricAdapter.Name, err)
+		return fmt.Errorf("error when creating deployment for %s, err: %w", util.KarmadaMetricsAdapterName(name), err)
 	}
 
 	ownerRef := *metav1.NewControllerRef(metricAdapter, apiserver.DeploymentGVK)

--- a/operator/pkg/controlplane/metricsadapter/metricsadapter_test.go
+++ b/operator/pkg/controlplane/metricsadapter/metricsadapter_test.go
@@ -18,16 +18,60 @@ package metricsadapter
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	coretesting "k8s.io/client-go/testing"
 
 	operatorv1alpha1 "github.com/karmada-io/karmada/operator/pkg/apis/operator/v1alpha1"
 	"github.com/karmada-io/karmada/operator/pkg/util"
 )
+
+// TestEnsureKarmadaMetricAdapter_CreateDeploymentError verifies that a deployment
+// creation failure (e.g. rejected by the API server due to an invalid spec)
+// is returned as a wrapped error instead of causing a nil pointer panic.
+func TestEnsureKarmadaMetricAdapter_CreateDeploymentError(t *testing.T) {
+	var replicas int32 = 2
+	image, imageTag := "docker.io/karmada/karmada-metrics-adapter", "latest"
+	name := "karmada-demo"
+	namespace := "test"
+	imagePullPolicy := corev1.PullIfNotPresent
+	annotations := map[string]string{"annotationKey": "annotationValue"}
+	labels := map[string]string{"labelKey": "labelValue"}
+
+	cfg := &operatorv1alpha1.KarmadaMetricsAdapter{
+		CommonSettings: operatorv1alpha1.CommonSettings{
+			Image: operatorv1alpha1.Image{
+				ImageRepository: image,
+				ImageTag:        imageTag,
+			},
+			Replicas:        new(replicas),
+			Annotations:     annotations,
+			Labels:          labels,
+			Resources:       corev1.ResourceRequirements{},
+			ImagePullPolicy: imagePullPolicy,
+		},
+	}
+
+	fakeClient := fakeclientset.NewClientset()
+	fakeClient.PrependReactor("create", "deployments", func(coretesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInvalid(schema.GroupKind{Group: "apps", Kind: "Deployment"}, util.KarmadaMetricsAdapterName(name), nil)
+	})
+
+	err := EnsureKarmadaMetricAdapter(fakeClient, cfg, name, namespace)
+	if err == nil {
+		t.Fatalf("expected an error, but got nil")
+	}
+	if !strings.Contains(err.Error(), util.KarmadaMetricsAdapterName(name)) {
+		t.Errorf("expected error to reference deployment name %q, got: %v", util.KarmadaMetricsAdapterName(name), err)
+	}
+}
 
 func TestEnsureKarmadaMetricAdapter(t *testing.T) {
 	var replicas int32 = 2

--- a/operator/pkg/controlplane/metricsadapter/metricsadapter_test.go
+++ b/operator/pkg/controlplane/metricsadapter/metricsadapter_test.go
@@ -71,6 +71,9 @@ func TestEnsureKarmadaMetricAdapter_CreateDeploymentError(t *testing.T) {
 	if !strings.Contains(err.Error(), util.KarmadaMetricsAdapterName(name)) {
 		t.Errorf("expected error to reference deployment name %q, got: %v", util.KarmadaMetricsAdapterName(name), err)
 	}
+	if !apierrors.IsInvalid(err) {
+		t.Errorf("expected the wrapped error to preserve the underlying Invalid error, got: %v", err)
+	}
 }
 
 func TestEnsureKarmadaMetricAdapter(t *testing.T) {

--- a/operator/pkg/controlplane/search/search.go
+++ b/operator/pkg/controlplane/search/search.go
@@ -79,7 +79,7 @@ func installKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.Karm
 		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(searchDeployment)
 
 	if searchDeployment, err = apiclient.CreateOrUpdateDeployment(client, searchDeployment); err != nil {
-		return fmt.Errorf("error when creating deployment for %s, err: %w", searchDeployment.Name, err)
+		return fmt.Errorf("error when creating deployment for %s, err: %w", util.KarmadaSearchName(name), err)
 	}
 
 	ownerRef := *metav1.NewControllerRef(searchDeployment, apiserver.DeploymentGVK)

--- a/operator/pkg/controlplane/search/search_test.go
+++ b/operator/pkg/controlplane/search/search_test.go
@@ -75,6 +75,9 @@ func TestEnsureKarmadaSearch_CreateDeploymentError(t *testing.T) {
 	if !strings.Contains(err.Error(), util.KarmadaSearchName(name)) {
 		t.Errorf("expected error to reference deployment name %q, got: %v", util.KarmadaSearchName(name), err)
 	}
+	if !apierrors.IsInvalid(err) {
+		t.Errorf("expected the wrapped error to preserve the underlying Invalid error, got: %v", err)
+	}
 }
 
 func TestEnsureKarmadaSearch(t *testing.T) {

--- a/operator/pkg/controlplane/search/search_test.go
+++ b/operator/pkg/controlplane/search/search_test.go
@@ -16,10 +16,14 @@ package search
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	coretesting "k8s.io/client-go/testing"
 
@@ -27,6 +31,51 @@ import (
 	"github.com/karmada-io/karmada/operator/pkg/constants"
 	"github.com/karmada-io/karmada/operator/pkg/util"
 )
+
+// TestEnsureKarmadaSearch_CreateDeploymentError verifies that a deployment
+// creation failure (e.g. rejected by the API server due to an invalid spec)
+// is returned as a wrapped error instead of causing a nil pointer panic.
+func TestEnsureKarmadaSearch_CreateDeploymentError(t *testing.T) {
+	var replicas int32 = 2
+	image, imageTag := "docker.io/karmada/karmada-search", "latest"
+	name := "karmada-demo"
+	namespace := "test"
+	imagePullPolicy := corev1.PullIfNotPresent
+	annotations := map[string]string{"annotationKey": "annotationValue"}
+	labels := map[string]string{"labelKey": "labelValue"}
+	extraArgs := map[string]string{"cmd1": "arg1", "cmd2": "arg2"}
+
+	cfg := &operatorv1alpha1.KarmadaSearch{
+		CommonSettings: operatorv1alpha1.CommonSettings{
+			Image: operatorv1alpha1.Image{
+				ImageRepository: image,
+				ImageTag:        imageTag,
+			},
+			Replicas:        new(replicas),
+			Annotations:     annotations,
+			Labels:          labels,
+			Resources:       corev1.ResourceRequirements{},
+			ImagePullPolicy: imagePullPolicy,
+		},
+		ExtraArgs: extraArgs,
+	}
+	etcdCfg := &operatorv1alpha1.Etcd{
+		Local: &operatorv1alpha1.LocalEtcd{},
+	}
+
+	fakeClient := fakeclientset.NewClientset()
+	fakeClient.PrependReactor("create", "deployments", func(coretesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInvalid(schema.GroupKind{Group: "apps", Kind: "Deployment"}, util.KarmadaSearchName(name), nil)
+	})
+
+	err := EnsureKarmadaSearch(fakeClient, cfg, etcdCfg, name, namespace, map[string]bool{})
+	if err == nil {
+		t.Fatalf("expected an error, but got nil")
+	}
+	if !strings.Contains(err.Error(), util.KarmadaSearchName(name)) {
+		t.Errorf("expected error to reference deployment name %q, got: %v", util.KarmadaSearchName(name), err)
+	}
+}
 
 func TestEnsureKarmadaSearch(t *testing.T) {
 	var replicas int32 = 2

--- a/operator/pkg/controlplane/webhook/webhook.go
+++ b/operator/pkg/controlplane/webhook/webhook.go
@@ -74,7 +74,7 @@ func installKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.Kar
 		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(webhookDeployment)
 
 	if webhookDeployment, err = apiclient.CreateOrUpdateDeployment(client, webhookDeployment); err != nil {
-		return fmt.Errorf("error when creating deployment for %s, err: %w", webhookDeployment.Name, err)
+		return fmt.Errorf("error when creating deployment for %s, err: %w", util.KarmadaWebhookName(name), err)
 	}
 
 	ownerRef := *metav1.NewControllerRef(webhookDeployment, apiserver.DeploymentGVK)

--- a/operator/pkg/controlplane/webhook/webhook_test.go
+++ b/operator/pkg/controlplane/webhook/webhook_test.go
@@ -137,6 +137,9 @@ func TestEnsureKarmadaWebhook_CreateDeploymentError(t *testing.T) {
 	if !strings.Contains(err.Error(), util.KarmadaWebhookName(name)) {
 		t.Errorf("expected error to reference deployment name %q, got: %v", util.KarmadaWebhookName(name), err)
 	}
+	if !apierrors.IsInvalid(err) {
+		t.Errorf("expected the wrapped error to preserve the underlying Invalid error, got: %v", err)
+	}
 }
 
 func TestInstallKarmadaWebhook(t *testing.T) {

--- a/operator/pkg/controlplane/webhook/webhook_test.go
+++ b/operator/pkg/controlplane/webhook/webhook_test.go
@@ -16,10 +16,14 @@ package webhook
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	coretesting "k8s.io/client-go/testing"
 
@@ -90,6 +94,48 @@ func TestEnsureKarmadaWebhook(t *testing.T) {
 
 	if pdbCount != 1 {
 		t.Errorf("expected 1 PDB action, but got %d", pdbCount)
+	}
+}
+
+// TestEnsureKarmadaWebhook_CreateDeploymentError verifies that a deployment
+// creation failure (e.g. rejected by the API server due to an invalid spec)
+// is returned as a wrapped error instead of causing a nil pointer panic.
+func TestEnsureKarmadaWebhook_CreateDeploymentError(t *testing.T) {
+	var replicas int32 = 2
+	image, imageTag := "docker.io/karmada/karmada-webhook", "latest"
+	name := "karmada-demo"
+	namespace := "test"
+	imagePullPolicy := corev1.PullIfNotPresent
+	annotations := map[string]string{"annotationKey": "annotationValue"}
+	labels := map[string]string{"labelKey": "labelValue"}
+	extraArgs := map[string]string{"cmd1": "arg1", "cmd2": "arg2"}
+
+	cfg := &operatorv1alpha1.KarmadaWebhook{
+		CommonSettings: operatorv1alpha1.CommonSettings{
+			Image: operatorv1alpha1.Image{
+				ImageRepository: image,
+				ImageTag:        imageTag,
+			},
+			Replicas:        new(replicas),
+			Annotations:     annotations,
+			Labels:          labels,
+			Resources:       corev1.ResourceRequirements{},
+			ImagePullPolicy: imagePullPolicy,
+		},
+		ExtraArgs: extraArgs,
+	}
+
+	fakeClient := fakeclientset.NewClientset()
+	fakeClient.PrependReactor("create", "deployments", func(coretesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInvalid(schema.GroupKind{Group: "apps", Kind: "Deployment"}, util.KarmadaWebhookName(name), nil)
+	})
+
+	err := EnsureKarmadaWebhook(fakeClient, cfg, name, namespace, map[string]bool{})
+	if err == nil {
+		t.Fatalf("expected an error, but got nil")
+	}
+	if !strings.Contains(err.Error(), util.KarmadaWebhookName(name)) {
+		t.Errorf("expected error to reference deployment name %q, got: %v", util.KarmadaWebhookName(name), err)
 	}
 }
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Motivation:
Issue #7731 asks whether karmada-operator CRD fields that accept label
values not satisfying the Kubernetes label format (e.g.
`volumeClaim.metadata.labels`) ever cause a real runtime failure.
Investigation in the issue thread found that setting an invalid label on
`karmadaAPIServer.extraVolumes[].ephemeral.volumeClaimTemplate.metadata.labels`
triggers a nil-pointer panic on the operator's reconcile path, rooted in
`operator/pkg/controlplane/apiserver.installKarmadaAPIServer`:

  panic: runtime error: invalid memory address or nil pointer dereference
  ...
          operator/pkg/controlplane/apiserver/apiserver.go:94 +0x408

Scope / impact (thanks to @ranxi2001 for narrowing this): the panic is
recovered by controller-runtime's Reconcile handler, so the operator
process does **not** crash, and the invalid Deployment is rejected before
and after this change. The bug's actual effect is that the recovered
nil-pointer panic *replaces* the underlying API error (the hosting
cluster rejecting the Deployment because of the invalid PVC template)
with a nil-dereference stack trace, so the reconcile fails and retries
(rate-limited) without ever surfacing the real cause. This PR's impact is
therefore narrow: **avoid the recovered reconcile panic and preserve the
original API error** in the logs. It does not change whether the invalid
input is accepted, and it does not address the broader input-validation
question in #7731.

Approach:
The root cause is a nil pointer dereference on the error path shared by
`installKarmadaAPIServer`, `installKarmadaAggregatedAPIServer`,
`installKarmadaWebhook`, `installKarmadaMetricAdapter`, and
`installKarmadaSearch`. Each does:

  if deployment, err = apiclient.CreateOrUpdateDeployment(client, deployment); err != nil {
      return fmt.Errorf("... %s ...", deployment.Name, err)
  }

`CreateOrUpdateDeployment` returns `(nil, err)` whenever the underlying
`Create` fails for a reason other than AlreadyExists (e.g. the hosting
cluster's API server rejects the Deployment because the ephemeral
volume's PVC template has an invalid label). The tuple assignment
reassigns `deployment` to nil before the error is checked, so
`deployment.Name` on the next line dereferences nil — turning a clear,
actionable API error into a recovered nil-pointer panic that obscures it.

This PR replaces the nil-able `deployment.Name` reference in each of these
5 call sites with the statically-known component name (e.g.
`util.KarmadaAPIServerName(name)`), which is already used to build the
very same deployment and is guaranteed to match. The operator now returns
a clean, wrapped error carrying the original API message instead of
panicking.

Adding the CRD-level pattern validation requested more broadly in #7731
(a validation rule across ~12 label fields, regenerating CRD manifests
across multiple chart/config locations) is left for follow-up.

**Which issue(s) this PR fixes**:
Part of #7731

**Validation**:
Added regression tests (using a fake clientset with a `PrependReactor` on
"create"/"deployments" that injects an error, matching this repo's
existing test conventions) to `apiserver_test.go`, `webhook_test.go`,
`metricsadapter_test.go`, and `search_test.go` that reproduce the exact
panic against the pre-fix code and verify a clean wrapped error is
returned instead against the fix — asserting `apierrors.IsInvalid`
survives the `%w` wrap so the original API validation error is preserved.

Ran:
  go build ./...
  go test ./operator/...

All packages build and all tests pass, including the new regression tests.

```release-note
`karmada-operator`: Fixed a nil-pointer panic on the reconcile path when creating the apiserver, aggregated-apiserver, webhook, metrics-adapter, or search Deployment fails (e.g. due to an invalid pod spec). The panic was recovered by controller-runtime (so the operator did not crash) but masked the original API error; the operator now returns a clean wrapped error that preserves it.
```

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
