### PR TITLE
fix: enforce deletion protection for Cluster resources

### DIFF
--- a/pkg/registry/cluster/storage/storage.go
+++ b/pkg/registry/cluster/storage/storage.go
@@ -23,8 +23,10 @@ import (
 	"net/url"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -34,6 +36,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 
 	clusterapis "github.com/karmada-io/karmada/pkg/apis/cluster"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/printers"
 	printersinternal "github.com/karmada-io/karmada/pkg/printers/internalversion"
 	printerstorage "github.com/karmada-io/karmada/pkg/printers/storage"
@@ -103,8 +106,49 @@ type REST struct {
 	*genericregistry.Store
 }
 
-// Implement Redirector.
-var _ = rest.Redirector(&REST{})
+const deletionProtectionErrorMessage = "This resource is protected, please make sure to remove the label: %s"
+
+var _ rest.GracefulDeleter = &REST{}
+var _ rest.Redirector = &REST{}
+
+// Delete deletes a Cluster after verifying that it is not protected from deletion.
+func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	return r.Store.Delete(ctx, name, composeDeleteValidations(validateDeletionProtection, deleteValidation), options)
+}
+
+// validateDeletionProtection checks whether a Cluster is protected from deletion.
+func validateDeletionProtection(_ context.Context, obj runtime.Object) error {
+	cluster, ok := obj.(*clusterapis.Cluster)
+	if !ok || cluster == nil {
+		return fmt.Errorf("expected non-nil *cluster.Cluster, got %T", obj)
+	}
+
+	if cluster.ObjectMeta.Labels[workv1alpha2.DeletionProtectionLabelKey] != workv1alpha2.DeletionProtectionAlways {
+		return nil
+	}
+
+	return apierrors.NewForbidden(
+		schema.GroupResource{Group: clusterapis.GroupName, Resource: "clusters"},
+		cluster.ObjectMeta.Name,
+		//nolint:staticcheck // Preserve the established webhook error wording for a consistent user-facing response.
+		fmt.Errorf(deletionProtectionErrorMessage, workv1alpha2.DeletionProtectionLabelKey),
+	)
+}
+
+// composeDeleteValidations combines multiple validators into one validator.
+func composeDeleteValidations(validations ...rest.ValidateObjectFunc) rest.ValidateObjectFunc {
+	return func(ctx context.Context, obj runtime.Object) error {
+		for _, validation := range validations {
+			if validation == nil {
+				continue
+			}
+			if err := validation(ctx, obj); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
 
 // ResourceLocation returns a URL to which one can send traffic for the specified cluster.
 func (r *REST) ResourceLocation(ctx context.Context, name string) (*url.URL, http.RoundTripper, error) {

--- a/pkg/registry/cluster/storage/storage_test.go
+++ b/pkg/registry/cluster/storage/storage_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	clusterapis "github.com/karmada-io/karmada/pkg/apis/cluster"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+)
+
+func TestValidateDeletionProtection(t *testing.T) {
+	var nilCluster *clusterapis.Cluster
+
+	tests := []struct {
+		name          string
+		object        runtime.Object
+		wantErr       bool
+		wantForbidden bool
+	}{
+		{
+			name:   "cluster without labels is allowed",
+			object: &clusterapis.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "member1"}},
+		},
+		{
+			name: "cluster with unrelated label is allowed",
+			object: &clusterapis.Cluster{ObjectMeta: metav1.ObjectMeta{
+				Name:   "member1",
+				Labels: map[string]string{"example.karmada.io/label": "value"},
+			}},
+		},
+		{
+			name: "cluster with non Always protection value is allowed",
+			object: &clusterapis.Cluster{ObjectMeta: metav1.ObjectMeta{
+				Name:   "member1",
+				Labels: map[string]string{workv1alpha2.DeletionProtectionLabelKey: "Never"},
+			}},
+		},
+		{
+			name: "cluster with empty protection value is allowed",
+			object: &clusterapis.Cluster{ObjectMeta: metav1.ObjectMeta{
+				Name:   "member1",
+				Labels: map[string]string{workv1alpha2.DeletionProtectionLabelKey: ""},
+			}},
+		},
+		{
+			name: "protected cluster is forbidden",
+			object: &clusterapis.Cluster{ObjectMeta: metav1.ObjectMeta{
+				Name:   "member1",
+				Labels: map[string]string{workv1alpha2.DeletionProtectionLabelKey: workv1alpha2.DeletionProtectionAlways},
+			}},
+			wantErr:       true,
+			wantForbidden: true,
+		},
+		{
+			name:    "unexpected object type returns an error",
+			object:  &corev1.ConfigMap{},
+			wantErr: true,
+		},
+		{
+			name:    "nil cluster returns an error",
+			object:  nilCluster,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDeletionProtection(context.Background(), tt.object)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateDeletionProtection() error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if apierrors.IsForbidden(err) != tt.wantForbidden {
+				t.Errorf("validateDeletionProtection() forbidden = %t, want %t", apierrors.IsForbidden(err), tt.wantForbidden)
+			}
+		})
+	}
+}
+
+func TestComposeDeleteValidations(t *testing.T) {
+	protectionErr := errors.New("protected")
+	originalErr := errors.New("original validation failed")
+	type validationResult struct {
+		name string
+		err  error
+	}
+
+	tests := []struct {
+		name        string
+		validations []*validationResult
+		wantErr     error
+		wantCalls   []string
+	}{
+		{
+			name: "all successful validations run in order",
+			validations: []*validationResult{
+				{name: "protection"},
+				nil,
+				{name: "original"},
+			},
+			wantCalls: []string{"protection", "original"},
+		},
+		{
+			name: "original validation error is returned after protection succeeds",
+			validations: []*validationResult{
+				{name: "protection"},
+				{name: "original", err: originalErr},
+			},
+			wantErr:   originalErr,
+			wantCalls: []string{"protection", "original"},
+		},
+		{
+			name: "protection error prevents original validation",
+			validations: []*validationResult{
+				{name: "protection", err: protectionErr},
+				{name: "original", err: originalErr},
+			},
+			wantErr:   protectionErr,
+			wantCalls: []string{"protection"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := make([]string, 0)
+			validations := make([]rest.ValidateObjectFunc, 0, len(tt.validations))
+			for _, result := range tt.validations {
+				if result == nil {
+					validations = append(validations, nil)
+					continue
+				}
+				result := result
+				validations = append(validations, func(_ context.Context, _ runtime.Object) error {
+					calls = append(calls, result.name)
+					return result.err
+				})
+			}
+
+			err := composeDeleteValidations(validations...)(context.Background(), &clusterapis.Cluster{})
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("composeDeleteValidations() error = %v, want %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(calls, tt.wantCalls) {
+				t.Errorf("composeDeleteValidations() calls = %v, want %v", calls, tt.wantCalls)
+			}
+		})
+	}
+}

--- a/test/e2e/suites/base/resource_deletion_protection_test.go
+++ b/test/e2e/suites/base/resource_deletion_protection_test.go
@@ -23,9 +23,12 @@ import (
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/util/retry"
 
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/test/e2e/framework"
 	"github.com/karmada-io/karmada/test/helper"
@@ -93,6 +96,65 @@ var _ = ginkgo.Describe("[resource deletion protection] deletion protection test
 		framework.UpdateNamespaceLabels(kubeClient, namespace, noProtectedLabelValues)
 		err = kubeClient.CoreV1().Namespaces().Delete(context.TODO(), namespaceName, metav1.DeleteOptions{})
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Delete the protected Cluster", func() {
+		clusterName := "cluster-deletion-protection-" + rand.String(RandomStrLength)
+		cluster := &clusterv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+			Spec:       clusterv1alpha1.ClusterSpec{SyncMode: clusterv1alpha1.Push},
+		}
+		_, err := karmadaClient.ClusterV1alpha1().Clusters().Create(context.TODO(), cluster, metav1.CreateOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+		ginkgo.DeferCleanup(func() {
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				current, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+				if current.ObjectMeta.Labels == nil {
+					return nil
+				}
+				delete(current.ObjectMeta.Labels, workv1alpha2.DeletionProtectionLabelKey)
+				_, err = karmadaClient.ClusterV1alpha1().Clusters().Update(context.TODO(), current, metav1.UpdateOptions{})
+				return err
+			})
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			err = karmadaClient.ClusterV1alpha1().Clusters().Delete(context.TODO(), clusterName, metav1.DeleteOptions{})
+			gomega.Expect(err == nil || apierrors.IsNotFound(err)).Should(gomega.BeTrue())
+		})
+
+		framework.UpdateClusterLabels(karmadaClient, clusterName, protectedLabelValues)
+		err = karmadaClient.ClusterV1alpha1().Clusters().Delete(context.TODO(), clusterName, metav1.DeleteOptions{})
+		gomega.Expect(err).Should(gomega.HaveOccurred())
+		gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.BeTrue())
+		gomega.Expect(err.Error()).Should(gomega.ContainSubstring(workv1alpha2.DeletionProtectionLabelKey))
+
+		_, err = karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			current, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			delete(current.ObjectMeta.Labels, workv1alpha2.DeletionProtectionLabelKey)
+			_, err = karmadaClient.ClusterV1alpha1().Clusters().Update(context.TODO(), current, metav1.UpdateOptions{})
+			return err
+		})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+		err = karmadaClient.ClusterV1alpha1().Clusters().Delete(context.TODO(), clusterName, metav1.DeleteOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		gomega.Eventually(func() bool {
+			_, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
+			return apierrors.IsNotFound(err)
+		}, pollTimeout, pollInterval).Should(gomega.BeTrue())
 	})
 
 	ginkgo.AfterEach(func() {


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

Fixes deletion protection for `Cluster` resources.

`Cluster` resources are served by `karmada-aggregated-apiserver`, so their DELETE requests do not reach the deletion-protection webhook on the main Karmada API server.

Because of this, a `Cluster` labeled with:

```text
resourcetemplate.karmada.io/deletion-protected=Always
```

could still be deleted.

This PR adds the protection check directly to the `Cluster` REST deletion path. It:

* blocks deletion when the label value is `Always`;
* returns a Kubernetes `Forbidden` error;
* preserves the original API-server delete validator;
* keeps the existing deletion-protection error message.

This is a targeted fix for built-in `Cluster` deletion protection. General admission-webhook support for aggregated resources is outside the scope of this PR.

## Which issue(s) this PR fixes

Fixes #7751

## Testing

Added unit tests for:

* protected and unprotected `Cluster` resources;
* `Forbidden` error behavior;
* invalid object types;
* delete-validator order and error handling.

Added an isolated E2E test that verifies:

* protected deletion is rejected;
* the `Cluster` still exists;
* deletion succeeds after removing the label;
* cleanup works safely.

Focused package tests passed:
<img width="1352" height="448" alt="image" src="https://github.com/user-attachments/assets/73d1624c-e736-45ba-95e6-665068023de7" />
The initial `go vet` run failed because `/tmp` ran out of disk quota, not because of a code failure.

## Documentation

No documentation update is needed because this fixes the behavior of an existing documented feature.

## Does this PR introduce a user-facing change?

```release-note
Fixed an issue where protected Cluster resources could still be deleted. Cluster resources labeled with `resourcetemplate.karmada.io/deletion-protected=Always` now return a Forbidden error until the label is removed.
```
