### PR TITLE
fix(karmadactl): add timeout to InternetIP() to prevent init from hanging

### DIFF
--- a/pkg/karmadactl/cmdinit/utils/format.go
+++ b/pkg/karmadactl/cmdinit/utils/format.go
@@ -32,7 +32,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/util"
 )
 
-
 const (
 	// A split symbol that receives multiple values from a command flag
 	separator      = ","

--- a/pkg/karmadactl/cmdinit/utils/format.go
+++ b/pkg/karmadactl/cmdinit/utils/format.go
@@ -25,21 +25,29 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
 	"github.com/karmada-io/karmada/pkg/util"
 )
 
+
 const (
-	// Query the IP address of the current host accessing the Internet
-	getInternetIPUrl = "https://myexternalip.com/raw"
 	// A split symbol that receives multiple values from a command flag
 	separator      = ","
 	labelSeparator = "="
 	// MaxRespBodyLength is the max length of http response body
 	MaxRespBodyLength = 1 << 20 // 1 MiB
 )
+
+// getInternetIPUrl is the endpoint used to discover the host's public IP.
+// It is a variable so that tests can substitute a local httptest.Server.
+var getInternetIPUrl = "https://myexternalip.com/raw"
+
+// InternetIPTimeout is the maximum time allowed to fetch the host's public IP.
+// It is a variable so that tests can substitute a short value.
+var InternetIPTimeout = 5 * time.Second
 
 // StringToNetIP String To NetIP
 func StringToNetIP(addr string) net.IP {
@@ -67,7 +75,8 @@ func FlagsDNS(dns string) []string {
 
 // InternetIP Current host Internet IP.
 func InternetIP() (net.IP, error) {
-	resp, err := http.Get(getInternetIPUrl)
+	client := &http.Client{Timeout: InternetIPTimeout}
+	resp, err := client.Get(getInternetIPUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/karmadactl/cmdinit/utils/format_test.go
+++ b/pkg/karmadactl/cmdinit/utils/format_test.go
@@ -18,10 +18,13 @@ package utils
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"slices"
 	"testing"
+	"time"
 )
 
 func stringInslice(target string, strArray []string) bool {
@@ -123,13 +126,52 @@ func TestFlagsDNS(t *testing.T) {
 }
 
 func TestInternetIP(t *testing.T) {
-	got, err := InternetIP()
-	if got == nil {
-		t.Errorf("InternetIP() want return not nil, but return nil")
-	}
-	if err != nil {
-		t.Errorf("InternetIP() want return not error, but return error")
-	}
+	t.Run("returns IP from server response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("1.2.3.4"))
+		}))
+		defer srv.Close()
+
+		orig := getInternetIPUrl
+		getInternetIPUrl = srv.URL
+		defer func() { getInternetIPUrl = orig }()
+
+		got, err := InternetIP()
+		if err != nil {
+			t.Fatalf("InternetIP() unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("InternetIP() returned nil IP")
+		}
+		if !got.Equal(net.ParseIP("1.2.3.4")) {
+			t.Errorf("InternetIP() = %v, want 1.2.3.4", got)
+		}
+	})
+
+	t.Run("respects timeout and returns error when server hangs", func(t *testing.T) {
+		hang := make(chan struct{})
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			<-hang
+		}))
+		defer func() {
+			close(hang)
+			srv.Close()
+		}()
+
+		orig := getInternetIPUrl
+		origTimeout := InternetIPTimeout
+		getInternetIPUrl = srv.URL
+		InternetIPTimeout = 100 * time.Millisecond
+		defer func() {
+			getInternetIPUrl = orig
+			InternetIPTimeout = origTimeout
+		}()
+
+		_, err := InternetIP()
+		if err == nil {
+			t.Error("InternetIP() expected timeout error, got nil")
+		}
+	})
 }
 
 func TestFileToBytes(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

`InternetIP()` in `pkg/karmadactl/cmdinit/utils/format.go` uses `http.Get` with Go's default `http.Client`, which has **no timeout**. In air-gapped or restricted-egress environments where `myexternalip.com` is unreachable, the call blocks indefinitely and makes `karmadactl init` appear to hang during certificate generation.

This was identified in #7695.

## Changes

- Add a 5-second timeout via `http.Client{Timeout: InternetIPTimeout}`, matching the existing pattern in `DownloadFile()` in the same package
- Promote `getInternetIPUrl` from `const` to `var` and introduce `var InternetIPTimeout` so tests can substitute a local `httptest.Server`
- Replace the live-network `TestInternetIP` test with two deterministic subtests: one for successful IP parsing, one that verifies the timeout fires against a hanging server

## Does this PR introduce a user-facing change?

```release-note
Fix `karmadactl init` hanging indefinitely when the external IP service is unreachable in air-gapped or restricted-egress environments.
```