### PR TITLE
test(scheduler): cover affinity reset on reschedule

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -536,13 +536,14 @@ func TestScheduleResourceBindingWithClusterAffinity(t *testing.T) {
 
 func TestScheduleResourceBindingWithClusterAffinities(t *testing.T) {
 	tests := []struct {
-		name            string
-		binding         *workv1alpha2.ResourceBinding
-		scheduleResults []core.ScheduleResult
-		scheduleErrors  []error
-		expectError     bool
-		expectedPatches []string
-		expectedEvent   string
+		name                  string
+		binding               *workv1alpha2.ResourceBinding
+		scheduleResults       []core.ScheduleResult
+		scheduleErrors        []error
+		expectError           bool
+		expectedPatches       []string
+		expectedEvent         string
+		expectedAffinityCalls []string
 	}{
 		{
 			name: "successful scheduling with first affinity",
@@ -584,6 +585,98 @@ func TestScheduleResourceBindingWithClusterAffinities(t *testing.T) {
 				`{"status":{"schedulerObservingAffinityName":"affinity1"}}`,
 			},
 			expectedEvent: fmt.Sprintf("Normal ScheduleBindingSucceed %s Result: {cluster1:1}", successfulSchedulingMessage),
+		},
+		{
+			name: "explicit rescheduling restarts from first affinity",
+			binding: &workv1alpha2.ResourceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-binding-reschedule",
+					Namespace: "default",
+				},
+				Spec: workv1alpha2.ResourceBindingSpec{
+					RescheduleTriggeredAt: &metav1.Time{Time: time.Unix(2, 0)},
+					Placement: &policyv1alpha1.Placement{
+						ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{
+							{
+								AffinityName: "affinity1",
+								ClusterAffinity: policyv1alpha1.ClusterAffinity{
+									ClusterNames: []string{"cluster1"},
+								},
+							},
+							{
+								AffinityName: "affinity2",
+								ClusterAffinity: policyv1alpha1.ClusterAffinity{
+									ClusterNames: []string{"cluster2"},
+								},
+							},
+						},
+					},
+				},
+				Status: workv1alpha2.ResourceBindingStatus{
+					LastScheduledTime:             &metav1.Time{Time: time.Unix(1, 0)},
+					SchedulerObservedAffinityName: "affinity2",
+				},
+			},
+			scheduleResults: []core.ScheduleResult{
+				{
+					SuggestedClusters: []workv1alpha2.TargetCluster{
+						{Name: "cluster1", Replicas: 1},
+					},
+				},
+			},
+			scheduleErrors: []error{nil},
+			expectError:    false,
+			expectedPatches: []string{
+				`{"metadata":{"annotations":{"policy.karmada.io/applied-placement":"{\"clusterAffinities\":[{\"affinityName\":\"affinity1\",\"clusterNames\":[\"cluster1\"]},{\"affinityName\":\"affinity2\",\"clusterNames\":[\"cluster2\"]}]}"}},"spec":{"clusters":[{"name":"cluster1","replicas":1}]}}`,
+				`{"status":{"schedulerObservingAffinityName":"affinity1"}}`,
+			},
+			expectedEvent:         fmt.Sprintf("Normal ScheduleBindingSucceed %s Result: {cluster1:1}", successfulSchedulingMessage),
+			expectedAffinityCalls: []string{"affinity1"},
+		},
+		{
+			name: "without explicit rescheduling resumes from observed affinity",
+			binding: &workv1alpha2.ResourceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-binding-resume",
+					Namespace: "default",
+				},
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Placement: &policyv1alpha1.Placement{
+						ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{
+							{
+								AffinityName: "affinity1",
+								ClusterAffinity: policyv1alpha1.ClusterAffinity{
+									ClusterNames: []string{"cluster1"},
+								},
+							},
+							{
+								AffinityName: "affinity2",
+								ClusterAffinity: policyv1alpha1.ClusterAffinity{
+									ClusterNames: []string{"cluster2"},
+								},
+							},
+						},
+					},
+				},
+				Status: workv1alpha2.ResourceBindingStatus{
+					SchedulerObservedAffinityName: "affinity2",
+				},
+			},
+			scheduleResults: []core.ScheduleResult{
+				{},
+				{
+					SuggestedClusters: []workv1alpha2.TargetCluster{
+						{Name: "cluster2", Replicas: 1},
+					},
+				},
+			},
+			scheduleErrors: []error{nil, nil},
+			expectError:    false,
+			expectedPatches: []string{
+				`{"metadata":{"annotations":{"policy.karmada.io/applied-placement":"{\"clusterAffinities\":[{\"affinityName\":\"affinity1\",\"clusterNames\":[\"cluster1\"]},{\"affinityName\":\"affinity2\",\"clusterNames\":[\"cluster2\"]}]}"}},"spec":{"clusters":[{"name":"cluster2","replicas":1}]}}`,
+			},
+			expectedEvent:         fmt.Sprintf("Normal ScheduleBindingSucceed %s Result: {cluster2:1}", successfulSchedulingMessage),
+			expectedAffinityCalls: []string{"affinity2"},
 		},
 		{
 			name: "successful scheduling with second affinity",
@@ -665,8 +758,10 @@ func TestScheduleResourceBindingWithClusterAffinities(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := karmadafake.NewClientset(tt.binding)
 			fakeRecorder := record.NewFakeRecorder(10)
+			var affinityCalls []string
 			mockAlgorithm := &mockAlgorithm{
 				scheduleFunc: func(_ context.Context, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus, _ *core.ScheduleAlgorithmOption) (core.ScheduleResult, error) {
+					affinityCalls = append(affinityCalls, status.SchedulerObservedAffinityName)
 					index := getAffinityIndex(spec.Placement.ClusterAffinities, status.SchedulerObservedAffinityName)
 					if index < len(tt.scheduleResults) {
 						return tt.scheduleResults[index], tt.scheduleErrors[index]
@@ -684,6 +779,9 @@ func TestScheduleResourceBindingWithClusterAffinities(t *testing.T) {
 
 			if (err != nil) != tt.expectError {
 				t.Errorf("scheduleResourceBindingWithClusterAffinities() error = %v, expectError %v", err, tt.expectError)
+			}
+			if tt.expectedAffinityCalls != nil {
+				assert.Equal(t, tt.expectedAffinityCalls, affinityCalls, "Schedule affinity calls do not match expected")
 			}
 
 			actions := fakeClient.Actions()
@@ -1108,12 +1206,13 @@ func TestScheduleClusterResourceBindingWithClusterAffinity(t *testing.T) {
 
 func TestScheduleClusterResourceBindingWithClusterAffinities(t *testing.T) {
 	tests := []struct {
-		name            string
-		binding         *workv1alpha2.ClusterResourceBinding
-		scheduleResults []core.ScheduleResult
-		scheduleErrors  []error
-		expectError     bool
-		expectedEvent   string
+		name                  string
+		binding               *workv1alpha2.ClusterResourceBinding
+		scheduleResults       []core.ScheduleResult
+		scheduleErrors        []error
+		expectError           bool
+		expectedEvent         string
+		expectedAffinityCalls []string
 	}{
 		{
 			name: "successful scheduling with first affinity",
@@ -1150,6 +1249,89 @@ func TestScheduleClusterResourceBindingWithClusterAffinities(t *testing.T) {
 			scheduleErrors: []error{nil},
 			expectError:    false,
 			expectedEvent:  fmt.Sprintf("Normal ScheduleBindingSucceed %s Result {cluster1:1}", successfulSchedulingMessage),
+		},
+		{
+			name: "explicit rescheduling restarts from first affinity",
+			binding: &workv1alpha2.ClusterResourceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-binding-reschedule",
+				},
+				Spec: workv1alpha2.ResourceBindingSpec{
+					RescheduleTriggeredAt: &metav1.Time{Time: time.Unix(2, 0)},
+					Placement: &policyv1alpha1.Placement{
+						ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{
+							{
+								AffinityName: "affinity1",
+								ClusterAffinity: policyv1alpha1.ClusterAffinity{
+									ClusterNames: []string{"cluster1"},
+								},
+							},
+							{
+								AffinityName: "affinity2",
+								ClusterAffinity: policyv1alpha1.ClusterAffinity{
+									ClusterNames: []string{"cluster2"},
+								},
+							},
+						},
+					},
+				},
+				Status: workv1alpha2.ResourceBindingStatus{
+					LastScheduledTime:             &metav1.Time{Time: time.Unix(1, 0)},
+					SchedulerObservedAffinityName: "affinity2",
+				},
+			},
+			scheduleResults: []core.ScheduleResult{
+				{
+					SuggestedClusters: []workv1alpha2.TargetCluster{
+						{Name: "cluster1", Replicas: 1},
+					},
+				},
+			},
+			scheduleErrors:        []error{nil},
+			expectError:           false,
+			expectedEvent:         fmt.Sprintf("Normal ScheduleBindingSucceed %s Result {cluster1:1}", successfulSchedulingMessage),
+			expectedAffinityCalls: []string{"affinity1"},
+		},
+		{
+			name: "without explicit rescheduling resumes from observed affinity",
+			binding: &workv1alpha2.ClusterResourceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-binding-resume",
+				},
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Placement: &policyv1alpha1.Placement{
+						ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{
+							{
+								AffinityName: "affinity1",
+								ClusterAffinity: policyv1alpha1.ClusterAffinity{
+									ClusterNames: []string{"cluster1"},
+								},
+							},
+							{
+								AffinityName: "affinity2",
+								ClusterAffinity: policyv1alpha1.ClusterAffinity{
+									ClusterNames: []string{"cluster2"},
+								},
+							},
+						},
+					},
+				},
+				Status: workv1alpha2.ResourceBindingStatus{
+					SchedulerObservedAffinityName: "affinity2",
+				},
+			},
+			scheduleResults: []core.ScheduleResult{
+				{},
+				{
+					SuggestedClusters: []workv1alpha2.TargetCluster{
+						{Name: "cluster2", Replicas: 1},
+					},
+				},
+			},
+			scheduleErrors:        []error{nil, nil},
+			expectError:           false,
+			expectedEvent:         fmt.Sprintf("Normal ScheduleBindingSucceed %s Result {cluster2:1}", successfulSchedulingMessage),
+			expectedAffinityCalls: []string{"affinity2"},
 		},
 		{
 			name: "successful scheduling with second affinity",
@@ -1224,8 +1406,10 @@ func TestScheduleClusterResourceBindingWithClusterAffinities(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := karmadafake.NewClientset(tt.binding)
 			fakeRecorder := record.NewFakeRecorder(10)
+			var affinityCalls []string
 			mockAlgorithm := &mockAlgorithm{
 				scheduleFunc: func(_ context.Context, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus, _ *core.ScheduleAlgorithmOption) (core.ScheduleResult, error) {
+					affinityCalls = append(affinityCalls, status.SchedulerObservedAffinityName)
 					index := getAffinityIndex(spec.Placement.ClusterAffinities, status.SchedulerObservedAffinityName)
 					if index < len(tt.scheduleResults) {
 						return tt.scheduleResults[index], tt.scheduleErrors[index]
@@ -1243,6 +1427,9 @@ func TestScheduleClusterResourceBindingWithClusterAffinities(t *testing.T) {
 
 			if (err != nil) != tt.expectError {
 				t.Errorf("scheduleClusterResourceBindingWithClusterAffinities() error = %v, expectError %v", err, tt.expectError)
+			}
+			if tt.expectedAffinityCalls != nil {
+				assert.Equal(t, tt.expectedAffinityCalls, affinityCalls, "Schedule affinity calls do not match expected")
 			}
 
 			// Check if an event was recorded

--- a/test/e2e/suites/base/clusteraffinities_test.go
+++ b/test/e2e/suites/base/clusteraffinities_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/ptr"
 
+	appsv1alpha1 "github.com/karmada-io/karmada/pkg/apis/apps/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -99,6 +100,93 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 
 				// 3. wait for deployment present on member2 cluster
 				framework.WaitDeploymentPresentOnClusterFitWith(member2, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
+			})
+
+			ginkgo.It("reschedule from the first cluster affinity", func() {
+				bindingName := names.GenerateBindingName(util.DeploymentKind, deployment.Name)
+				bindingFits := func(cluster, affinityName string) func(*workv1alpha2.ResourceBinding) bool {
+					return func(binding *workv1alpha2.ResourceBinding) bool {
+						return len(binding.Spec.Clusters) == 1 &&
+							binding.Spec.Clusters[0].Name == cluster &&
+							binding.Status.SchedulerObservedAffinityName == affinityName &&
+							binding.Status.SchedulerObservedGeneration == binding.Generation
+					}
+				}
+				waitForClockAfter := func(timestamp metav1.Time) {
+					gomega.Eventually(func() bool {
+						return metav1.Now().Rfc3339Copy().Time.After(timestamp.Time)
+					}, pollTimeout, pollInterval).Should(gomega.BeTrue())
+				}
+
+				framework.WaitDeploymentPresentOnClusterFitWith(member1, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
+				var group1ScheduledAt metav1.Time
+				framework.WaitResourceBindingFitWith(karmadaClient, deployment.Namespace, bindingName, func(binding *workv1alpha2.ResourceBinding) bool {
+					if bindingFits(member1, "group1")(binding) && binding.Status.LastScheduledTime != nil {
+						group1ScheduledAt = *binding.Status.LastScheduledTime
+						return true
+					}
+					return false
+				})
+
+				waitForClockAfter(group1ScheduledAt)
+				framework.UpdateClusterLabels(karmadaClient, member1, map[string]string{member1LabelKey: "not-ok"})
+				framework.WaitDeploymentDisappearOnCluster(member1, deployment.Namespace, deployment.Name)
+				framework.WaitDeploymentPresentOnClusterFitWith(member2, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
+
+				var group2ScheduledAt metav1.Time
+				framework.WaitResourceBindingFitWith(karmadaClient, deployment.Namespace, bindingName, func(binding *workv1alpha2.ResourceBinding) bool {
+					if bindingFits(member2, "group2")(binding) &&
+						binding.Status.LastScheduledTime != nil &&
+						binding.Status.LastScheduledTime.After(group1ScheduledAt.Time) {
+						group2ScheduledAt = *binding.Status.LastScheduledTime
+						return true
+					}
+					return false
+				})
+
+				// metav1.Time is persisted at second precision, so cross a clock tick before each causal timestamp.
+				waitForClockAfter(group2ScheduledAt)
+				// Synchronize the scheduler's cluster cache after restoring group1 without relying on a fixed delay.
+				framework.UpdateClusterLabels(karmadaClient, member1, map[string]string{member1LabelKey: "ok"})
+				syncLabelKey := fmt.Sprintf("%s-sync-%s", member2, rand.String(RandomStrLength))
+				framework.UpdateClusterLabels(karmadaClient, member2, map[string]string{syncLabelKey: "ok"})
+				ginkgo.DeferCleanup(func() {
+					framework.DeleteClusterLabels(karmadaClient, member2, map[string]string{syncLabelKey: ""})
+				})
+				framework.WaitResourceBindingFitWith(karmadaClient, deployment.Namespace, bindingName, func(binding *workv1alpha2.ResourceBinding) bool {
+					if bindingFits(member2, "group2")(binding) &&
+						binding.Status.LastScheduledTime != nil &&
+						binding.Status.LastScheduledTime.After(group2ScheduledAt.Time) {
+						group2ScheduledAt = *binding.Status.LastScheduledTime
+						return true
+					}
+					return false
+				})
+				waitForClockAfter(group2ScheduledAt)
+
+				workload := appsv1alpha1.ObjectReference{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Namespace:  deployment.Namespace,
+					Name:       deployment.Name,
+				}
+				rebalancer := testhelper.NewWorkloadRebalancer(workloadRebalancerPrefix+rand.String(RandomStrLength), []appsv1alpha1.ObjectReference{workload})
+				framework.CreateWorkloadRebalancer(karmadaClient, rebalancer)
+				ginkgo.DeferCleanup(func() {
+					framework.RemoveWorkloadRebalancer(karmadaClient, rebalancer.Name)
+				})
+				framework.WaitRebalancerObservedWorkloads(karmadaClient, rebalancer.Name, []appsv1alpha1.ObservedWorkload{
+					{Workload: workload, Result: appsv1alpha1.RebalanceSuccessful},
+				})
+
+				framework.WaitResourceBindingFitWith(karmadaClient, deployment.Namespace, bindingName, func(binding *workv1alpha2.ResourceBinding) bool {
+					return bindingFits(member1, "group1")(binding) &&
+						binding.Spec.RescheduleTriggeredAt != nil &&
+						binding.Status.LastScheduledTime != nil &&
+						bindingHasRescheduled(binding.Spec, binding.Status, rebalancer.CreationTimestamp)
+				})
+				framework.WaitDeploymentPresentOnClusterFitWith(member1, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
+				framework.WaitDeploymentDisappearOnCluster(member2, deployment.Namespace, deployment.Name)
 			})
 		})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

#5425 implemented restarting top-level `clusterAffinities` evaluation from the first term when a WorkloadRebalancer-triggered reschedule is pending. This follow-up adds the missing regression coverage: symmetric unit tests for ResourceBinding and ClusterResourceBinding, plus an A-to-B-to-A E2E scenario after bounded scheduler-cache convergence.

Scheduling without a pending reschedule trigger is also covered and continues from the observed affinity term. This PR now contains test changes only.

**Which issue(s) this PR fixes**:

Follow-up to #5425.

Refs #5070

**Special notes for your reviewer**:

- Scope: test-only; the six-line implementation commit was dropped during rebase because #5425 is now in `master`.
- Tests: no post-rebase rerun; `git range-diff` confirms the test patch is unchanged. The pre-rebase targeted race test, scheduler package tests, and E2E compile check passed.
- AI assistance: Codex helped inspect the rebase and draft tests/text; I reviewed the diff and validation evidence.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
