### PR TITLE
Remove deprecated PurgeMode values

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19441,12 +19441,12 @@
           "$ref": "#/definitions/com.github.karmada-io.karmada.pkg.apis.policy.v1alpha1.DecisionConditions"
         },
         "gracePeriodSeconds": {
-          "description": "GracePeriodSeconds is the maximum waiting duration in seconds before application on the migrated cluster should be deleted. Required only when PurgeMode is \"Graciously\" and defaults to 600s. If the application on the new cluster cannot reach a Healthy state, Karmada will delete the application after GracePeriodSeconds is reached. Value must be positive integer.",
+          "description": "GracePeriodSeconds is the maximum waiting duration in seconds before application on the migrated cluster should be deleted. Required only when PurgeMode is \"Gracefully\" and defaults to 600s. If the application on the new cluster cannot reach a Healthy state, Karmada will delete the application after GracePeriodSeconds is reached. Value must be positive integer.",
           "type": "integer",
           "format": "int32"
         },
         "purgeMode": {
-          "description": "PurgeMode represents how to deal with the legacy applications on the cluster from which the application is migrated. Valid options are \"Directly\", \"Gracefully\", \"Never\", \"Immediately\"(deprecated), and \"Graciously\"(deprecated). Defaults to \"Gracefully\".",
+          "description": "PurgeMode represents how to deal with the legacy applications on the cluster from which the application is migrated. Valid options are \"Directly\", \"Gracefully\", \"Never\". Defaults to \"Gracefully\".",
           "type": "string"
         },
         "statePreservation": {
@@ -21584,7 +21584,7 @@
           "default": ""
         },
         "purgeMode": {
-          "description": "PurgeMode represents how to deal with the legacy applications on the cluster from which the application is migrated. Valid options are \"Immediately\", \"Directly\", \"Graciously\", \"Gracefully\" and \"Never\".",
+          "description": "PurgeMode represents how to deal with the legacy applications on the cluster from which the application is migrated. Valid options are \"Directly\", \"Gracefully\" and \"Never\".",
           "type": "string"
         },
         "reason": {

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -147,7 +147,7 @@ spec:
                         description: |-
                           GracePeriodSeconds is the maximum waiting duration in seconds before
                           application on the migrated cluster should be deleted.
-                          Required only when PurgeMode is "Graciously" and defaults to 600s.
+                          Required only when PurgeMode is "Gracefully" and defaults to 600s.
                           If the application on the new cluster cannot reach a Healthy state,
                           Karmada will delete the application after GracePeriodSeconds is reached.
                           Value must be positive integer.
@@ -158,15 +158,12 @@ spec:
                         description: |-
                           PurgeMode represents how to deal with the legacy applications on the
                           cluster from which the application is migrated.
-                          Valid options are "Directly", "Gracefully", "Never", "Immediately"(deprecated),
-                          and "Graciously"(deprecated).
+                          Valid options are "Directly", "Gracefully", "Never".
                           Defaults to "Gracefully".
                         enum:
                         - Directly
                         - Gracefully
                         - Never
-                        - Immediately
-                        - Graciously
                         type: string
                       statePreservation:
                         description: |-

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
@@ -144,7 +144,7 @@ spec:
                         description: |-
                           GracePeriodSeconds is the maximum waiting duration in seconds before
                           application on the migrated cluster should be deleted.
-                          Required only when PurgeMode is "Graciously" and defaults to 600s.
+                          Required only when PurgeMode is "Gracefully" and defaults to 600s.
                           If the application on the new cluster cannot reach a Healthy state,
                           Karmada will delete the application after GracePeriodSeconds is reached.
                           Value must be positive integer.
@@ -155,15 +155,12 @@ spec:
                         description: |-
                           PurgeMode represents how to deal with the legacy applications on the
                           cluster from which the application is migrated.
-                          Valid options are "Directly", "Gracefully", "Never", "Immediately"(deprecated),
-                          and "Graciously"(deprecated).
+                          Valid options are "Directly", "Gracefully", "Never".
                           Defaults to "Gracefully".
                         enum:
                         - Directly
                         - Gracefully
                         - Never
-                        - Immediately
-                        - Graciously
                         type: string
                       statePreservation:
                         description: |-

--- a/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
@@ -503,7 +503,7 @@ spec:
                         description: |-
                           GracePeriodSeconds is the maximum waiting duration in seconds before
                           application on the migrated cluster should be deleted.
-                          Required only when PurgeMode is "Graciously" and defaults to 600s.
+                          Required only when PurgeMode is "Gracefully" and defaults to 600s.
                           If the application on the new cluster cannot reach a Healthy state,
                           Karmada will delete the application after GracePeriodSeconds is reached.
                           Value must be positive integer.
@@ -514,15 +514,12 @@ spec:
                         description: |-
                           PurgeMode represents how to deal with the legacy applications on the
                           cluster from which the application is migrated.
-                          Valid options are "Directly", "Gracefully", "Never", "Immediately"(deprecated),
-                          and "Graciously"(deprecated).
+                          Valid options are "Directly", "Gracefully", "Never".
                           Defaults to "Gracefully".
                         enum:
                         - Directly
                         - Gracefully
                         - Never
-                        - Immediately
-                        - Graciously
                         type: string
                       statePreservation:
                         description: |-
@@ -729,11 +726,9 @@ spec:
                       description: |-
                         PurgeMode represents how to deal with the legacy applications on the
                         cluster from which the application is migrated.
-                        Valid options are "Immediately", "Directly", "Graciously", "Gracefully" and "Never".
+                        Valid options are "Directly", "Gracefully" and "Never".
                       enum:
-                      - Immediately
                       - Directly
-                      - Graciously
                       - Gracefully
                       - Never
                       type: string

--- a/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
@@ -503,7 +503,7 @@ spec:
                         description: |-
                           GracePeriodSeconds is the maximum waiting duration in seconds before
                           application on the migrated cluster should be deleted.
-                          Required only when PurgeMode is "Graciously" and defaults to 600s.
+                          Required only when PurgeMode is "Gracefully" and defaults to 600s.
                           If the application on the new cluster cannot reach a Healthy state,
                           Karmada will delete the application after GracePeriodSeconds is reached.
                           Value must be positive integer.
@@ -514,15 +514,12 @@ spec:
                         description: |-
                           PurgeMode represents how to deal with the legacy applications on the
                           cluster from which the application is migrated.
-                          Valid options are "Directly", "Gracefully", "Never", "Immediately"(deprecated),
-                          and "Graciously"(deprecated).
+                          Valid options are "Directly", "Gracefully", "Never".
                           Defaults to "Gracefully".
                         enum:
                         - Directly
                         - Gracefully
                         - Never
-                        - Immediately
-                        - Graciously
                         type: string
                       statePreservation:
                         description: |-
@@ -729,11 +726,9 @@ spec:
                       description: |-
                         PurgeMode represents how to deal with the legacy applications on the
                         cluster from which the application is migrated.
-                        Valid options are "Immediately", "Directly", "Graciously", "Gracefully" and "Never".
+                        Valid options are "Directly", "Gracefully" and "Never".
                       enum:
-                      - Immediately
                       - Directly
-                      - Graciously
                       - Gracefully
                       - Never
                       type: string

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -281,31 +281,6 @@ type SuspendClusters struct {
 type PurgeMode string
 
 const (
-	// Immediately represents that Karmada will immediately evict the legacy
-	// application. This is useful in scenarios where an application can not
-	// tolerate two instances running simultaneously.
-	// For example, the Flink application supports exactly-once state consistency,
-	// which means it requires that no two instances of the application are running
-	// at the same time. During a failover, it is crucial to ensure that the old
-	// application is removed before creating a new one to avoid duplicate
-	// processing and maintaining state consistency.
-	//
-	// Deprecated: The term `Immediately` may be confusing when used alongside
-	// `GracePeriodSeconds`, which specifies that resources are removed after
-	// a grace period rather than at once.
-	// `Immediately` is replaced by `Directly` for clarity. This term remains
-	// functional in the current API version for backward compatibility and will
-	// be removed when PropagationPolicy advances to alpha2 or beta.
-	Immediately PurgeMode = "Immediately"
-	// Graciously represents that Karmada will wait for the application to
-	// come back to healthy on the new cluster or after a timeout is reached
-	// before evicting the application.
-	//
-	// Deprecated: The term `Graciously` is replaced by `Gracefully` for correct
-	// English usage. This term remains functional in the current API version for
-	// backward compatibility and will be removed when PropagationPolicy advances
-	// to alpha2 or beta.
-	Graciously PurgeMode = "Graciously"
 	// Never represents that Karmada will not evict the application and
 	// users manually confirms how to clean up redundant copies.
 	Never PurgeMode = "Never"
@@ -356,17 +331,16 @@ type ApplicationFailoverBehavior struct {
 
 	// PurgeMode represents how to deal with the legacy applications on the
 	// cluster from which the application is migrated.
-	// Valid options are "Directly", "Gracefully", "Never", "Immediately"(deprecated),
-	// and "Graciously"(deprecated).
+	// Valid options are "Directly", "Gracefully", "Never".
 	// Defaults to "Gracefully".
-	// +kubebuilder:validation:Enum=Directly;Gracefully;Never;Immediately;Graciously
+	// +kubebuilder:validation:Enum=Directly;Gracefully;Never
 	// +kubebuilder:default=Gracefully
 	// +optional
 	PurgeMode PurgeMode `json:"purgeMode,omitempty"`
 
 	// GracePeriodSeconds is the maximum waiting duration in seconds before
 	// application on the migrated cluster should be deleted.
-	// Required only when PurgeMode is "Graciously" and defaults to 600s.
+	// Required only when PurgeMode is "Gracefully" and defaults to 600s.
 	// If the application on the new cluster cannot reach a Healthy state,
 	// Karmada will delete the application after GracePeriodSeconds is reached.
 	// Value must be positive integer.

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -300,8 +300,8 @@ type GracefulEvictionTask struct {
 
 	// PurgeMode represents how to deal with the legacy applications on the
 	// cluster from which the application is migrated.
-	// Valid options are "Immediately", "Directly", "Graciously", "Gracefully" and "Never".
-	// +kubebuilder:validation:Enum=Immediately;Directly;Graciously;Gracefully;Never
+	// Valid options are "Directly", "Gracefully" and "Never".
+	// +kubebuilder:validation:Enum=Directly;Gracefully;Never
 	// +optional
 	PurgeMode policyv1alpha1.PurgeMode `json:"purgeMode,omitempty"`
 

--- a/pkg/controllers/applicationfailover/common.go
+++ b/pkg/controllers/applicationfailover/common.go
@@ -159,9 +159,7 @@ func buildTaskOptions(failoverBehavior *policyv1alpha1.ApplicationFailoverBehavi
 	}
 
 	switch failoverBehavior.PurgeMode {
-	//nolint:staticcheck
-	// disable `deprecation` check for backward compatibility.
-	case policyv1alpha1.Graciously, policyv1alpha1.PurgeModeGracefully:
+	case policyv1alpha1.PurgeModeGracefully:
 		if features.FeatureGate.Enabled(features.GracefulEviction) {
 			taskOpts = append(taskOpts, workv1alpha2.WithGracePeriodSeconds(failoverBehavior.GracePeriodSeconds))
 		} else {

--- a/pkg/controllers/applicationfailover/common_test.go
+++ b/pkg/controllers/applicationfailover/common_test.go
@@ -300,7 +300,7 @@ func Test_buildTaskOptions(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "Immediately purgeMode with ClusterResourceBinding",
+			name: "Directly purgeMode with ClusterResourceBinding",
 			args: args{
 				failoverBehavior: &policyv1alpha1.ApplicationFailoverBehavior{
 					DecisionConditions: policyv1alpha1.DecisionConditions{

--- a/pkg/controllers/applicationfailover/crb_application_failover_controller_test.go
+++ b/pkg/controllers/applicationfailover/crb_application_failover_controller_test.go
@@ -221,7 +221,7 @@ func TestCRBApplicationFailoverController_evictBinding(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "PurgeMode is Immediately",
+			name:        "PurgeMode is Directly",
 			purgeMode:   policyv1alpha1.PurgeModeDirectly,
 			expectError: false,
 		},

--- a/pkg/controllers/applicationfailover/rb_application_failover_controller_test.go
+++ b/pkg/controllers/applicationfailover/rb_application_failover_controller_test.go
@@ -217,7 +217,7 @@ func TestRBApplicationFailoverController_evictBinding(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "PurgeMode is Immediately",
+			name:        "PurgeMode is Directly",
 			purgeMode:   policyv1alpha1.PurgeModeDirectly,
 			expectError: false,
 		},

--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -207,7 +207,7 @@ func getBindingSpec(binding metav1.Object, scope apiextensionsv1.ResourceScope) 
 //  2. If consecutive failovers occur, for example, an application is migrated form clusterA
 //     to clusterB and then to clusterC, the PreservedLabelState before the last failover is
 //     used for injection. If the PreservedLabelState is empty, the injection is skipped.
-//  3. The injection operation is performed only when PurgeMode is set to Immediately or Directly.
+//  3. The injection operation is performed only when PurgeMode is set to Directly.
 func injectReservedLabelState(bindingSpec workv1alpha2.ResourceBindingSpec, moveToCluster workv1alpha2.TargetCluster, workload *unstructured.Unstructured, clustersLen int) *unstructured.Unstructured {
 	if clustersLen > 1 {
 		return workload
@@ -218,10 +218,7 @@ func injectReservedLabelState(bindingSpec workv1alpha2.ResourceBindingSpec, move
 	}
 	targetEvictionTask := bindingSpec.GracefulEvictionTasks[len(bindingSpec.GracefulEvictionTasks)-1]
 
-	//nolint:staticcheck
-	// disable `deprecation` check for backward compatibility.
-	if targetEvictionTask.PurgeMode != policyv1alpha1.Immediately &&
-		targetEvictionTask.PurgeMode != policyv1alpha1.PurgeModeDirectly {
+	if targetEvictionTask.PurgeMode != policyv1alpha1.PurgeModeDirectly {
 		return workload
 	}
 

--- a/pkg/generated/applyconfigurations/policy/v1alpha1/applicationfailoverbehavior.go
+++ b/pkg/generated/applyconfigurations/policy/v1alpha1/applicationfailoverbehavior.go
@@ -34,13 +34,12 @@ type ApplicationFailoverBehaviorApplyConfiguration struct {
 	DecisionConditions *DecisionConditionsApplyConfiguration `json:"decisionConditions,omitempty"`
 	// PurgeMode represents how to deal with the legacy applications on the
 	// cluster from which the application is migrated.
-	// Valid options are "Directly", "Gracefully", "Never", "Immediately"(deprecated),
-	// and "Graciously"(deprecated).
+	// Valid options are "Directly", "Gracefully", "Never".
 	// Defaults to "Gracefully".
 	PurgeMode *policyv1alpha1.PurgeMode `json:"purgeMode,omitempty"`
 	// GracePeriodSeconds is the maximum waiting duration in seconds before
 	// application on the migrated cluster should be deleted.
-	// Required only when PurgeMode is "Graciously" and defaults to 600s.
+	// Required only when PurgeMode is "Gracefully" and defaults to 600s.
 	// If the application on the new cluster cannot reach a Healthy state,
 	// Karmada will delete the application after GracePeriodSeconds is reached.
 	// Value must be positive integer.

--- a/pkg/generated/applyconfigurations/work/v1alpha2/gracefulevictiontask.go
+++ b/pkg/generated/applyconfigurations/work/v1alpha2/gracefulevictiontask.go
@@ -32,7 +32,7 @@ type GracefulEvictionTaskApplyConfiguration struct {
 	FromCluster *string `json:"fromCluster,omitempty"`
 	// PurgeMode represents how to deal with the legacy applications on the
 	// cluster from which the application is migrated.
-	// Valid options are "Immediately", "Directly", "Graciously", "Gracefully" and "Never".
+	// Valid options are "Directly", "Gracefully" and "Never".
 	PurgeMode *v1alpha1.PurgeMode `json:"purgeMode,omitempty"`
 	// Replicas indicates the number of replicas should be evicted.
 	// Should be ignored for resource type that doesn't have replica.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3560,14 +3560,14 @@ func schema_pkg_apis_policy_v1alpha1_ApplicationFailoverBehavior(ref common.Refe
 					},
 					"purgeMode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PurgeMode represents how to deal with the legacy applications on the cluster from which the application is migrated. Valid options are \"Directly\", \"Gracefully\", \"Never\", \"Immediately\"(deprecated), and \"Graciously\"(deprecated). Defaults to \"Gracefully\".",
+							Description: "PurgeMode represents how to deal with the legacy applications on the cluster from which the application is migrated. Valid options are \"Directly\", \"Gracefully\", \"Never\". Defaults to \"Gracefully\".",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"gracePeriodSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "GracePeriodSeconds is the maximum waiting duration in seconds before application on the migrated cluster should be deleted. Required only when PurgeMode is \"Graciously\" and defaults to 600s. If the application on the new cluster cannot reach a Healthy state, Karmada will delete the application after GracePeriodSeconds is reached. Value must be positive integer.",
+							Description: "GracePeriodSeconds is the maximum waiting duration in seconds before application on the migrated cluster should be deleted. Required only when PurgeMode is \"Gracefully\" and defaults to 600s. If the application on the new cluster cannot reach a Healthy state, Karmada will delete the application after GracePeriodSeconds is reached. Value must be positive integer.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -7455,7 +7455,7 @@ func schema_pkg_apis_work_v1alpha2_GracefulEvictionTask(ref common.ReferenceCall
 					},
 					"purgeMode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PurgeMode represents how to deal with the legacy applications on the cluster from which the application is migrated. Valid options are \"Immediately\", \"Directly\", \"Graciously\", \"Gracefully\" and \"Never\".",
+							Description: "PurgeMode represents how to deal with the legacy applications on the cluster from which the application is migrated. Valid options are \"Directly\", \"Gracefully\" and \"Never\".",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -200,10 +200,7 @@ func ObtainBindingSpecExistingClusters(bindingSpec workv1alpha2.ResourceBindingS
 		// EvictionTasks with Directly PurgeMode should not be treated as existing clusters
 		// Work on those clusters should be removed directly and treated as orphans.
 		//
-		//nolint:staticcheck
-		// disable `deprecation` check for backward compatibility.
-		if task.PurgeMode != policyv1alpha1.Immediately &&
-			task.PurgeMode != policyv1alpha1.PurgeModeDirectly {
+		if task.PurgeMode != policyv1alpha1.PurgeModeDirectly {
 			clusterNames.Insert(task.FromCluster)
 		}
 	}
@@ -215,10 +212,7 @@ func ObtainBindingSpecExistingClusters(bindingSpec workv1alpha2.ResourceBindingS
 func ObtainClustersWithPurgeModeDirectly(bindingSpec workv1alpha2.ResourceBindingSpec) sets.Set[string] {
 	clusterNames := sets.New[string]()
 	for _, task := range bindingSpec.GracefulEvictionTasks {
-		//nolint:staticcheck
-		// disable `deprecation` check for backward compatibility.
-		if task.PurgeMode == policyv1alpha1.PurgeModeDirectly ||
-			task.PurgeMode == policyv1alpha1.Immediately {
+		if task.PurgeMode == policyv1alpha1.PurgeModeDirectly {
 			clusterNames.Insert(task.FromCluster)
 		}
 	}

--- a/pkg/util/helper/binding_test.go
+++ b/pkg/util/helper/binding_test.go
@@ -529,7 +529,7 @@ func TestObtainBindingSpecExistingClusters(t *testing.T) {
 			want: sets.New("member1", "member2", "member3"),
 		},
 		{
-			name: "unique cluster names with GracefulEvictionTasks with PurgeMode Immediately",
+			name: "unique cluster names with GracefulEvictionTasks with PurgeMode Directly",
 			bindingSpec: workv1alpha2.ResourceBindingSpec{
 				Clusters: []workv1alpha2.TargetCluster{
 					{

--- a/pkg/util/helper/policy.go
+++ b/pkg/util/helper/policy.go
@@ -128,9 +128,7 @@ func SetReplicaDivisionPreferenceWeighted(placement *policyv1alpha1.Placement) {
 
 // SetDefaultGracePeriodSeconds sets the default value of GracePeriodSeconds in ApplicationFailoverBehavior
 func SetDefaultGracePeriodSeconds(behavior *policyv1alpha1.ApplicationFailoverBehavior) {
-	//nolint:staticcheck
-	// disable `deprecation` check for backward compatibility.
-	if (behavior.PurgeMode == policyv1alpha1.Graciously || behavior.PurgeMode == policyv1alpha1.PurgeModeGracefully) &&
+	if behavior.PurgeMode == policyv1alpha1.PurgeModeGracefully &&
 		behavior.GracePeriodSeconds == nil {
 		behavior.GracePeriodSeconds = ptr.To[int32](600)
 	}

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -337,18 +337,12 @@ func ValidateApplicationFailover(applicationFailoverBehavior *policyv1alpha1.App
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("decisionConditions").Child("tolerationSeconds"), *applicationFailoverBehavior.DecisionConditions.TolerationSeconds, "must be greater than or equal to 0"))
 	}
 
-	//nolint:staticcheck
-	// disable `deprecation` check for backward compatibility.
-	if applicationFailoverBehavior.PurgeMode != policyv1alpha1.Graciously &&
-		applicationFailoverBehavior.PurgeMode != policyv1alpha1.PurgeModeGracefully &&
+	if applicationFailoverBehavior.PurgeMode != policyv1alpha1.PurgeModeGracefully &&
 		applicationFailoverBehavior.GracePeriodSeconds != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("gracePeriodSeconds"), *applicationFailoverBehavior.GracePeriodSeconds, "only takes effect when purgeMode is gracefully"))
 	}
 
-	//nolint:staticcheck
-	// disable `deprecation` check for backward compatibility.
-	if (applicationFailoverBehavior.PurgeMode == policyv1alpha1.Graciously ||
-		applicationFailoverBehavior.PurgeMode == policyv1alpha1.PurgeModeGracefully) &&
+	if applicationFailoverBehavior.PurgeMode == policyv1alpha1.PurgeModeGracefully &&
 		applicationFailoverBehavior.GracePeriodSeconds == nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("gracePeriodSeconds"), applicationFailoverBehavior.GracePeriodSeconds, "should not be empty when purgeMode is gracefully"))
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind api-change
/kind deprecation

**What this PR does / why we need it**:

Removes the deprecated `PurgeMode` values `Immediately` and `Graciously`, along with their backward-compatibility handling.

The corresponding CRDs, generated OpenAPI definitions, apply configurations, validation logic, controller logic, helper functions, and tests are updated to support only `Directly`, `Gracefully`, and `Never`.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Users still using `Immediately` should migrate to `Directly`, and users still using `Graciously` should migrate to `Gracefully`.

**Does this PR introduce a user-facing change?**:

```
API Change: Removed the deprecated `PurgeMode` values `Immediately` and `Graciously`. Use `Directly` and `Gracefully` instead.
```