### PR TITLE
test: add unit tests for GetClusterSet and GetClusterWithKarmadaClient in pkg/util/cluster.go

### DIFF
--- a/pkg/karmadactl/cmdinit/utils/format.go
+++ b/pkg/karmadactl/cmdinit/utils/format.go
@@ -32,7 +32,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/util"
 )
 
-
 const (
 	// A split symbol that receives multiple values from a command flag
 	separator      = ","

--- a/pkg/karmadactl/cmdinit/utils/format.go
+++ b/pkg/karmadactl/cmdinit/utils/format.go
@@ -25,21 +25,29 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
 	"github.com/karmada-io/karmada/pkg/util"
 )
 
+
 const (
-	// Query the IP address of the current host accessing the Internet
-	getInternetIPUrl = "https://myexternalip.com/raw"
 	// A split symbol that receives multiple values from a command flag
 	separator      = ","
 	labelSeparator = "="
 	// MaxRespBodyLength is the max length of http response body
 	MaxRespBodyLength = 1 << 20 // 1 MiB
 )
+
+// getInternetIPUrl is the endpoint used to discover the host's public IP.
+// It is a variable so that tests can substitute a local httptest.Server.
+var getInternetIPUrl = "https://myexternalip.com/raw"
+
+// InternetIPTimeout is the maximum time allowed to fetch the host's public IP.
+// It is a variable so that tests can substitute a short value.
+var InternetIPTimeout = 5 * time.Second
 
 // StringToNetIP String To NetIP
 func StringToNetIP(addr string) net.IP {
@@ -67,7 +75,8 @@ func FlagsDNS(dns string) []string {
 
 // InternetIP Current host Internet IP.
 func InternetIP() (net.IP, error) {
-	resp, err := http.Get(getInternetIPUrl)
+	client := &http.Client{Timeout: InternetIPTimeout}
+	resp, err := client.Get(getInternetIPUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/karmadactl/cmdinit/utils/format_test.go
+++ b/pkg/karmadactl/cmdinit/utils/format_test.go
@@ -18,10 +18,13 @@ package utils
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"slices"
 	"testing"
+	"time"
 )
 
 func stringInslice(target string, strArray []string) bool {
@@ -123,13 +126,52 @@ func TestFlagsDNS(t *testing.T) {
 }
 
 func TestInternetIP(t *testing.T) {
-	got, err := InternetIP()
-	if got == nil {
-		t.Errorf("InternetIP() want return not nil, but return nil")
-	}
-	if err != nil {
-		t.Errorf("InternetIP() want return not error, but return error")
-	}
+	t.Run("returns IP from server response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("1.2.3.4"))
+		}))
+		defer srv.Close()
+
+		orig := getInternetIPUrl
+		getInternetIPUrl = srv.URL
+		defer func() { getInternetIPUrl = orig }()
+
+		got, err := InternetIP()
+		if err != nil {
+			t.Fatalf("InternetIP() unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("InternetIP() returned nil IP")
+		}
+		if !got.Equal(net.ParseIP("1.2.3.4")) {
+			t.Errorf("InternetIP() = %v, want 1.2.3.4", got)
+		}
+	})
+
+	t.Run("respects timeout and returns error when server hangs", func(t *testing.T) {
+		hang := make(chan struct{})
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			<-hang
+		}))
+		defer func() {
+			close(hang)
+			srv.Close()
+		}()
+
+		orig := getInternetIPUrl
+		origTimeout := InternetIPTimeout
+		getInternetIPUrl = srv.URL
+		InternetIPTimeout = 100 * time.Millisecond
+		defer func() {
+			getInternetIPUrl = orig
+			InternetIPTimeout = origTimeout
+		}()
+
+		_, err := InternetIP()
+		if err == nil {
+			t.Error("InternetIP() expected timeout error, got nil")
+		}
+	})
 }
 
 func TestFileToBytes(t *testing.T) {

--- a/pkg/util/cluster_test.go
+++ b/pkg/util/cluster_test.go
@@ -510,6 +510,95 @@ func TestGetCluster(t *testing.T) {
 	}
 }
 
+func TestGetClusterSet(t *testing.T) {
+	tests := []struct {
+		name       string
+		hostClient client.Client
+		want       []string
+		wantErr    bool
+	}{
+		{
+			name:       "no clusters returns empty set",
+			hostClient: fakeclient.NewClientBuilder().WithScheme(gclient.NewSchema()).Build(),
+			want:       []string{},
+			wantErr:    false,
+		},
+		{
+			name: "returns all cluster names",
+			hostClient: fakeclient.NewClientBuilder().WithScheme(gclient.NewSchema()).
+				WithObjects(newCluster("cluster-a"), newCluster("cluster-b")).Build(),
+			want:    []string{"cluster-a", "cluster-b"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetClusterSet(tt.hostClient)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetClusterSet() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+			for _, name := range tt.want {
+				if !got.Has(name) {
+					t.Errorf("GetClusterSet() missing cluster %q, got %v", name, got)
+				}
+			}
+			if got.Len() != len(tt.want) {
+				t.Errorf("GetClusterSet() got %d clusters, want %d", got.Len(), len(tt.want))
+			}
+		})
+	}
+}
+
+func TestGetClusterWithKarmadaClient(t *testing.T) {
+	tests := []struct {
+		name        string
+		client      karmadaclientset.Interface
+		clusterName string
+		wantCluster bool
+		wantExist   bool
+		wantErr     bool
+	}{
+		{
+			name:        "cluster exists",
+			client:      karmadaclientsetfake.NewSimpleClientset(newCluster("member1")),
+			clusterName: "member1",
+			wantCluster: true,
+			wantExist:   true,
+			wantErr:     false,
+		},
+		{
+			name:        "cluster not found",
+			client:      karmadaclientsetfake.NewSimpleClientset(),
+			clusterName: "nonexistent",
+			wantCluster: false,
+			wantExist:   false,
+			wantErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, exist, err := GetClusterWithKarmadaClient(tt.client, tt.clusterName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetClusterWithKarmadaClient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if exist != tt.wantExist {
+				t.Errorf("GetClusterWithKarmadaClient() exist = %v, want %v", exist, tt.wantExist)
+			}
+			if tt.wantCluster && got == nil {
+				t.Error("GetClusterWithKarmadaClient() expected non-nil cluster, got nil")
+			}
+			if !tt.wantCluster && got != nil {
+				t.Errorf("GetClusterWithKarmadaClient() expected nil cluster, got %v", got)
+			}
+		})
+	}
+}
+
 func TestObtainClusterID(t *testing.T) {
 	type args struct {
 		clusterKubeClient kubernetes.Interface


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it:**

Adds unit tests for `GetClusterSet` and `GetClusterWithKarmadaClient` in `pkg/util/cluster.go` as requested in #7740.

`TestGetClusterSet` covers:
- Empty cluster list returns an empty set
- Multiple clusters all appear in the returned name set

`TestGetClusterWithKarmadaClient` covers:
- Cluster found returns `(cluster, true, nil)`  
- Cluster absent returns `(nil, false, nil)`

The tests follow the fake client pattern already established in `cluster_test.go` (using `karmadaclientsetfake.NewSimpleClientset` and `fakeclient.NewClientBuilder().WithScheme(gclient.NewSchema())`).

**Which issue(s) this PR fixes:**

Fixes #7740

**Special notes for your reviewer:**

None.

**Does this PR introduce a user-facing change?**
No.