### PR TITLE
test(e2e): stabilize karmadactl top pod fixture

### DIFF
--- a/test/e2e/suites/base/karmadactl_test.go
+++ b/test/e2e/suites/base/karmadactl_test.go
@@ -579,13 +579,51 @@ var _ = ginkgo.Describe("Karmadactl top testing", func() {
 	})
 
 	ginkgo.Context("Karmadactl top pod", func() {
+		type podRuntimeState struct {
+			uid          string
+			containerIDs map[string]string
+		}
+
 		var policyName string
 		var pod *corev1.Pod
 		var policy *policyv1alpha1.PropagationPolicy
+		var initialPodStates map[string]podRuntimeState
+
+		getPodRuntimeStates := func() map[string]podRuntimeState {
+			states := make(map[string]podRuntimeState, len(framework.ClusterNames()))
+			for _, clusterName := range framework.ClusterNames() {
+				clusterClient := framework.GetClusterClient(clusterName)
+				gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+				memberPod, err := clusterClient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				gomega.Expect(khelper.IsPodReady(memberPod)).Should(gomega.BeTrue())
+				gomega.Expect(memberPod.Status.ContainerStatuses).Should(gomega.HaveLen(len(memberPod.Spec.Containers)))
+
+				containerIDs := make(map[string]string, len(memberPod.Status.ContainerStatuses))
+				for _, status := range memberPod.Status.ContainerStatuses {
+					gomega.Expect(status.Ready).Should(gomega.BeTrue())
+					gomega.Expect(status.State.Running).ShouldNot(gomega.BeNil())
+					gomega.Expect(status.ContainerID).ShouldNot(gomega.BeEmpty())
+					gomega.Expect(status.RestartCount).Should(gomega.BeZero())
+					containerIDs[status.Name] = status.ContainerID
+				}
+				states[clusterName] = podRuntimeState{uid: string(memberPod.UID), containerIDs: containerIDs}
+			}
+			return states
+		}
+
 		ginkgo.BeforeEach(func() {
 			// create a pod and a propagationPolicy
 			policyName = podNamePrefix + rand.String(RandomStrLength)
 			pod = helper.NewPod(testNamespace, podNamePrefix+rand.String(RandomStrLength))
+			busyboxFound := false
+			for index := range pod.Spec.Containers {
+				if pod.Spec.Containers[index].Name == "busybox" {
+					pod.Spec.Containers[index].Command = []string{"sleep", "3600"}
+					busyboxFound = true
+				}
+			}
+			gomega.Expect(busyboxFound).Should(gomega.BeTrue())
 			policy = helper.NewPropagationPolicy(testNamespace, policyName, []policyv1alpha1.ResourceSelector{
 				{
 					APIVersion: pod.APIVersion,
@@ -608,11 +646,12 @@ var _ = ginkgo.Describe("Karmadactl top testing", func() {
 			// wait for pod and metrics ready
 			framework.WaitPodPresentOnClustersFitWith(framework.ClusterNames(), pod.Namespace, pod.Name,
 				func(pod *corev1.Pod) bool {
-					return pod.Status.Phase == corev1.PodRunning
+					return khelper.IsPodReady(pod)
 				})
 			for _, cluster := range framework.ClusterNames() {
 				framework.WaitPodMetricsReady(kubeClient, karmadaClient, cluster, pod.Namespace, pod.Name)
 			}
+			initialPodStates = getPodRuntimeStates()
 		})
 
 		ginkgo.It("Karmadactl top existing pod", func() {
@@ -639,6 +678,10 @@ var _ = ginkgo.Describe("Karmadactl top testing", func() {
 					_, err := cmd.ExecOrDie()
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				}
+			})
+
+			ginkgo.By("Verify pod containers remained stable during metrics queries", func() {
+				gomega.Expect(getPodRuntimeStates()).Should(gomega.Equal(initialPodStates))
 			})
 		})
 	})

--- a/test/e2e/suites/base/karmadactl_test.go
+++ b/test/e2e/suites/base/karmadactl_test.go
@@ -608,7 +608,7 @@ var _ = ginkgo.Describe("Karmadactl top testing", func() {
 			// wait for pod and metrics ready
 			framework.WaitPodPresentOnClustersFitWith(framework.ClusterNames(), pod.Namespace, pod.Name,
 				func(pod *corev1.Pod) bool {
-					return pod.Status.Phase == corev1.PodRunning
+					return khelper.IsPodReady(pod)
 				})
 			for _, cluster := range framework.ClusterNames() {
 				framework.WaitPodMetricsReady(kubeClient, karmadaClient, cluster, pod.Namespace, pod.Name)

--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -350,7 +350,7 @@ func NewService(namespace string, name string, svcType corev1.ServiceType) *core
 	}
 }
 
-// NewPod will build a service object.
+// NewPod will build a Pod object with long-running containers.
 func NewPod(namespace string, name string) *corev1.Pod {
 	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -376,8 +376,9 @@ func NewPod(namespace string, name string) *corev1.Pod {
 					},
 				},
 				{
-					Name:  "busybox",
-					Image: "busybox:1.36.0",
+					Name:    "busybox",
+					Image:   "busybox:1.36.0",
+					Command: []string{"sleep", "3600"},
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "web",


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`helper.NewPod` builds an nginx and BusyBox Pod reused across E2E tests. BusyBox has no long-running command, so it exits and restarts, while `PodRunning` does not guarantee that every container is ready.

This change makes the BusyBox container sleep for 3600 seconds by default, giving every E2E caller a stable fixture for the expected test duration; existing Pod or namespace cleanup still removes it afterward. The top test also waits for `PodReady=True` before querying metrics.

This does not claim that the BusyBox restart was the complete cause of the observed `PodMetrics NotFound`; subsequent runs still need to be monitored.

**Which issue(s) this PR fixes**:

Refs #6841

**Special notes for your reviewer**:

- Scope: shared test fixture default and top readiness condition; existing two-argument API retained; no production or CLI retry behavior.
- Tests: `go test ./test/helper ./pkg/controllers/execution ./pkg/util/helper -count=1`; `go test ./test/e2e/suites/base -run '^$' -count=1`.
- AI assistance: Codex helped inspect the review feedback, audit the shared helper contract, and run validation; I reviewed the code and results.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```