### PR TITLE
fix: reconcile remedy action status updates

### DIFF
--- a/pkg/controllers/remediation/eventhandlers.go
+++ b/pkg/controllers/remediation/eventhandlers.go
@@ -49,7 +49,12 @@ func (h *clusterEventHandler) Create(context.Context, event.TypedCreateEvent[*cl
 
 func (h *clusterEventHandler) Update(_ context.Context, e event.TypedUpdateEvent[*clusterv1alpha1.Cluster], queue workqueue.TypedRateLimitingInterface[controllerruntime.Request]) {
 	if reflect.DeepEqual(e.ObjectOld.Status.Conditions, e.ObjectNew.Status.Conditions) {
-		return
+		if len(e.ObjectOld.Status.RemedyActions) == 0 && len(e.ObjectNew.Status.RemedyActions) == 0 {
+			return
+		}
+		if sets.New(e.ObjectOld.Status.RemedyActions...).Equal(sets.New(e.ObjectNew.Status.RemedyActions...)) {
+			return
+		}
 	}
 
 	queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{

--- a/pkg/controllers/remediation/eventhandlers_test.go
+++ b/pkg/controllers/remediation/eventhandlers_test.go
@@ -68,13 +68,14 @@ func Test_clusterEventHandler(t *testing.T) {
 			wantQLen: 0,
 		},
 		{
-			name: "update event: equal cluster condition",
+			name: "update event: equal cluster condition and equivalent empty remedy actions",
 			args: args{
 				operation: "Update",
 				q:         &controllertest.TypedQueue[controllerruntime.Request]{TypedInterface: workqueue.NewTyped[controllerruntime.Request]()},
 				obj: &clusterv1alpha1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "member1"},
 					Status: clusterv1alpha1.ClusterStatus{
+						RemedyActions: []string{},
 						Conditions: []metav1.Condition{
 							{
 								Type:   "Ready",
@@ -96,6 +97,69 @@ func Test_clusterEventHandler(t *testing.T) {
 				},
 			},
 			wantQLen: 0,
+		},
+		{
+			name: "update event: equal cluster condition and equal non-empty remedy actions",
+			args: args{
+				operation: "Update",
+				q:         &controllertest.TypedQueue[controllerruntime.Request]{TypedInterface: workqueue.NewTyped[controllerruntime.Request]()},
+				obj: &clusterv1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "member1"},
+					Status: clusterv1alpha1.ClusterStatus{
+						RemedyActions: []string{string(remedyv1alpha1.TrafficControl)},
+						Conditions: []metav1.Condition{
+							{
+								Type:   "Ready",
+								Status: metav1.ConditionFalse,
+							},
+						},
+					},
+				},
+				oldObj: &clusterv1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "member1"},
+					Status: clusterv1alpha1.ClusterStatus{
+						RemedyActions: []string{string(remedyv1alpha1.TrafficControl)},
+						Conditions: []metav1.Condition{
+							{
+								Type:   "Ready",
+								Status: metav1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			wantQLen: 0,
+		},
+		{
+			name: "update event: equal cluster condition but different remedy actions",
+			args: args{
+				operation: "Update",
+				q:         &controllertest.TypedQueue[controllerruntime.Request]{TypedInterface: workqueue.NewTyped[controllerruntime.Request]()},
+				obj: &clusterv1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "member1"},
+					Status: clusterv1alpha1.ClusterStatus{
+						RemedyActions: []string{string(remedyv1alpha1.TrafficControl)},
+						Conditions: []metav1.Condition{
+							{
+								Type:   "Ready",
+								Status: metav1.ConditionFalse,
+							},
+						},
+					},
+				},
+				oldObj: &clusterv1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "member1"},
+					Status: clusterv1alpha1.ClusterStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   "Ready",
+								Status: metav1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			wantQLen: 1,
 		},
 		{
 			name: "update event: not equal cluster condition",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind flake

**What this PR does / why we need it**:

Remedy action cleanup can remain stuck when `UpdateStatus` reads a stale cached Cluster and skips the post-delete status write. The later `RemedyActions`-only cache update was ignored because the Cluster event handler compared only `Conditions`.

This change enqueues Cluster updates when either `Conditions` or `RemedyActions` changes. Remedy actions are compared as a set so semantically equivalent empty values do not cause unnecessary reconciles.

**Which issue(s) this PR fixes**:

Fixes #7776

**Special notes for your reviewer**:

- Regression: the new handler test fails with queue length `0`, want `1` when the production change is reverted.
- Tests: `go test ./pkg/controllers/remediation -count=1`; fork CI at `3861906f2c3c` passed lint, codegen, compile, unit tests, and E2E on Kubernetes v1.34, v1.35, and v1.36.
- AI assistance: Codex assisted with root-cause analysis, implementation, and tests; I reviewed the changes and validation results.

**Does this PR introduce a user-facing change?**:

```release-note
karmada-controller-manager: Fixed an issue where `Cluster.status.remedyActions` could remain stale after an associated `Remedy` resource was removed.
```
