### PR TITLE
fix(scheduler): prevent AssigningResourceBindings cache leak on infomer race

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -214,6 +214,32 @@ func (b *AssigningResourceBindingCache) Add(binding *workv1alpha2.ResourceBindin
 	b.items[names.NamespacedKey(binding.Namespace, binding.Name)] = binding
 }
 
+// Remove deletes the cached entry for the given ResourceBinding, if any.
+// It is used to roll back an entry recorded by Add when committing the scheduling
+// decision to the API server fails.
+func (b *AssigningResourceBindingCache) Remove(binding *workv1alpha2.ResourceBinding) {
+	b.Lock()
+	defer b.Unlock()
+
+	delete(b.items, names.NamespacedKey(binding.Namespace, binding.Name))
+}
+
+// UpdateIfExist replaces the cached entry for the given ResourceBinding only if an entry
+// is still present. It is used to refresh an entry recorded by Add before the API server
+// commit with the authoritative object returned by the API server (carrying the new
+// resourceVersion), without resurrecting an entry that the Informer has already cleaned
+// up in the meantime.
+func (b *AssigningResourceBindingCache) UpdateIfExist(binding *workv1alpha2.ResourceBinding) {
+	b.Lock()
+	defer b.Unlock()
+
+	key := names.NamespacedKey(binding.Namespace, binding.Name)
+	if _, ok := b.items[key]; !ok {
+		return
+	}
+	b.items[key] = binding
+}
+
 // GetBindings returns all currently cached ResourceBindings that are in the "assigning" state,
 // providing the scheduler with the most up-to-date view of pending assignments.
 func (b *AssigningResourceBindingCache) GetBindings() map[string]*workv1alpha2.ResourceBinding {

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -204,9 +204,11 @@ func (b *AssigningResourceBindingCache) OnBindingDelete(binding *workv1alpha2.Re
 	delete(b.items, key)
 }
 
-// Add records a ResourceBinding that has a new scheduling decision committed to the API server.
-// This binding is considered to be in an "assigning" state and will be served by the scheduler
-// as the intended state until its full reflection in the Informer cache and member clusters.
+// Add records a ResourceBinding that is about to have a new scheduling decision committed to
+// the API server, before the commit is issued, so that an Informer event for the commit can
+// never arrive before the cache entry exists. This binding is considered to be in an "assigning"
+// state and will be served by the scheduler as the intended state until its full reflection in
+// the Informer cache and member clusters.
 func (b *AssigningResourceBindingCache) Add(binding *workv1alpha2.ResourceBinding) {
 	b.Lock()
 	defer b.Unlock()
@@ -218,18 +220,22 @@ func (b *AssigningResourceBindingCache) Add(binding *workv1alpha2.ResourceBindin
 // It is used to roll back an entry recorded by Add when committing the scheduling
 // decision to the API server fails.
 func (b *AssigningResourceBindingCache) Remove(binding *workv1alpha2.ResourceBinding) {
+	if binding == nil {
+		return
+	}
+
 	b.Lock()
 	defer b.Unlock()
 
 	delete(b.items, names.NamespacedKey(binding.Namespace, binding.Name))
 }
 
-// UpdateIfExist replaces the cached entry for the given ResourceBinding only if an entry
+// UpdateIfExists replaces the cached entry for the given ResourceBinding only if an entry
 // is still present. It is used to refresh an entry recorded by Add before the API server
 // commit with the authoritative object returned by the API server (carrying the new
 // resourceVersion), without resurrecting an entry that the Informer has already cleaned
 // up in the meantime.
-func (b *AssigningResourceBindingCache) UpdateIfExist(binding *workv1alpha2.ResourceBinding) {
+func (b *AssigningResourceBindingCache) UpdateIfExists(binding *workv1alpha2.ResourceBinding) {
 	b.Lock()
 	defer b.Unlock()
 

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -428,6 +428,48 @@ func TestGC(t *testing.T) {
 	assert.Contains(t, c.assumptions, "ns/rb3", "non-expired entry should be kept")
 }
 
+func makeBinding(ns, name, resourceVersion string) *workv1alpha2.ResourceBinding {
+	return &workv1alpha2.ResourceBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, ResourceVersion: resourceVersion},
+	}
+}
+
+func TestRemove(t *testing.T) {
+	c := newTestAssumptionCache(time.Minute)
+	binding := makeBinding("ns", "rb1", "1000")
+	c.Add(binding)
+	assert.Contains(t, c.items, "ns/rb1")
+
+	c.Remove(binding)
+
+	assert.NotContains(t, c.items, "ns/rb1")
+}
+
+func TestRemove_NoOp(t *testing.T) {
+	c := newTestAssumptionCache(time.Minute)
+	// Should not panic when called on a non-existent key
+	c.Remove(makeBinding("ns", "rb1", "1000"))
+	assert.Empty(t, c.items)
+}
+
+func TestUpdateIfExist(t *testing.T) {
+	c := newTestAssumptionCache(time.Minute)
+	c.Add(makeBinding("ns", "rb1", "1000"))
+
+	updated := makeBinding("ns", "rb1", "1001")
+	c.UpdateIfExist(updated)
+
+	assert.Same(t, updated, c.items["ns/rb1"], "existing entry should be replaced")
+}
+
+func TestUpdateIfExist_SkipsAbsentEntry(t *testing.T) {
+	c := newTestAssumptionCache(time.Minute)
+
+	c.UpdateIfExist(makeBinding("ns", "rb1", "1001"))
+
+	assert.Empty(t, c.items, "UpdateIfExist must not resurrect an entry the Informer has already cleaned up")
+}
+
 // BenchmarkGetAssumedWorkloads measures the performance of GetAssumedWorkloads under
 // varying cache sizes.  The benchmark covers the realistic operating range (N ≤ 50,
 // governed by the reservation TTL) as well as stress sizes to quantify O(N) scaling.

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -452,12 +452,12 @@ func TestRemove_NoOp(t *testing.T) {
 	assert.Empty(t, c.items)
 }
 
-func TestUpdateIfExist(t *testing.T) {
+func TestUpdateIfExists(t *testing.T) {
 	c := newTestAssumptionCache(time.Minute)
 	c.Add(makeBinding("ns", "rb1", "1000"))
 
 	updated := makeBinding("ns", "rb1", "1001")
-	c.UpdateIfExist(updated)
+	c.UpdateIfExists(updated)
 
 	assert.Same(t, updated, c.items["ns/rb1"], "existing entry should be replaced")
 }
@@ -465,9 +465,9 @@ func TestUpdateIfExist(t *testing.T) {
 func TestUpdateIfExist_SkipsAbsentEntry(t *testing.T) {
 	c := newTestAssumptionCache(time.Minute)
 
-	c.UpdateIfExist(makeBinding("ns", "rb1", "1001"))
+	c.UpdateIfExists(makeBinding("ns", "rb1", "1001"))
 
-	assert.Empty(t, c.items, "UpdateIfExist must not resurrect an entry the Informer has already cleaned up")
+	assert.Empty(t, c.items, "UpdateIfExists must not resurrect an entry the Informer has already cleaned up")
 }
 
 // BenchmarkGetAssumedWorkloads measures the performance of GetAssumedWorkloads under

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -696,15 +696,28 @@ func (s *Scheduler) patchScheduleResultForResourceBinding(oldBinding *workv1alph
 		return nil
 	}
 
+	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+		// Record the binding in the AssigningResourceBindings cache before sending the patch,
+		// so the Informer event triggered by the patch can never arrive before the cache entry
+		// exists. Otherwise the event would find nothing to clean up, and an entry added
+		// afterwards would leak if no further updates occur.
+		s.schedulerCache.AssigningResourceBindings().Add(newBinding)
+	}
+
 	result, err := s.KarmadaClient.WorkV1alpha2().ResourceBindings(newBinding.Namespace).Patch(context.TODO(), newBinding.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
+		if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+			// The scheduling decision was not committed; roll back the entry recorded above.
+			s.schedulerCache.AssigningResourceBindings().Remove(newBinding)
+		}
 		klog.Errorf("Failed to patch schedule to ResourceBinding(%s/%s): %v", oldBinding.Namespace, oldBinding.Name, err)
 		return err
 	}
 	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
-		// TODO(@zhzhuang-zju): Consider race condition where Informer's event for 'result' arrives before this Add call,
-		// leading to a potential memory leak in AssigningResourceBindings cache if no further updates occur.
-		s.schedulerCache.AssigningResourceBindings().Add(result)
+		// Refresh the entry with the authoritative object returned by the API server, which
+		// carries the new resourceVersion. UpdateIfExist skips the refresh if the Informer
+		// has already cleaned the entry up, so the cleanup cannot be undone.
+		s.schedulerCache.AssigningResourceBindings().UpdateIfExist(result)
 	}
 	if features.FeatureGate.Enabled(features.SchedulingOvercommitProtection) {
 		s.updateAssumptionsCache(oldBinding, scheduleResult)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -696,28 +696,33 @@ func (s *Scheduler) patchScheduleResultForResourceBinding(oldBinding *workv1alph
 		return nil
 	}
 
-	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+	var assigningCache *schedulercache.AssigningResourceBindingCache
+	if features.FeatureGate.Enabled(features.WorkloadAffinity) && s.schedulerCache != nil && s.schedulerCache.AssigningResourceBindings() != nil {
+		assigningCache = s.schedulerCache.AssigningResourceBindings()
+	}
+
+	if assigningCache != nil {
 		// Record the binding in the AssigningResourceBindings cache before sending the patch,
 		// so the Informer event triggered by the patch can never arrive before the cache entry
 		// exists. Otherwise the event would find nothing to clean up, and an entry added
 		// afterwards would leak if no further updates occur.
-		s.schedulerCache.AssigningResourceBindings().Add(newBinding)
+		assigningCache.Add(newBinding)
 	}
 
 	result, err := s.KarmadaClient.WorkV1alpha2().ResourceBindings(newBinding.Namespace).Patch(context.TODO(), newBinding.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+		if assigningCache != nil {
 			// The scheduling decision was not committed; roll back the entry recorded above.
-			s.schedulerCache.AssigningResourceBindings().Remove(newBinding)
+			assigningCache.Remove(newBinding)
 		}
 		klog.Errorf("Failed to patch schedule to ResourceBinding(%s/%s): %v", oldBinding.Namespace, oldBinding.Name, err)
 		return err
 	}
-	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+	if assigningCache != nil {
 		// Refresh the entry with the authoritative object returned by the API server, which
-		// carries the new resourceVersion. UpdateIfExist skips the refresh if the Informer
+		// carries the new resourceVersion. UpdateIfExists skips the refresh if the Informer
 		// has already cleaned the entry up, so the cleanup cannot be undone.
-		s.schedulerCache.AssigningResourceBindings().UpdateIfExist(result)
+		assigningCache.UpdateIfExists(result)
 	}
 	if features.FeatureGate.Enabled(features.SchedulingOvercommitProtection) {
 		s.updateAssumptionsCache(oldBinding, scheduleResult)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1010,6 +1010,89 @@ func TestUpdatesAssumptions(t *testing.T) {
 	})
 }
 
+func TestAssigningCacheLifecycleOnPatch(t *testing.T) {
+	defer setFeatureGateDuringTest(t, features.FeatureGate, features.WorkloadAffinity, true)()
+
+	newTestBinding := func() *workv1alpha2.ResourceBinding {
+		return &workv1alpha2.ResourceBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-binding", Namespace: "default", ResourceVersion: "1000"},
+			Spec: workv1alpha2.ResourceBindingSpec{
+				Resource: workv1alpha2.ObjectReference{Namespace: "work-ns"},
+			},
+		}
+	}
+	scheduleResult := []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: 1}}
+	bindingKey := "default/test-binding"
+
+	t.Run("patch success records the assigning entry", func(t *testing.T) {
+		oldBinding := newTestBinding()
+		cache := schedulercache.NewCache(nil, nil, 0)
+		s := &Scheduler{
+			KarmadaClient:  karmadafake.NewClientset(oldBinding),
+			schedulerCache: cache,
+		}
+
+		err := s.patchScheduleResultForResourceBinding(oldBinding, "test-placement", scheduleResult)
+		assert.NoError(t, err)
+
+		bindings := cache.AssigningResourceBindings().GetBindings()
+		assert.Contains(t, bindings, bindingKey)
+		assert.Equal(t, scheduleResult, bindings[bindingKey].Spec.Clusters)
+	})
+
+	t.Run("patch failure rolls back the assigning entry", func(t *testing.T) {
+		oldBinding := newTestBinding()
+		cache := schedulercache.NewCache(nil, nil, 0)
+		karmadaClient := karmadafake.NewClientset(oldBinding)
+		karmadaClient.PrependReactor("patch", "resourcebindings", func(clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("patch failed")
+		})
+		s := &Scheduler{
+			KarmadaClient:  karmadaClient,
+			schedulerCache: cache,
+		}
+
+		err := s.patchScheduleResultForResourceBinding(oldBinding, "test-placement", scheduleResult)
+		assert.Error(t, err)
+
+		assert.Empty(t, cache.AssigningResourceBindings().GetBindings(),
+			"assigning entry must be rolled back when the patch fails")
+	})
+
+	t.Run("informer cleanup racing with the patch is not undone", func(t *testing.T) {
+		// Regression test for the race where the Informer's event for the patched binding
+		// arrives before the scheduler records the binding in the assigning cache: the event
+		// found nothing to clean up and the entry recorded afterwards leaked. Now the entry
+		// is recorded before the patch, so the event always finds it, and the post-patch
+		// refresh must not resurrect an entry the event already cleaned up.
+		oldBinding := newTestBinding()
+		cache := schedulercache.NewCache(nil, nil, 0)
+		karmadaClient := karmadafake.NewClientset(oldBinding)
+		karmadaClient.PrependReactor("patch", "resourcebindings", func(clienttesting.Action) (bool, runtime.Object, error) {
+			// Simulate the Informer delivering the update event for the patched binding
+			// (newer resourceVersion, FullyApplied) while the patch call is still in flight.
+			eventBinding := newTestBinding()
+			eventBinding.ResourceVersion = "1001"
+			eventBinding.Spec.Clusters = scheduleResult
+			eventBinding.Status.Conditions = []metav1.Condition{
+				{Type: workv1alpha2.FullyApplied, Status: metav1.ConditionTrue},
+			}
+			cache.AssigningResourceBindings().OnBindingUpdate(eventBinding)
+			return false, nil, nil
+		})
+		s := &Scheduler{
+			KarmadaClient:  karmadaClient,
+			schedulerCache: cache,
+		}
+
+		err := s.patchScheduleResultForResourceBinding(oldBinding, "test-placement", scheduleResult)
+		assert.NoError(t, err)
+
+		assert.Empty(t, cache.AssigningResourceBindings().GetBindings(),
+			"an entry cleaned up by the Informer during the patch must not be resurrected")
+	})
+}
+
 func TestScheduleClusterResourceBindingWithClusterAffinity(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When the `WorkloadAffinity` feature gate is enabled, `patchScheduleResultForResourceBinding` previously added the binding to the `AssigningResourceBindings` cache only **after** the patch call returned. If the Informer's update event for the patched binding arrived before that `Add` (the race noted in the existing TODO), the event found nothing to clean up, and the entry added afterwards leaked permanently — the cache's `items` map has no TTL/GC, so if the binding received no further updates, the entry stayed forever.

This PR closes the race by construction instead of by timing:

- **`Add` before the patch**: the cache entry now provably exists before the API server can emit the corresponding Informer event, so the event can never miss it.
- **`Remove` on patch failure**: a scheduling decision that was never committed is rolled back instead of lingering as an "assigning" entry.
- **`UpdateIfExist` after a successful patch**: refreshes the entry with the authoritative object returned by the API server (carrying the new `resourceVersion`), but deliberately does **not** resurrect an entry the Informer has already cleaned up in the meantime — a plain `Add(result)` here would reintroduce the leak from the other direction.


**Which issue(s) this PR fixes**:
Fixes #7781

**Special notes for your reviewer**:

- The pre-patch entry carries the old `resourceVersion`; `OnBindingUpdate`'s version comparison still allows the newer Informer event to replace or delete it, so the stale-RV window is harmless.
- If the patch succeeds server-side but returns an error (e.g., timeout), `Remove` clears the entry and the later Informer event no-ops on the missing key — no leak, and the scheduler retries.
- Test coverage added:
  - `TestRemove` / `TestUpdateIfExist` unit tests for the new cache methods, including that `UpdateIfExist` does not resurrect an absent entry.
  - `TestAssigningCacheLifecycleOnPatch` covering patch success, patch failure rollback, and a regression test that uses a fake-client reactor to inject the Informer cleanup while the patch is in flight, asserting the entry is not resurrected.

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-scheduler`: Fixed a memory leak in the AssigningResourceBindings cache where an entry could be retained forever if the Informer's update event for a patched ResourceBinding arrived before the scheduler recorded it.
```
