### PR TITLE
feat : Add sequential rollout strategy to PropagationPolicy for health-gated multi-cluster propagation

### DIFF
--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -526,7 +526,87 @@ type Placement struct {
 	// scheduling policies.
 	// +optional
 	WorkloadAffinity *WorkloadAffinity `json:"workloadAffinity,omitempty"`
+
+	// RolloutStrategy defines the strategy for rolling out resources across clusters.
+	// If not specified, resources are propagated to all clusters simultaneously.
+	// +optional
+	RolloutStrategy *RolloutStrategy `json:"rolloutStrategy,omitempty"`
 }
+
+// RolloutStrategy defines the strategy for rolling out resources across clusters.
+type RolloutStrategy struct {
+	// Type determines the rollout strategy type.
+	// Valid options are "Sequential" and "Parallel".
+	// "Sequential" rolls out to clusters one by one in the specified order.
+	// "Parallel" rolls out to all clusters simultaneously (default behavior).
+	// +kubebuilder:validation:Enum=Sequential;Parallel
+	// +optional
+	Type RolloutStrategyType `json:"type,omitempty"`
+
+	// Sequential configuration for sequential rollout.
+	// Required when Type is "Sequential".
+	// +optional
+	Sequential *SequentialRolloutConfig `json:"sequential,omitempty"`
+}
+
+// RolloutStrategyType defines the type of rollout strategy.
+type RolloutStrategyType string
+
+const (
+	// RolloutStrategyTypeSequential rolls out to clusters sequentially.
+	RolloutStrategyTypeSequential RolloutStrategyType = "Sequential"
+	// RolloutStrategyTypeParallel rolls out to clusters in parallel.
+	RolloutStrategyTypeParallel RolloutStrategyType = "Parallel"
+)
+
+// SequentialRolloutConfig defines the configuration for sequential rollout.
+type SequentialRolloutConfig struct {
+	// Order defines the order in which clusters should be updated.
+	// Clusters not in this list will not be updated.
+	// +required
+	// +kubebuilder:validation:MinItems=1
+	Order []string `json:"order"`
+
+	// HealthCheck defines the health check configuration.
+	// +required
+	HealthCheck HealthCheckConfig `json:"healthCheck"`
+
+	// OnFailure defines the behavior when a cluster fails health check or timeout.
+	// Valid options are "Pause", "RollbackAll", "Continue".
+	// Defaults to "Pause".
+	// +kubebuilder:validation:Enum=Pause;RollbackAll;Continue
+	// +kubebuilder:default=Pause
+	// +optional
+	OnFailure OnFailureBehavior `json:"onFailure,omitempty"`
+}
+
+// HealthCheckConfig defines the health check configuration.
+type HealthCheckConfig struct {
+	// Timeout is the maximum time to wait for the cluster to become healthy.
+	// Defaults to 300s.
+	// +kubebuilder:default="300s"
+	// +optional
+	Timeout metav1.Duration `json:"timeout,omitempty"`
+
+	// Condition is the condition type to check for health.
+	// Common values: "Ready", "Available", "Healthy".
+	// Defaults to "Ready".
+	// +kubebuilder:default=Ready
+	// +optional
+	Condition string `json:"condition,omitempty"`
+}
+
+// OnFailureBehavior defines the behavior when rollout fails.
+type OnFailureBehavior string
+
+const (
+	// OnFailurePause pauses the rollout and does not update remaining clusters.
+	OnFailurePause OnFailureBehavior = "Pause"
+	// OnFailureRollbackAll rolls back all clusters to the previous version.
+	OnFailureRollbackAll OnFailureBehavior = "RollbackAll"
+	// OnFailureContinue continues to update remaining clusters despite failure.
+	OnFailureContinue OnFailureBehavior = "Continue"
+)
 
 // SpreadFieldValue is the type to define valid values for SpreadConstraint.SpreadByField
 type SpreadFieldValue string

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -446,6 +446,10 @@ type ResourceBindingStatus struct {
 	// AggregatedStatus represents status list of the resource running in each member cluster.
 	// +optional
 	AggregatedStatus []AggregatedStatusItem `json:"aggregatedStatus,omitempty"`
+
+	// RolloutStatus tracks the status of sequential rollout.
+	// +optional
+	RolloutStatus *RolloutStatus `json:"rolloutStatus,omitempty"`
 }
 
 // AggregatedStatusItem represents status of the resource running in a member cluster.
@@ -475,6 +479,44 @@ type AggregatedStatusItem struct {
 	// +optional
 	Health ResourceHealth `json:"health,omitempty"`
 }
+
+// RolloutStatus tracks the status of sequential rollout.
+type RolloutStatus struct {
+	// CurrentStage is the current stage of the rollout (0-indexed).
+	// +optional
+	CurrentStage int32 `json:"currentStage,omitempty"`
+
+	// TotalStages is the total number of stages in the rollout.
+	// +optional
+	TotalStages int32 `json:"totalStages,omitempty"`
+
+	// Phase is the current phase of the rollout.
+	// +kubebuilder:validation:Enum=Progressing;Paused;Completed;Failed
+	// +optional
+	Phase RolloutPhase `json:"phase,omitempty"`
+
+	// Message provides human-readable information about the rollout status.
+	// +optional
+	Message string `json:"message,omitempty"`
+
+	// LastTransitionTime is the last time the phase transitioned.
+	// +optional
+	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
+}
+
+// RolloutPhase defines the phase of a rollout.
+type RolloutPhase string
+
+const (
+	// RolloutPhaseProgressing indicates the rollout is in progress.
+	RolloutPhaseProgressing RolloutPhase = "Progressing"
+	// RolloutPhasePaused indicates the rollout is paused.
+	RolloutPhasePaused RolloutPhase = "Paused"
+	// RolloutPhaseCompleted indicates the rollout completed successfully.
+	RolloutPhaseCompleted RolloutPhase = "Completed"
+	// RolloutPhaseFailed indicates the rollout failed.
+	RolloutPhaseFailed RolloutPhase = "Failed"
+)
 
 // Conditions definition
 const (

--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -25,6 +25,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/record"
@@ -39,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/metrics"
@@ -47,6 +49,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/helper"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/util/overridemanager"
 )
 
@@ -109,6 +112,18 @@ func (c *ResourceBindingController) removeFinalizer(ctx context.Context, rb *wor
 
 // syncBinding will sync resourceBinding to Works.
 func (c *ResourceBindingController) syncBinding(ctx context.Context, binding *workv1alpha2.ResourceBinding) (controllerruntime.Result, error) {
+	// Handle sequential rollout if enabled
+	if binding.Spec.Placement != nil && binding.Spec.Placement.RolloutStrategy != nil &&
+		binding.Spec.Placement.RolloutStrategy.Type == policyv1alpha1.RolloutStrategyTypeSequential {
+		result, err := c.handleSequentialRollout(ctx, binding)
+		if err != nil {
+			return controllerruntime.Result{}, err
+		}
+		if result.RequeueAfter > 0 {
+			return result, nil
+		}
+	}
+
 	if err := c.removeOrphanWorks(ctx, binding); err != nil {
 		return controllerruntime.Result{}, err
 	}
@@ -181,6 +196,172 @@ func (c *ResourceBindingController) checkDirectPurgeOrphanWorks(ctx context.Cont
 	}
 
 	return len(works) > 0, nil
+}
+
+// handleSequentialRollout handles the sequential rollout logic for ResourceBinding.
+func (c *ResourceBindingController) handleSequentialRollout(ctx context.Context, binding *workv1alpha2.ResourceBinding) (controllerruntime.Result, error) {
+	// Check if rollout is complete
+	if binding.Status.RolloutStatus != nil && binding.Status.RolloutStatus.Phase == workv1alpha2.RolloutPhaseCompleted {
+		return controllerruntime.Result{}, nil
+	}
+
+	// Initialize rollout status if not present
+	if binding.Status.RolloutStatus == nil {
+		if binding.Annotations == nil {
+			binding.Annotations = make(map[string]string)
+		}
+		binding.Annotations["rollout.karmada.io/stage"] = "0"
+		binding.Annotations["rollout.karmada.io/startTime"] = time.Now().Format(time.RFC3339)
+
+		binding.Status.RolloutStatus = &workv1alpha2.RolloutStatus{
+			CurrentStage:       0,
+			TotalStages:        int32(len(binding.Spec.Placement.RolloutStrategy.Sequential.Order)),
+			Phase:              workv1alpha2.RolloutPhaseProgressing,
+			Message:            "Rollout started",
+			LastTransitionTime: &metav1.Time{Time: time.Now()},
+		}
+
+		if err := c.Client.Status().Update(ctx, binding); err != nil {
+			return controllerruntime.Result{}, err
+		}
+		if err := c.Client.Update(ctx, binding); err != nil {
+			return controllerruntime.Result{}, err
+		}
+		return controllerruntime.Result{}, nil
+	}
+
+	// Check if current cluster is healthy
+	currentStage := binding.Status.RolloutStatus.CurrentStage
+	if currentStage >= int32(len(binding.Spec.Placement.RolloutStrategy.Sequential.Order)) {
+		// All stages completed
+		now := metav1.Now()
+		binding.Status.RolloutStatus.Phase = workv1alpha2.RolloutPhaseCompleted
+		binding.Status.RolloutStatus.Message = "Rollout completed successfully"
+		binding.Status.RolloutStatus.LastTransitionTime = &now
+		if err := c.Client.Status().Update(ctx, binding); err != nil {
+			return controllerruntime.Result{}, err
+		}
+		return controllerruntime.Result{}, nil
+	}
+
+	currentCluster := binding.Spec.Placement.RolloutStrategy.Sequential.Order[currentStage]
+	healthy, err := c.checkClusterHealth(ctx, binding, currentCluster)
+	if err != nil {
+		return controllerruntime.Result{}, err
+	}
+
+	if !healthy {
+		// Check timeout
+		timeout := binding.Spec.Placement.RolloutStrategy.Sequential.HealthCheck.Timeout.Duration
+		startTimeStr, exists := binding.Annotations["rollout.karmada.io/startTime"]
+		if !exists {
+			return controllerruntime.Result{}, fmt.Errorf("rollout start time not found")
+		}
+		startTime, err := time.Parse(time.RFC3339, startTimeStr)
+		if err != nil {
+			return controllerruntime.Result{}, err
+		}
+
+		if time.Since(startTime) > timeout {
+			// Handle timeout based on OnFailure policy
+			return c.handleRolloutFailure(ctx, binding, int(currentStage), "timeout")
+		}
+		// Requeue to check again
+		return controllerruntime.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	// Current cluster is healthy, advance to next stage
+	return c.advanceRolloutStage(ctx, binding, int(currentStage))
+}
+
+// checkClusterHealth checks if a cluster is healthy based on Work status.
+func (c *ResourceBindingController) checkClusterHealth(ctx context.Context, binding *workv1alpha2.ResourceBinding, clusterName string) (bool, error) {
+	workNamespace := names.GenerateExecutionSpaceName(clusterName)
+	workName := names.GenerateWorkName(binding.Namespace, binding.Name, binding.Labels[workv1alpha2.ResourceBindingPermanentIDLabel])
+
+	work := &workv1alpha1.Work{}
+	err := c.Client.Get(ctx, types.NamespacedName{Namespace: workNamespace, Name: workName}, work)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Work not created yet, not healthy
+			return false, nil
+		}
+		return false, err
+	}
+
+	// Check health condition
+	condition := binding.Spec.Placement.RolloutStrategy.Sequential.HealthCheck.Condition
+	for _, cond := range work.Status.Conditions {
+		if cond.Type == condition && cond.Status == metav1.ConditionTrue {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// advanceRolloutStage advances the rollout to the next stage.
+func (c *ResourceBindingController) advanceRolloutStage(ctx context.Context, binding *workv1alpha2.ResourceBinding, currentStage int) (controllerruntime.Result, error) {
+	nextStage := currentStage + 1
+	if binding.Annotations == nil {
+		binding.Annotations = make(map[string]string)
+	}
+	binding.Annotations["rollout.karmada.io/stage"] = fmt.Sprintf("%d", nextStage)
+
+	// Update rollout status
+	now := metav1.Now()
+	binding.Status.RolloutStatus.CurrentStage = int32(nextStage)
+	binding.Status.RolloutStatus.LastTransitionTime = &now
+
+	if nextStage >= len(binding.Spec.Placement.RolloutStrategy.Sequential.Order) {
+		binding.Status.RolloutStatus.Phase = workv1alpha2.RolloutPhaseCompleted
+		binding.Status.RolloutStatus.Message = "Rollout completed successfully"
+	} else {
+		binding.Status.RolloutStatus.Message = fmt.Sprintf("Rollout progressing to stage %d", nextStage)
+	}
+
+	// Trigger rescheduling by updating RescheduleTriggeredAt
+	binding.Spec.RescheduleTriggeredAt = &now
+
+	if err := c.Client.Status().Update(ctx, binding); err != nil {
+		return controllerruntime.Result{}, err
+	}
+	if err := c.Client.Update(ctx, binding); err != nil {
+		return controllerruntime.Result{}, err
+	}
+
+	return controllerruntime.Result{}, nil
+}
+
+// handleRolloutFailure handles rollout failure based on OnFailure policy.
+func (c *ResourceBindingController) handleRolloutFailure(ctx context.Context, binding *workv1alpha2.ResourceBinding, stage int, reason string) (controllerruntime.Result, error) {
+	onFailure := binding.Spec.Placement.RolloutStrategy.Sequential.OnFailure
+
+	switch onFailure {
+	case policyv1alpha1.OnFailurePause:
+		return c.markRolloutPaused(ctx, binding, stage, reason)
+	case policyv1alpha1.OnFailureRollbackAll:
+		// TODO: Implement rollback logic
+		return c.markRolloutPaused(ctx, binding, stage, fmt.Sprintf("Rollback not yet implemented: %s", reason))
+	case policyv1alpha1.OnFailureContinue:
+		return c.advanceRolloutStage(ctx, binding, stage)
+	default:
+		return c.markRolloutPaused(ctx, binding, stage, reason)
+	}
+}
+
+// markRolloutPaused marks the rollout as paused.
+func (c *ResourceBindingController) markRolloutPaused(ctx context.Context, binding *workv1alpha2.ResourceBinding, stage int, reason string) (controllerruntime.Result, error) {
+	now := metav1.Now()
+	binding.Status.RolloutStatus.Phase = workv1alpha2.RolloutPhasePaused
+	binding.Status.RolloutStatus.Message = fmt.Sprintf("Rollout paused at stage %d: %s", stage, reason)
+	binding.Status.RolloutStatus.LastTransitionTime = &now
+
+	if err := c.Client.Status().Update(ctx, binding); err != nil {
+		return controllerruntime.Result{}, err
+	}
+
+	return controllerruntime.Result{}, nil
 }
 
 // SetupWithManager creates a controller and register to controller manager.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -139,6 +139,14 @@ const (
 	// owner: @mszacillo, @RainbowMango, @kevin-wangzefeng
 	// alpha: v1.17
 	WorkloadAffinity featuregate.Feature = "WorkloadAffinity"
+
+	// SequentialRollout controls whether the sequential rollout strategy is enabled.
+	// When enabled, PropagationPolicy can specify a rolloutStrategy to propagate
+	// resources to clusters sequentially with health checks between stages.
+	//
+	// owner: @your-github-username
+	// alpha: v1.18
+	SequentialRollout featuregate.Feature = "SequentialRollout"
 )
 
 var (
@@ -167,6 +175,7 @@ var (
 		MultiplePodTemplatesScheduling:    {Default: false, PreRelease: featuregate.Alpha},
 		ControllerPriorityQueue:           {Default: true, PreRelease: featuregate.Beta},
 		WorkloadAffinity:                  {Default: false, PreRelease: featuregate.Alpha},
+		SequentialRollout:                 {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/scheduler/helper.go
+++ b/pkg/scheduler/helper.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"reflect"
 
@@ -143,4 +144,48 @@ func getConditionByError(err error) (metav1.Condition, bool) {
 		}
 	}
 	return util.NewCondition(workv1alpha2.Scheduled, workv1alpha2.BindingReasonSchedulerError, err.Error(), metav1.ConditionFalse), false
+}
+
+// applyRolloutStrategy applies the rollout strategy to filter clusters for sequential rollout.
+func (s *Scheduler) applyRolloutStrategy(rb *workv1alpha2.ResourceBinding, candidateClusters []workv1alpha2.TargetCluster) []workv1alpha2.TargetCluster {
+	if rb.Spec.Placement == nil || rb.Spec.Placement.RolloutStrategy == nil {
+		return candidateClusters
+	}
+
+	if rb.Spec.Placement.RolloutStrategy.Type != policyv1alpha1.RolloutStrategyTypeSequential {
+		return candidateClusters
+	}
+
+	// For sequential rollout, only include the next cluster in the order
+	currentStage := getCurrentRolloutStage(rb)
+	if currentStage >= len(rb.Spec.Placement.RolloutStrategy.Sequential.Order) {
+		// All stages completed, return all clusters
+		return candidateClusters
+	}
+
+	nextCluster := rb.Spec.Placement.RolloutStrategy.Sequential.Order[currentStage]
+	for _, cluster := range candidateClusters {
+		if cluster.Name == nextCluster {
+			return []workv1alpha2.TargetCluster{cluster}
+		}
+	}
+
+	// If the next cluster is not in the candidate list, return empty
+	return nil
+}
+
+// getCurrentRolloutStage gets the current rollout stage from ResourceBinding annotations.
+func getCurrentRolloutStage(rb *workv1alpha2.ResourceBinding) int {
+	if rb.Annotations == nil {
+		return 0
+	}
+	stage, exists := rb.Annotations["rollout.karmada.io/stage"]
+	if !exists {
+		return 0
+	}
+	stageInt := 0
+	if _, err := fmt.Sscanf(stage, "%d", &stageInt); err == nil {
+		return stageInt
+	}
+	return 0
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -591,11 +591,15 @@ func (s *Scheduler) scheduleResourceBindingWithClusterAffinity(rb *workv1alpha2.
 	}
 
 	klog.V(4).Infof("ResourceBinding(%s/%s) scheduled to clusters %v", rb.Namespace, rb.Name, scheduleResult.SuggestedClusters)
-	patchErr := s.patchScheduleResultForResourceBinding(rb, string(placementBytes), scheduleResult.SuggestedClusters)
+
+	// Apply rollout strategy to filter clusters if sequential rollout is enabled
+	filteredClusters := s.applyRolloutStrategy(rb, scheduleResult.SuggestedClusters)
+
+	patchErr := s.patchScheduleResultForResourceBinding(rb, string(placementBytes), filteredClusters)
 	if patchErr != nil {
 		err = utilerrors.NewAggregate([]error{err, patchErr})
 	}
-	s.recordScheduleResultEventForResourceBinding(rb, scheduleResult.SuggestedClusters, err)
+	s.recordScheduleResultEventForResourceBinding(rb, filteredClusters, err)
 	return err
 }
 

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -119,6 +119,7 @@ func ValidatePlacement(placement policyv1alpha1.Placement, fldPath *field.Path) 
 	allErrs = append(allErrs, ValidateSpreadConstraint(placement.SpreadConstraints, fldPath.Child("spreadConstraints"))...)
 	allErrs = append(allErrs, ValidateWorkloadAffinity(placement.WorkloadAffinity, fldPath.Child("workloadAffinity"))...)
 	allErrs = append(allErrs, validateClusterTolerations(placement.ClusterTolerations, fldPath.Child("clusterTolerations"))...)
+	allErrs = append(allErrs, ValidateRolloutStrategy(placement.RolloutStrategy, fldPath.Child("rolloutStrategy"))...)
 	return allErrs
 }
 
@@ -165,6 +166,43 @@ func ValidateWorkloadAffinity(workloadAffinity *policyv1alpha1.WorkloadAffinity,
 		allErrs = append(allErrs, field.Invalid(fldPath, workloadAffinity,
 			"affinity and antiAffinity must not use the same groupByLabelKey"))
 	}
+	return allErrs
+}
+
+// ValidateRolloutStrategy validates a rolloutStrategy before creation or update.
+func ValidateRolloutStrategy(rolloutStrategy *policyv1alpha1.RolloutStrategy, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	if rolloutStrategy == nil {
+		return allErrs
+	}
+
+	if rolloutStrategy.Type == policyv1alpha1.RolloutStrategyTypeSequential {
+		if rolloutStrategy.Sequential == nil {
+			allErrs = append(allErrs, field.Invalid(
+				fldPath.Child("sequential"),
+				nil,
+				"sequential config is required when type is Sequential",
+			))
+			return allErrs
+		}
+
+		if len(rolloutStrategy.Sequential.Order) == 0 {
+			allErrs = append(allErrs, field.Invalid(
+				fldPath.Child("sequential").Child("order"),
+				rolloutStrategy.Sequential.Order,
+				"order must have at least one cluster",
+			))
+		}
+
+		if rolloutStrategy.Sequential.HealthCheck.Timeout.Duration <= 0 {
+			allErrs = append(allErrs, field.Invalid(
+				fldPath.Child("sequential").Child("healthCheck").Child("timeout"),
+				rolloutStrategy.Sequential.HealthCheck.Timeout,
+				"timeout must be positive",
+			))
+		}
+	}
+
 	return allErrs
 }
 


### PR DESCRIPTION
## Summary
This PR adds a new rolloutStrategy field to the PropagationPolicy API that enables ordered, health-gated propagation across member clusters. When a resource is updated on the Karmada control plane, instead of propagating to all clusters simultaneously, Karmada can now propagate sequentially — waiting for each cluster to report healthy before proceeding to the next.

Motivation
Multi-DC High Availability During Updates

We operate workloads across multiple datacenters where updates must propagate without causing simultaneous unavailability in both DCs — at least one cluster must always be healthy and serving traffic.

## Current Problem:

Karmada's default scheduling propagates updates to all member clusters simultaneously
No built-in mechanism to say "update DC1 first, verify it's healthy, then update DC2"
Teams currently use the imperative spec.suspension.dispatchingOnClusters workaround, which requires:
Custom controller orchestration
Race condition management
Tight coupling between application logic and infrastructure
## API Changes
New Types in propagation_types.go:

RolloutStrategy: Defines rollout strategy type (Sequential/Parallel)
SequentialRolloutConfig: Configuration for sequential rollout
HealthCheckConfig: Health check parameters (timeout, condition)
OnFailureBehavior: Failure handling policy (Pause/RollbackAll/Continue)
New Status Fields in binding_types.go:

RolloutStatus: Tracks rollout progress (CurrentStage, TotalStages, Phase, Message, LastTransitionTime)
RolloutPhase: Rollout phase enum (Progressing/Paused/Completed/Failed)

## Future Work
Implement RollbackAll failure policy
Add unit tests for validation, scheduler, and controller logic
Add E2E tests for various rollout scenarios
Add API documentation with examples
Add user guide for rollout strategy usage
#7767 