### PR TITLE
Optimize GetMatching for waiting objects in ResourceDetector

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -92,10 +92,12 @@ type ResourceDetector struct {
 
 	RESTMapper meta.RESTMapper
 
-	// waitingObjects tracks of objects which haven't been propagated yet as lack of appropriate policies.
-	waitingObjects map[keys.ClusterWideKey]struct{}
-	// waitingLock is the lock for waitingObjects operation.
-	waitingLock sync.RWMutex
+	// waitingStore tracks objects that have not been propagated because no policy currently matches them.
+	// It keeps lightweight identity and label snapshots so policy reconciliation does not need to fetch and
+	// deep-copy every waiting object while looking for matches.
+	waitingStore *waitingObjectStore
+	// waitingStoreOnce allows detector helpers to initialize the store safely even before Start is called in tests.
+	waitingStoreOnce sync.Once
 	// ConcurrentPropagationPolicySyncs is the number of PropagationPolicy that are allowed to sync concurrently.
 	ConcurrentPropagationPolicySyncs int
 	// ConcurrentClusterPropagationPolicySyncs is the number of ClusterPropagationPolicy that are allowed to sync concurrently.
@@ -112,7 +114,7 @@ type ResourceDetector struct {
 // Start runs the detector, never stop until context canceled.
 func (d *ResourceDetector) Start(ctx context.Context) error {
 	klog.Infof("Starting resource detector.")
-	d.waitingObjects = make(map[keys.ClusterWideKey]struct{})
+	d.getWaitingStore()
 
 	// setup policy reconcile worker
 	policyWorkerOptions := util.Options{
@@ -934,53 +936,37 @@ func (d *ResourceDetector) BuildClusterResourceBinding(object *unstructured.Unst
 
 // isWaiting indicates if the object is in waiting list.
 func (d *ResourceDetector) isWaiting(objectKey keys.ClusterWideKey) bool {
-	d.waitingLock.RLock()
-	_, ok := d.waitingObjects[objectKey]
-	d.waitingLock.RUnlock()
-	return ok
+	return d.getWaitingStore().Contains(objectKey)
 }
 
-// AddWaiting adds object's key to waiting list.
-func (d *ResourceDetector) AddWaiting(objectKey keys.ClusterWideKey) {
-	d.waitingLock.Lock()
-	defer d.waitingLock.Unlock()
-
-	d.waitingObjects[objectKey] = struct{}{}
-	klog.V(1).Infof("Add object(%s) to waiting list, length of list is: %d", objectKey.String(), len(d.waitingObjects))
+// AddWaiting adds an object's key to the waiting store or refreshes its labels.
+// It returns whether the object should be retried after the store changed.
+func (d *ResourceDetector) AddWaiting(objectKey keys.ClusterWideKey, objectLabels map[string]string) bool {
+	store := d.getWaitingStore()
+	inserted, labelsChanged := store.Upsert(objectKey, objectLabels)
+	if inserted {
+		klog.V(1).Infof("Add object(%s) to waiting list, length of list is: %d", objectKey.String(), store.Len())
+	}
+	return inserted || labelsChanged
 }
 
 // RemoveWaiting removes object's key from waiting list.
 func (d *ResourceDetector) RemoveWaiting(objectKey keys.ClusterWideKey) {
-	d.waitingLock.Lock()
-	defer d.waitingLock.Unlock()
-
-	delete(d.waitingObjects, objectKey)
+	d.getWaitingStore().Delete(objectKey)
 }
 
-// GetMatching gets objects keys in waiting list that matches one of resource selectors.
+// GetMatching returns the keys of waiting objects matched by at least one resource selector.
+// Matching is performed against the waiting store's indexes and label snapshots, avoiding informer object fetches.
 func (d *ResourceDetector) GetMatching(resourceSelectors []policyv1alpha1.ResourceSelector) []keys.ClusterWideKey {
-	d.waitingLock.RLock()
-	defer d.waitingLock.RUnlock()
+	return d.getWaitingStore().Match(resourceSelectors)
+}
 
-	var matchedResult []keys.ClusterWideKey
-
-	for waitKey := range d.waitingObjects {
-		waitObj, err := d.GetUnstructuredObject(waitKey)
-		if err != nil {
-			// all object in waiting list should exist. Just print a log to trace.
-			klog.Errorf("Failed to get object(%s), error: %v", waitKey.String(), err)
-			continue
-		}
-
-		for _, rs := range resourceSelectors {
-			if util.ResourceMatches(waitObj, rs) {
-				matchedResult = append(matchedResult, waitKey)
-				break
-			}
-		}
-	}
-
-	return matchedResult
+// getWaitingStore lazily initializes the store because some detector code paths and unit tests can use it before Start.
+func (d *ResourceDetector) getWaitingStore() *waitingObjectStore {
+	d.waitingStoreOnce.Do(func() {
+		d.waitingStore = newWaitingObjectStore()
+	})
+	return d.waitingStore
 }
 
 // OnPropagationPolicyAdd handles object add event and push the object to queue.
@@ -1029,7 +1015,7 @@ func (d *ResourceDetector) OnPropagationPolicyUpdate(oldObj, newObj any) {
 }
 
 // ReconcilePropagationPolicy handles PropagationPolicy resource changes.
-// When adding a PropagationPolicy, the detector will pick the objects in waitingObjects list that matches the policy and
+// When adding a PropagationPolicy, the detector will pick the objects in the waiting store that match the policy and
 // put the object to queue.
 // When removing a PropagationPolicy, the relevant ResourceBinding will be removed and
 // the relevant objects will be put into queue again to try another policy.
@@ -1117,7 +1103,7 @@ func (d *ResourceDetector) OnClusterPropagationPolicyUpdate(oldObj, newObj any) 
 }
 
 // ReconcileClusterPropagationPolicy handles ClusterPropagationPolicy resource changes.
-// When adding a ClusterPropagationPolicy, the detector will pick the objects in waitingObjects list that matches the policy and
+// When adding a ClusterPropagationPolicy, the detector will pick the objects in the waiting store that match the policy and
 // put the object to queue.
 // When removing a ClusterPropagationPolicy, the relevant ClusterResourceBinding will be removed and
 // the relevant objects will be put into queue again to try another policy.

--- a/pkg/detector/policy.go
+++ b/pkg/detector/policy.go
@@ -93,15 +93,14 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured,
 		return d.ApplyClusterPolicy(object, objectKey, resourceChangeByKarmada, clusterPolicy)
 	}
 
-	if d.isWaiting(objectKey) {
+	// put it into waiting list and retry once in case the resource and propagation policy come at the same time
+	// see https://github.com/karmada-io/karmada/issues/1195
+	shouldRetry := d.AddWaiting(objectKey, object.GetLabels())
+	if !shouldRetry {
 		// reaching here means there is no appropriate policy for the object
 		klog.V(4).Infof("No matched policy for object: %s", objectKey.String())
 		return nil
 	}
-
-	// put it into waiting list and retry once in case the resource and propagation policy come at the same time
-	// see https://github.com/karmada-io/karmada/issues/1195
-	d.AddWaiting(objectKey)
 	return fmt.Errorf("no matched propagation policy")
 }
 

--- a/pkg/detector/waiting_store.go
+++ b/pkg/detector/waiting_store.go
@@ -1,0 +1,416 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package detector
+
+import (
+	"maps"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
+)
+
+// waitingObjectStore keeps the minimum object data required by ResourceSelector matching.
+//
+// The primary map owns stable candidate entries whose label snapshots are immutable. Secondary indexes share pointers
+// to those entries instead of duplicating the full ClusterWideKey, and all indexes are updated atomically under lock.
+type waitingObjectStore struct {
+	lock sync.RWMutex
+
+	// objects is the source of truth. Keeping ClusterWideKey as the map key preserves value-based direct lookup, while
+	// the stable candidate pointer is reused by every secondary index and survives label snapshot replacement.
+	objects map[keys.ClusterWideKey]*waitingCandidate
+	// byGVK serves selectors without namespace or name constraints. Its buckets can be large, so a pointer set avoids
+	// repeating ClusterWideKey values while preserving constant-time deletion.
+	byGVK map[schema.GroupVersionKind]sets.Set[*waitingCandidate]
+	// byScope serves namespaced selectors without an exact name. It uses the same pointer-set representation because
+	// a namespace bucket can contain many waiting objects and objects are removed individually after policy matching.
+	byScope map[waitingScopeKey]sets.Set[*waitingCandidate]
+	// byGVKName serves name-only selectors across namespaces. These buckets are usually singletons and Match must
+	// iterate all entries anyway, so a slice avoids allocating one Set map per unique name. The primary map prevents
+	// duplicate insertion; deletion scans only resources sharing the same GVK and name. Cluster-scoped objects are
+	// resolved directly from objects and therefore do not enter this index.
+	byGVKName map[waitingGVKNameKey][]*waitingCandidate
+}
+
+type waitingObject struct {
+	// labels is cloned on insertion and never mutated. Label updates replace the waitingCandidate's object pointer,
+	// which makes a snapshot captured under the store lock safe to read after the lock has been released.
+	labels map[string]string
+}
+
+type waitingScopeKey struct {
+	gvk       schema.GroupVersionKind
+	namespace string
+}
+
+type waitingGVKNameKey struct {
+	gvk  schema.GroupVersionKind
+	name string
+}
+
+type compiledWaitingSelector struct {
+	gvk           schema.GroupVersionKind
+	namespace     string
+	name          string
+	labelSelector labels.Selector
+}
+
+type waitingNameSelectorKey struct {
+	gvk       schema.GroupVersionKind
+	namespace string
+	name      string
+}
+
+type waitingLabelSelectorGroup struct {
+	matchAll  bool
+	selectors map[string]labels.Selector
+}
+
+type waitingGVKMatchPlan struct {
+	gvk         schema.GroupVersionKind
+	global      *waitingLabelSelectorGroup
+	byNamespace map[string]*waitingLabelSelectorGroup
+}
+
+type waitingMatchPlan struct {
+	byName map[waitingNameSelectorKey]struct{}
+	byGVK  map[schema.GroupVersionKind]*waitingGVKMatchPlan
+}
+
+type waitingCandidate struct {
+	// key is immutable for the lifetime of this candidate. The stable candidate pointer is shared by the primary map
+	// and secondary indexes, while candidates() returns value snapshots for lock-free selector evaluation.
+	key    keys.ClusterWideKey
+	object *waitingObject
+}
+
+func newWaitingObjectStore() *waitingObjectStore {
+	return &waitingObjectStore{
+		objects:   make(map[keys.ClusterWideKey]*waitingCandidate),
+		byGVK:     make(map[schema.GroupVersionKind]sets.Set[*waitingCandidate]),
+		byScope:   make(map[waitingScopeKey]sets.Set[*waitingCandidate]),
+		byGVKName: make(map[waitingGVKNameKey][]*waitingCandidate),
+	}
+}
+
+// Upsert inserts key into the primary map and every secondary index, or replaces its immutable label snapshot.
+// The return values let resource reconciliation retry only when policy matching could observe new state.
+func (s *waitingObjectStore) Upsert(key keys.ClusterWideKey, objectLabels map[string]string) (inserted bool, labelsChanged bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if candidate, exists := s.objects[key]; exists {
+		if !maps.Equal(candidate.object.labels, objectLabels) {
+			candidate.object = &waitingObject{labels: maps.Clone(objectLabels)}
+			return false, true
+		}
+		return false, false
+	}
+
+	candidate := &waitingCandidate{
+		key:    key,
+		object: &waitingObject{labels: maps.Clone(objectLabels)},
+	}
+	s.objects[key] = candidate
+	gvk := key.GroupVersionKind()
+	insertWaitingIndex(s.byGVK, gvk, candidate)
+	if key.Namespace != "" {
+		insertWaitingIndex(s.byScope, waitingScopeKey{gvk: gvk, namespace: key.Namespace}, candidate)
+		insertWaitingNameIndex(s.byGVKName, waitingGVKNameKey{gvk: gvk, name: key.Name}, candidate)
+	}
+	return true, false
+}
+
+func (s *waitingObjectStore) Contains(key keys.ClusterWideKey) bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	_, exists := s.objects[key]
+	return exists
+}
+
+func (s *waitingObjectStore) Delete(key keys.ClusterWideKey) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	candidate, exists := s.objects[key]
+	if !exists {
+		return
+	}
+
+	gvk := key.GroupVersionKind()
+	deleteWaitingIndex(s.byGVK, gvk, candidate)
+	if key.Namespace != "" {
+		deleteWaitingIndex(s.byScope, waitingScopeKey{gvk: gvk, namespace: key.Namespace}, candidate)
+		deleteWaitingNameIndex(s.byGVKName, waitingGVKNameKey{gvk: gvk, name: key.Name}, candidate)
+	}
+	delete(s.objects, key)
+}
+
+// Match returns the union of waiting object keys selected by resourceSelectors.
+// Exact-name selectors use direct or indexed lookup. Other selectors are grouped into a match plan so each applicable
+// GVK or namespace bucket is snapshotted once, even when a policy contains many overlapping selectors. Matching is
+// candidate-first within each snapshot and stops after the first matching selector, preserving ResourceMatches
+// semantics without multiplying candidate-slice allocations by the number of selectors.
+func (s *waitingObjectStore) Match(resourceSelectors []policyv1alpha1.ResourceSelector) []keys.ClusterWideKey {
+	plan := buildWaitingMatchPlan(compileWaitingSelectors(resourceSelectors))
+	matched := sets.New[keys.ClusterWideKey]()
+
+	for selector := range plan.byName {
+		candidates := s.candidates(compiledWaitingSelector{
+			gvk: selector.gvk, namespace: selector.namespace, name: selector.name,
+		})
+		for _, candidate := range candidates {
+			matched.Insert(candidate.key)
+		}
+	}
+	for _, gvkPlan := range plan.byGVK {
+		s.matchGVKPlan(gvkPlan, matched)
+	}
+
+	return matched.UnsortedList()
+}
+
+func (s *waitingObjectStore) matchGVKPlan(plan *waitingGVKMatchPlan, matched sets.Set[keys.ClusterWideKey]) {
+	if plan.global != nil {
+		// A GVK-wide selector already requires the complete GVK bucket. Namespace selectors are evaluated against the
+		// same snapshot so overlapping scopes do not copy and scan their namespace buckets a second time.
+		candidates := s.candidates(compiledWaitingSelector{gvk: plan.gvk})
+		for _, candidate := range candidates {
+			if plan.global.matches(candidate.object.labels) {
+				matched.Insert(candidate.key)
+				continue
+			}
+			if namespaceGroup := plan.byNamespace[candidate.key.Namespace]; namespaceGroup != nil && namespaceGroup.matches(candidate.object.labels) {
+				matched.Insert(candidate.key)
+			}
+		}
+		return
+	}
+
+	for namespace, selectorGroup := range plan.byNamespace {
+		candidates := s.candidates(compiledWaitingSelector{gvk: plan.gvk, namespace: namespace})
+		for _, candidate := range candidates {
+			if selectorGroup.matches(candidate.object.labels) {
+				matched.Insert(candidate.key)
+			}
+		}
+	}
+}
+
+func (s *waitingObjectStore) Len() int {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return len(s.objects)
+}
+
+func (s *waitingObjectStore) candidates(selector compiledWaitingSelector) []waitingCandidate {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	switch {
+	case selector.name != "":
+		// All name selectors first use the complete key. With a namespace, a miss is final. Without a namespace, this
+		// directly resolves cluster-scoped resources before falling back to the cross-namespace name index.
+		key := keys.ClusterWideKey{
+			Group:     selector.gvk.Group,
+			Version:   selector.gvk.Version,
+			Kind:      selector.gvk.Kind,
+			Namespace: selector.namespace,
+			Name:      selector.name,
+		}
+		if candidate, exists := s.objects[key]; exists {
+			return []waitingCandidate{snapshotWaitingCandidate(candidate)}
+		}
+		if selector.namespace != "" {
+			return nil
+		}
+
+		index := s.byGVKName[waitingGVKNameKey{gvk: selector.gvk, name: selector.name}]
+		candidates := make([]waitingCandidate, 0, len(index))
+		for _, candidate := range index {
+			candidates = append(candidates, snapshotWaitingCandidate(candidate))
+		}
+		return candidates
+	case selector.namespace != "":
+		return snapshotWaitingCandidateSet(s.byScope[waitingScopeKey{gvk: selector.gvk, namespace: selector.namespace}])
+	default:
+		return snapshotWaitingCandidateSet(s.byGVK[selector.gvk])
+	}
+}
+
+// snapshotWaitingCandidate copies the immutable key and the current immutable object pointer while the store lock is
+// held. Upsert may replace candidate.object after the lock is released, but it never mutates the captured object.
+func snapshotWaitingCandidate(candidate *waitingCandidate) waitingCandidate {
+	return waitingCandidate{key: candidate.key, object: candidate.object}
+}
+
+func snapshotWaitingCandidateSet(index sets.Set[*waitingCandidate]) []waitingCandidate {
+	candidates := make([]waitingCandidate, 0, len(index))
+	for candidate := range index {
+		candidates = append(candidates, snapshotWaitingCandidate(candidate))
+	}
+	return candidates
+}
+
+// compileWaitingSelectors parses selector fields once per Match call.
+// ResourceMatches treats Name as authoritative when it is present, so a label selector accompanying Name is
+// intentionally ignored to preserve the existing matching semantics.
+func compileWaitingSelectors(resourceSelectors []policyv1alpha1.ResourceSelector) []compiledWaitingSelector {
+	selectors := make([]compiledWaitingSelector, 0, len(resourceSelectors))
+	for _, resourceSelector := range resourceSelectors {
+		groupVersion, err := schema.ParseGroupVersion(resourceSelector.APIVersion)
+		if err != nil {
+			continue
+		}
+
+		selector := compiledWaitingSelector{
+			gvk:       groupVersion.WithKind(resourceSelector.Kind),
+			namespace: resourceSelector.Namespace,
+			name:      resourceSelector.Name,
+		}
+		if resourceSelector.Name == "" && resourceSelector.LabelSelector != nil {
+			selector.labelSelector, err = metav1.LabelSelectorAsSelector(resourceSelector.LabelSelector)
+			if err != nil {
+				continue
+			}
+		}
+		selectors = append(selectors, selector)
+	}
+	return selectors
+}
+
+// buildWaitingMatchPlan groups selectors by the candidate indexes they use. Name selectors remain independent indexed
+// lookups, while label and match-all selectors sharing a GVK or namespace reuse one candidate snapshot. Equivalent
+// selectors are deduplicated, and a match-all selector subsumes every other selector in the same group.
+func buildWaitingMatchPlan(selectors []compiledWaitingSelector) waitingMatchPlan {
+	plan := waitingMatchPlan{
+		byName: make(map[waitingNameSelectorKey]struct{}),
+		byGVK:  make(map[schema.GroupVersionKind]*waitingGVKMatchPlan),
+	}
+	for _, selector := range selectors {
+		if selector.name != "" {
+			plan.byName[waitingNameSelectorKey{
+				gvk: selector.gvk, namespace: selector.namespace, name: selector.name,
+			}] = struct{}{}
+			continue
+		}
+
+		gvkPlan := plan.byGVK[selector.gvk]
+		if gvkPlan == nil {
+			gvkPlan = &waitingGVKMatchPlan{
+				gvk:         selector.gvk,
+				byNamespace: make(map[string]*waitingLabelSelectorGroup),
+			}
+			plan.byGVK[selector.gvk] = gvkPlan
+		}
+
+		if selector.namespace == "" {
+			if gvkPlan.global == nil {
+				gvkPlan.global = &waitingLabelSelectorGroup{}
+			}
+			gvkPlan.global.add(selector.labelSelector)
+			continue
+		}
+
+		selectorGroup := gvkPlan.byNamespace[selector.namespace]
+		if selectorGroup == nil {
+			selectorGroup = &waitingLabelSelectorGroup{}
+			gvkPlan.byNamespace[selector.namespace] = selectorGroup
+		}
+		selectorGroup.add(selector.labelSelector)
+	}
+	return plan
+}
+
+func (g *waitingLabelSelectorGroup) add(selector labels.Selector) {
+	if g.matchAll {
+		return
+	}
+	if selector == nil || selector.Empty() {
+		g.matchAll = true
+		g.selectors = nil
+		return
+	}
+	if g.selectors == nil {
+		g.selectors = make(map[string]labels.Selector)
+	}
+	g.selectors[selector.String()] = selector
+}
+
+func (g *waitingLabelSelectorGroup) matches(objectLabels map[string]string) bool {
+	if g.matchAll {
+		return true
+	}
+	labelSet := labels.Set(objectLabels)
+	for _, selector := range g.selectors {
+		if selector.Matches(labelSet) {
+			return true
+		}
+	}
+	return false
+}
+
+func insertWaitingIndex[T comparable](index map[T]sets.Set[*waitingCandidate], bucket T, candidate *waitingCandidate) {
+	candidatesInBucket, exists := index[bucket]
+	if !exists {
+		candidatesInBucket = sets.New[*waitingCandidate]()
+		index[bucket] = candidatesInBucket
+	}
+	candidatesInBucket.Insert(candidate)
+}
+
+func deleteWaitingIndex[T comparable](index map[T]sets.Set[*waitingCandidate], bucket T, candidate *waitingCandidate) {
+	candidatesInBucket, exists := index[bucket]
+	if !exists {
+		return
+	}
+	candidatesInBucket.Delete(candidate)
+	if len(candidatesInBucket) == 0 {
+		delete(index, bucket)
+	}
+}
+
+func insertWaitingNameIndex(index map[waitingGVKNameKey][]*waitingCandidate, bucket waitingGVKNameKey, candidate *waitingCandidate) {
+	index[bucket] = append(index[bucket], candidate)
+}
+
+func deleteWaitingNameIndex(index map[waitingGVKNameKey][]*waitingCandidate, bucket waitingGVKNameKey, candidate *waitingCandidate) {
+	candidatesInBucket := index[bucket]
+	for i, indexedCandidate := range candidatesInBucket {
+		if indexedCandidate != candidate {
+			continue
+		}
+
+		last := len(candidatesInBucket) - 1
+		candidatesInBucket[i] = candidatesInBucket[last]
+		candidatesInBucket[last] = nil
+		candidatesInBucket = candidatesInBucket[:last]
+		if len(candidatesInBucket) == 0 {
+			delete(index, bucket)
+		} else {
+			index[bucket] = candidatesInBucket
+		}
+		return
+	}
+}

--- a/pkg/detector/waiting_store_test.go
+++ b/pkg/detector/waiting_store_test.go
@@ -1,0 +1,777 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package detector
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+)
+
+func TestWaitingObjectStoreLifecycle(t *testing.T) {
+	store := newWaitingObjectStore()
+	key := waitingKey("apps/v1", "Deployment", "default", "demo")
+	labels := map[string]string{"env": "prod"}
+
+	inserted, labelsChanged := store.Upsert(key, labels)
+	if !inserted || labelsChanged {
+		t.Fatalf("first Upsert() = (%t, %t), want (true, false)", inserted, labelsChanged)
+	}
+	if !store.Contains(key) {
+		t.Fatal("Contains() should find an inserted key")
+	}
+	inserted, labelsChanged = store.Upsert(key, labels)
+	if inserted || labelsChanged {
+		t.Fatalf("duplicate Upsert() = (%t, %t), want (false, false)", inserted, labelsChanged)
+	}
+
+	labels["env"] = "mutated-after-upsert"
+	assertWaitingKeys(t, store.Match([]policyv1alpha1.ResourceSelector{{
+		APIVersion:    "apps/v1",
+		Kind:          "Deployment",
+		Namespace:     "default",
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+	}}), key)
+
+	inserted, labelsChanged = store.Upsert(key, map[string]string{"env": "staging"})
+	if inserted || !labelsChanged {
+		t.Fatalf("label update Upsert() = (%t, %t), want (false, true)", inserted, labelsChanged)
+	}
+	assertWaitingKeys(t, store.Match([]policyv1alpha1.ResourceSelector{{
+		APIVersion:    "apps/v1",
+		Kind:          "Deployment",
+		Namespace:     "default",
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "staging"}},
+	}}), key)
+
+	store.Delete(key)
+	store.Delete(key)
+	if store.Contains(key) {
+		t.Fatal("Contains() should not find a deleted key")
+	}
+	if len(store.objects) != 0 || len(store.byGVK) != 0 || len(store.byScope) != 0 || len(store.byGVKName) != 0 {
+		t.Fatalf("Delete() should remove empty index buckets: objects=%d byGVK=%d byScope=%d byGVKName=%d",
+			len(store.objects), len(store.byGVK), len(store.byScope), len(store.byGVKName))
+	}
+}
+
+func TestWaitingObjectStoreStableCandidateLifecycle(t *testing.T) {
+	store := newWaitingObjectStore()
+	key := waitingKey("apps/v1", "Deployment", "default", "demo")
+	gvk := key.GroupVersionKind()
+	scopeKey := waitingScopeKey{gvk: gvk, namespace: key.Namespace}
+	nameKey := waitingGVKNameKey{gvk: gvk, name: key.Name}
+
+	store.Upsert(key, map[string]string{"env": "prod"})
+	candidate := store.objects[key]
+	initialObject := candidate.object
+	if !store.byGVK[gvk].Has(candidate) || !store.byScope[scopeKey].Has(candidate) {
+		t.Fatal("secondary indexes should reference the primary map candidate")
+	}
+	if got := store.byGVKName[nameKey]; len(got) != 1 || got[0] != candidate {
+		t.Fatalf("name index should contain the primary map candidate once, got %#v", got)
+	}
+
+	store.Upsert(key, map[string]string{"env": "prod"})
+	if store.objects[key] != candidate || candidate.object != initialObject {
+		t.Fatal("unchanged Upsert should preserve the candidate and label snapshot pointers")
+	}
+	if got := store.byGVKName[nameKey]; len(got) != 1 {
+		t.Fatalf("duplicate Upsert should not append to the name index, got %d entries", len(got))
+	}
+
+	store.Upsert(key, map[string]string{"env": "staging"})
+	if store.objects[key] != candidate {
+		t.Fatal("label update should preserve the stable candidate pointer")
+	}
+	if candidate.object == initialObject {
+		t.Fatal("label update should replace the immutable label snapshot")
+	}
+	if initialObject.labels["env"] != "prod" || candidate.object.labels["env"] != "staging" {
+		t.Fatalf("unexpected old/new label snapshots: old=%v new=%v", initialObject.labels, candidate.object.labels)
+	}
+}
+
+func TestWaitingObjectStoreNameIndexSliceLifecycle(t *testing.T) {
+	store := newWaitingObjectStore()
+	keysByNamespace := []keys.ClusterWideKey{
+		waitingKey("apps/v1", "Deployment", "team-a", "demo"),
+		waitingKey("apps/v1", "Deployment", "team-b", "demo"),
+		waitingKey("apps/v1", "Deployment", "team-c", "demo"),
+	}
+	for _, key := range keysByNamespace {
+		store.Upsert(key, map[string]string{"app": "demo"})
+	}
+
+	nameKey := waitingGVKNameKey{gvk: keysByNamespace[0].GroupVersionKind(), name: "demo"}
+	selector := []policyv1alpha1.ResourceSelector{{APIVersion: "apps/v1", Kind: "Deployment", Name: "demo"}}
+	if got := len(store.byGVKName[nameKey]); got != 3 {
+		t.Fatalf("name index length = %d, want 3", got)
+	}
+	assertWaitingKeys(t, store.Match(selector), keysByNamespace...)
+
+	store.Upsert(keysByNamespace[0], map[string]string{"app": "updated"})
+	if got := len(store.byGVKName[nameKey]); got != 3 {
+		t.Fatalf("label update should not append to the name index, got %d entries", got)
+	}
+
+	store.Delete(keysByNamespace[1])
+	assertWaitingKeys(t, store.Match(selector), keysByNamespace[0], keysByNamespace[2])
+	if got := len(store.byGVKName[nameKey]); got != 2 {
+		t.Fatalf("name index length after middle deletion = %d, want 2", got)
+	}
+
+	store.Delete(keysByNamespace[0])
+	assertWaitingKeys(t, store.Match(selector), keysByNamespace[2])
+	if got := len(store.byGVKName[nameKey]); got != 1 {
+		t.Fatalf("name index length after first deletion = %d, want 1", got)
+	}
+
+	store.Delete(keysByNamespace[2])
+	assertWaitingKeys(t, store.Match(selector))
+	if _, exists := store.byGVKName[nameKey]; exists {
+		t.Fatal("last deletion should remove the empty name index bucket")
+	}
+}
+
+func TestWaitingObjectStoreClusterScopedExactName(t *testing.T) {
+	store := newWaitingObjectStore()
+	key := waitingKey("v1", "Namespace", "", "demo")
+	store.Upsert(key, map[string]string{"team": "demo"})
+
+	if len(store.byScope) != 0 || len(store.byGVKName) != 0 {
+		t.Fatalf("cluster-scoped object should not enter namespace indexes: byScope=%d byGVKName=%d", len(store.byScope), len(store.byGVKName))
+	}
+	assertWaitingKeys(t, store.Match([]policyv1alpha1.ResourceSelector{{
+		APIVersion: "v1", Kind: "Namespace", Name: "demo",
+	}}), key)
+
+	store.Delete(key)
+	if len(store.objects) != 0 || len(store.byGVK) != 0 {
+		t.Fatalf("cluster-scoped deletion should clean primary and GVK indexes: objects=%d byGVK=%d", len(store.objects), len(store.byGVK))
+	}
+}
+
+func TestWaitingObjectStoreMatchIndexPaths(t *testing.T) {
+	store := newWaitingObjectStore()
+	deploymentDefault := waitingKey("apps/v1", "Deployment", "default", "demo")
+	deploymentOtherNamespace := waitingKey("apps/v1", "Deployment", "other", "demo")
+	deploymentOtherName := waitingKey("apps/v1", "Deployment", "default", "other")
+	statefulSet := waitingKey("apps/v1", "StatefulSet", "default", "demo")
+	corePod := waitingKey("v1", "Pod", "default", "demo")
+
+	for _, key := range []keys.ClusterWideKey{
+		deploymentDefault,
+		deploymentOtherNamespace,
+		deploymentOtherName,
+		statefulSet,
+		corePod,
+	} {
+		store.Upsert(key, map[string]string{"app": "demo"})
+	}
+
+	tests := []struct {
+		name     string
+		selector policyv1alpha1.ResourceSelector
+		want     []keys.ClusterWideKey
+	}{
+		{
+			name: "namespace and name uses the full key",
+			selector: policyv1alpha1.ResourceSelector{
+				APIVersion: "apps/v1", Kind: "Deployment", Namespace: "default", Name: "demo",
+			},
+			want: []keys.ClusterWideKey{deploymentDefault},
+		},
+		{
+			name: "namespace and name miss does not fall back across namespaces",
+			selector: policyv1alpha1.ResourceSelector{
+				APIVersion: "apps/v1", Kind: "Deployment", Namespace: "missing", Name: "demo",
+			},
+		},
+		{
+			name: "name without namespace matches across namespaces",
+			selector: policyv1alpha1.ResourceSelector{
+				APIVersion: "apps/v1", Kind: "Deployment", Name: "demo",
+			},
+			want: []keys.ClusterWideKey{deploymentDefault, deploymentOtherNamespace},
+		},
+		{
+			name: "namespace without name is scope isolated",
+			selector: policyv1alpha1.ResourceSelector{
+				APIVersion: "apps/v1", Kind: "Deployment", Namespace: "default",
+			},
+			want: []keys.ClusterWideKey{deploymentDefault, deploymentOtherName},
+		},
+		{
+			name: "gvk bucket is kind and api version isolated",
+			selector: policyv1alpha1.ResourceSelector{
+				APIVersion: "apps/v1", Kind: "Deployment",
+			},
+			want: []keys.ClusterWideKey{deploymentDefault, deploymentOtherNamespace, deploymentOtherName},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertWaitingKeys(t, store.Match([]policyv1alpha1.ResourceSelector{tt.selector}), tt.want...)
+		})
+	}
+}
+
+func TestWaitingObjectStoreLabelSelectors(t *testing.T) {
+	store := newWaitingObjectStore()
+	matchingKey := waitingKey("apps/v1", "Deployment", "default", "matching")
+	nonMatchingKey := waitingKey("apps/v1", "Deployment", "default", "non-matching")
+	store.Upsert(matchingKey, map[string]string{"env": "prod", "tier": "frontend", "region": "east"})
+	store.Upsert(nonMatchingKey, map[string]string{"env": "dev", "tier": "backend", "backend-only": "true"})
+
+	tests := []struct {
+		name     string
+		selector *metav1.LabelSelector
+	}{
+		{
+			name: "In",
+			selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod", "staging"},
+			}}},
+		},
+		{
+			name: "NotIn",
+			selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key: "tier", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"backend"},
+			}}},
+		},
+		{
+			name: "Exists",
+			selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key: "region", Operator: metav1.LabelSelectorOpExists,
+			}}},
+		},
+		{
+			name: "DoesNotExist",
+			selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key: "backend-only", Operator: metav1.LabelSelectorOpDoesNotExist,
+			}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertWaitingKeys(t, store.Match([]policyv1alpha1.ResourceSelector{{
+				APIVersion: "apps/v1", Kind: "Deployment", Namespace: "default", LabelSelector: tt.selector,
+			}}), matchingKey)
+		})
+	}
+
+	assertWaitingKeys(t, store.Match([]policyv1alpha1.ResourceSelector{{
+		APIVersion: "apps/v1", Kind: "Deployment", Namespace: "default",
+	}}), matchingKey, nonMatchingKey)
+}
+
+func TestWaitingObjectStoreMatchSelectorSemantics(t *testing.T) {
+	store := newWaitingObjectStore()
+	key := waitingKey("apps/v1", "Deployment", "default", "demo")
+	other := waitingKey("apps/v1", "Deployment", "default", "other")
+	store.Upsert(key, map[string]string{"env": "prod"})
+	store.Upsert(other, map[string]string{"env": "prod"})
+
+	t.Run("name ignores label selector", func(t *testing.T) {
+		assertWaitingKeys(t, store.Match([]policyv1alpha1.ResourceSelector{{
+			APIVersion: "apps/v1", Kind: "Deployment", Namespace: "default", Name: "demo",
+			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "does-not-match"}},
+		}}), key)
+	})
+
+	t.Run("multiple selectors merge and deduplicate", func(t *testing.T) {
+		assertWaitingKeys(t, store.Match([]policyv1alpha1.ResourceSelector{
+			{APIVersion: "apps/v1", Kind: "Deployment", Namespace: "default", Name: "demo"},
+			{APIVersion: "apps/v1", Kind: "Deployment", Namespace: "default"},
+		}), key, other)
+	})
+
+	t.Run("invalid selectors are skipped", func(t *testing.T) {
+		assertWaitingKeys(t, store.Match([]policyv1alpha1.ResourceSelector{
+			{APIVersion: "apps/v1/invalid", Kind: "Deployment"},
+			{
+				APIVersion: "apps/v1", Kind: "Deployment",
+				LabelSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key: "env", Operator: metav1.LabelSelectorOperator("Invalid"),
+				}},
+				},
+			},
+		}))
+	})
+}
+
+func TestWaitingObjectStoreOverlappingSelectors(t *testing.T) {
+	store := newWaitingObjectStore()
+	defaultProd := waitingKey("apps/v1", "Deployment", "default", "prod")
+	defaultDev := waitingKey("apps/v1", "Deployment", "default", "dev")
+	otherProd := waitingKey("apps/v1", "Deployment", "other", "prod")
+	otherDev := waitingKey("apps/v1", "Deployment", "other", "dev")
+	store.Upsert(defaultProd, map[string]string{"env": "prod"})
+	store.Upsert(defaultDev, map[string]string{"env": "dev"})
+	store.Upsert(otherProd, map[string]string{"env": "prod"})
+	store.Upsert(otherDev, map[string]string{"env": "dev"})
+
+	selectors := []policyv1alpha1.ResourceSelector{
+		{
+			APIVersion: "apps/v1", Kind: "Deployment",
+			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+		},
+		{
+			APIVersion: "apps/v1", Kind: "Deployment", Namespace: "default",
+			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "dev"}},
+		},
+		{
+			APIVersion: "apps/v1", Kind: "Deployment", Namespace: "other", Name: "dev",
+			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "does-not-match"}},
+		},
+		{
+			APIVersion: "apps/v1", Kind: "Deployment",
+			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+		},
+	}
+
+	assertWaitingKeys(t, store.Match(selectors), defaultProd, defaultDev, otherProd, otherDev)
+}
+
+func TestWaitingObjectStoreDifferentialAgainstResourceMatches(t *testing.T) {
+	// A fixed seed makes this differential test reproducible; the generated values are not security-sensitive.
+	//nolint:gosec
+	random := rand.New(rand.NewSource(42))
+	store := newWaitingObjectStore()
+	objects := make([]*unstructured.Unstructured, 0, 360)
+	apiVersions := []string{"v1", "apps/v1"}
+	kinds := []string{"ConfigMap", "Deployment"}
+	namespaces := []string{"default", "team-a", "team-b"}
+	environments := []string{"dev", "staging", "prod"}
+
+	for i := range 360 {
+		apiVersion := apiVersions[random.Intn(len(apiVersions))]
+		kind := kinds[random.Intn(len(kinds))]
+		namespace := namespaces[random.Intn(len(namespaces))]
+		name := fmt.Sprintf("object-%03d", i)
+		object := &unstructured.Unstructured{}
+		object.SetAPIVersion(apiVersion)
+		object.SetKind(kind)
+		object.SetNamespace(namespace)
+		object.SetName(name)
+		object.SetLabels(map[string]string{
+			"env":  environments[random.Intn(len(environments))],
+			"even": fmt.Sprintf("%t", i%2 == 0),
+		})
+		objects = append(objects, object)
+		store.Upsert(waitingKey(apiVersion, kind, namespace, name), object.GetLabels())
+	}
+
+	for i := range 200 {
+		selector := policyv1alpha1.ResourceSelector{
+			APIVersion: apiVersions[random.Intn(len(apiVersions))],
+			Kind:       kinds[random.Intn(len(kinds))],
+		}
+		switch random.Intn(4) {
+		case 0:
+			selector.Namespace = namespaces[random.Intn(len(namespaces))]
+			selector.Name = objects[random.Intn(len(objects))].GetName()
+		case 1:
+			selector.Name = objects[random.Intn(len(objects))].GetName()
+		case 2:
+			selector.Namespace = namespaces[random.Intn(len(namespaces))]
+			selector.LabelSelector = &metav1.LabelSelector{MatchLabels: map[string]string{
+				"env": environments[random.Intn(len(environments))],
+			}}
+		case 3:
+			selector.LabelSelector = &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key: "even", Operator: metav1.LabelSelectorOpIn, Values: []string{fmt.Sprintf("%t", random.Intn(2) == 0)},
+			}}}
+		}
+
+		want := sets.New[keys.ClusterWideKey]()
+		for _, object := range objects {
+			if util.ResourceMatches(object, selector) {
+				want.Insert(waitingKey(object.GetAPIVersion(), object.GetKind(), object.GetNamespace(), object.GetName()))
+			}
+		}
+		got := sets.New[keys.ClusterWideKey](store.Match([]policyv1alpha1.ResourceSelector{selector})...)
+		if !want.Equal(got) {
+			t.Fatalf("iteration %d differs from ResourceMatches(): selector=%+v want=%v got=%v", i, selector, want, got)
+		}
+	}
+}
+
+func TestWaitingObjectStoreConcurrentAccess(_ *testing.T) {
+	store := newWaitingObjectStore()
+	var wg sync.WaitGroup
+	for worker := range 8 {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := range 250 {
+				key := waitingKey("apps/v1", "Deployment", fmt.Sprintf("ns-%d", worker%2), fmt.Sprintf("object-%d-%d", worker, i))
+				store.Upsert(key, map[string]string{"worker": fmt.Sprint(worker), "iteration": fmt.Sprint(i)})
+				store.Match([]policyv1alpha1.ResourceSelector{{
+					APIVersion: "apps/v1", Kind: "Deployment", Namespace: key.Namespace,
+					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"worker": fmt.Sprint(worker)}},
+				}})
+				if i%3 == 0 {
+					store.Delete(key)
+				}
+			}
+		}(worker)
+	}
+	wg.Wait()
+}
+
+func TestResourceDetectorWaitingLifecycle(t *testing.T) {
+	scheme := setupTestScheme()
+	detector := &ResourceDetector{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	key := waitingKey("apps/v1", "Deployment", "default", "demo")
+	object := &unstructured.Unstructured{}
+	object.SetAPIVersion("apps/v1")
+	object.SetKind("Deployment")
+	object.SetNamespace("default")
+	object.SetName("demo")
+	object.SetLabels(map[string]string{"env": "prod"})
+
+	if err := detector.propagateResource(object, key, false); err == nil {
+		t.Fatal("first reconcile without a policy should request one retry")
+	}
+	if !detector.isWaiting(key) {
+		t.Fatal("first reconcile should add the object to the waiting store")
+	}
+	if err := detector.propagateResource(object, key, false); err != nil {
+		t.Fatalf("repeat reconcile without any state change should not request another retry: %v", err)
+	}
+
+	object.SetLabels(map[string]string{"env": "staging"})
+	if err := detector.propagateResource(object, key, false); err == nil {
+		t.Fatal("label update should request one retry to avoid missing a concurrent policy event")
+	}
+	assertWaitingKeys(t, detector.GetMatching([]policyv1alpha1.ResourceSelector{{
+		APIVersion:    "apps/v1",
+		Kind:          "Deployment",
+		Namespace:     "default",
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "staging"}},
+	}}), key)
+	if err := detector.propagateResource(object, key, false); err != nil {
+		t.Fatalf("repeat reconcile after the label snapshot is current should not request another retry: %v", err)
+	}
+}
+
+func TestResourceDetectorWaitingLabelUpdateRetriesAfterStalePolicyMatch(t *testing.T) {
+	scheme := setupTestScheme()
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	blockingClient := &blockingClusterPolicyListClient{
+		Client:      baseClient,
+		listStarted: make(chan struct{}),
+		releaseList: make(chan struct{}),
+	}
+	detector := &ResourceDetector{Client: blockingClient}
+	key := waitingKey("apps/v1", "Deployment", "default", "demo")
+	detector.AddWaiting(key, map[string]string{"env": "old"})
+
+	object := &unstructured.Unstructured{}
+	object.SetAPIVersion("apps/v1")
+	object.SetKind("Deployment")
+	object.SetNamespace("default")
+	object.SetName("demo")
+	object.SetLabels(map[string]string{"env": "new"})
+
+	reconcileResult := make(chan error, 1)
+	go func() {
+		reconcileResult <- detector.propagateResource(object, key, false)
+	}()
+
+	select {
+	case <-blockingClient.listStarted:
+	case <-time.After(time.Second):
+		t.Fatal("resource reconcile did not reach the cluster policy lookup")
+	}
+
+	assertWaitingKeys(t, detector.GetMatching([]policyv1alpha1.ResourceSelector{{
+		APIVersion:    "apps/v1",
+		Kind:          "Deployment",
+		Namespace:     "default",
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "new"}},
+	}}))
+	close(blockingClient.releaseList)
+
+	select {
+	case err := <-reconcileResult:
+		if err == nil {
+			t.Fatal("label update should request a retry after a policy may have matched the stale snapshot")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("resource reconcile did not finish")
+	}
+}
+
+func TestResourceDetectorWaitingPolicyRequeuesForResourceReconcile(t *testing.T) {
+	scheme := setupTestScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	worker := &recordingPriorityWorker{}
+	detector := &ResourceDetector{Client: fakeClient, Processor: worker}
+	key := waitingKey("apps/v1", "Deployment", "default", "demo")
+	detector.AddWaiting(key, map[string]string{"app": "demo"})
+	policy := &policyv1alpha1.PropagationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "demo-policy",
+			Labels: map[string]string{
+				policyv1alpha1.PropagationPolicyPermanentIDLabel: "policy-id",
+			},
+		},
+		Spec: policyv1alpha1.PropagationSpec{ResourceSelectors: []policyv1alpha1.ResourceSelector{{
+			APIVersion: "apps/v1", Kind: "Deployment", Namespace: "default", Name: "demo",
+		}}},
+	}
+
+	if err := detector.HandlePropagationPolicyCreationOrUpdate(policy); err != nil {
+		t.Fatalf("HandlePropagationPolicyCreationOrUpdate() returned error: %v", err)
+	}
+	if detector.isWaiting(key) {
+		t.Fatal("policy match should remove the object from the waiting store before resource reconciliation")
+	}
+	if len(worker.items) != 1 {
+		t.Fatalf("policy match should enqueue one resource reconciliation, got %d", len(worker.items))
+	}
+	if got, ok := worker.items[0].(keys.ClusterWideKeyWithConfig); !ok || got.ClusterWideKey != key {
+		t.Fatalf("unexpected resource queue item: %#v", worker.items[0])
+	}
+
+	bindings := &workv1alpha2.ResourceBindingList{}
+	if err := fakeClient.List(t.Context(), bindings, client.InNamespace("default")); err != nil {
+		t.Fatalf("failed to list ResourceBindings: %v", err)
+	}
+	if len(bindings.Items) != 0 {
+		t.Fatal("policy reconciliation must not create bindings; resource reconciliation remains authoritative")
+	}
+}
+
+func BenchmarkLegacyWaitingExactName24564(b *testing.B) {
+	objects := benchmarkWaitingObjects(24564)
+	selectors := []policyv1alpha1.ResourceSelector{{
+		APIVersion: "apps/v1", Kind: "Deployment", Namespace: "namespace-42", Name: "object-12342",
+	}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = legacyWaitingMatch(objects, selectors)
+	}
+}
+
+func BenchmarkWaitingObjectStoreExactName24564(b *testing.B) {
+	store := benchmarkWaitingStore(24564)
+	selectors := []policyv1alpha1.ResourceSelector{{
+		APIVersion: "apps/v1", Kind: "Deployment", Namespace: "namespace-42", Name: "object-12342",
+	}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = store.Match(selectors)
+	}
+}
+
+func BenchmarkWaitingObjectStoreCrossNamespaceName24564(b *testing.B) {
+	store := benchmarkWaitingStoreWithCrossNamespaceName(24564, 100)
+	selectors := []policyv1alpha1.ResourceSelector{{
+		APIVersion: "apps/v1", Kind: "Deployment", Name: "shared-name",
+	}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = store.Match(selectors)
+	}
+}
+
+func BenchmarkLegacyWaitingLabelSelector24564(b *testing.B) {
+	objects := benchmarkWaitingObjects(24564)
+	selectors := []policyv1alpha1.ResourceSelector{{
+		APIVersion: "apps/v1", Kind: "Deployment", Namespace: "namespace-42",
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"shard": "42"}},
+	}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = legacyWaitingMatch(objects, selectors)
+	}
+}
+
+func BenchmarkWaitingObjectStoreLabelSelector24564(b *testing.B) {
+	store := benchmarkWaitingStore(24564)
+	selectors := []policyv1alpha1.ResourceSelector{{
+		APIVersion: "apps/v1", Kind: "Deployment", Namespace: "namespace-42",
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"shard": "42"}},
+	}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = store.Match(selectors)
+	}
+}
+
+func BenchmarkWaitingObjectStoreMatchAll24564(b *testing.B) {
+	store := benchmarkWaitingStore(24564)
+	selectors := []policyv1alpha1.ResourceSelector{{APIVersion: "apps/v1", Kind: "Deployment"}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = store.Match(selectors)
+	}
+}
+
+func BenchmarkWaitingObjectStoreOverlappingSelectors24564(b *testing.B) {
+	store := benchmarkWaitingStore(24564)
+	selectors := make([]policyv1alpha1.ResourceSelector, 100)
+	for i := range selectors {
+		selectors[i] = policyv1alpha1.ResourceSelector{APIVersion: "apps/v1", Kind: "Deployment"}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = store.Match(selectors)
+	}
+}
+
+func waitingKey(apiVersion, kind, namespace, name string) keys.ClusterWideKey {
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		panic(err)
+	}
+	return keys.ClusterWideKey{
+		Group: gv.Group, Version: gv.Version, Kind: kind, Namespace: namespace, Name: name,
+	}
+}
+
+func assertWaitingKeys(t *testing.T, got []keys.ClusterWideKey, want ...keys.ClusterWideKey) {
+	t.Helper()
+	gotSet := sets.New[keys.ClusterWideKey](got...)
+	wantSet := sets.New[keys.ClusterWideKey](want...)
+	if !wantSet.Equal(gotSet) {
+		t.Fatalf("unexpected matching keys: want=%v got=%v", wantSet, gotSet)
+	}
+}
+
+type recordingPriorityWorker struct {
+	items []any
+}
+
+type blockingClusterPolicyListClient struct {
+	client.Client
+	listStarted chan struct{}
+	releaseList chan struct{}
+}
+
+func (c *blockingClusterPolicyListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if _, ok := list.(*policyv1alpha1.ClusterPropagationPolicyList); ok {
+		close(c.listStarted)
+		<-c.releaseList
+	}
+	return c.Client.List(ctx, list, opts...)
+}
+
+func (w *recordingPriorityWorker) Add(item any) {
+	w.items = append(w.items, item)
+}
+
+func (w *recordingPriorityWorker) AddAfter(item any, _ time.Duration) {
+	w.Add(item)
+}
+
+func (w *recordingPriorityWorker) Enqueue(item any) {
+	w.Add(item)
+}
+
+func (w *recordingPriorityWorker) Run(_ context.Context, _ int) {}
+
+func (w *recordingPriorityWorker) AddWithOpts(_ util.AddOpts, items ...any) {
+	for _, item := range items {
+		w.Add(item)
+	}
+}
+
+func (w *recordingPriorityWorker) EnqueueWithOpts(_ util.AddOpts, item any) {
+	w.Enqueue(item)
+}
+
+func benchmarkWaitingObjects(count int) []*unstructured.Unstructured {
+	objects := make([]*unstructured.Unstructured, 0, count)
+	for i := range count {
+		object := &unstructured.Unstructured{}
+		object.SetAPIVersion("apps/v1")
+		object.SetKind("Deployment")
+		object.SetNamespace(fmt.Sprintf("namespace-%d", i%100))
+		object.SetName(fmt.Sprintf("object-%d", i))
+		object.SetLabels(map[string]string{"shard": fmt.Sprint(i % 100)})
+		objects = append(objects, object)
+	}
+	return objects
+}
+
+func benchmarkWaitingStore(count int) *waitingObjectStore {
+	store := newWaitingObjectStore()
+	for _, object := range benchmarkWaitingObjects(count) {
+		store.Upsert(
+			waitingKey(object.GetAPIVersion(), object.GetKind(), object.GetNamespace(), object.GetName()),
+			object.GetLabels(),
+		)
+	}
+	return store
+}
+
+func benchmarkWaitingStoreWithCrossNamespaceName(count, namespaceCount int) *waitingObjectStore {
+	store := newWaitingObjectStore()
+	for i := range count {
+		name := fmt.Sprintf("object-%d", i)
+		if i < namespaceCount {
+			name = "shared-name"
+		}
+		store.Upsert(
+			waitingKey("apps/v1", "Deployment", fmt.Sprintf("namespace-%d", i%namespaceCount), name),
+			map[string]string{"shard": fmt.Sprint(i % namespaceCount)},
+		)
+	}
+	return store
+}
+
+func legacyWaitingMatch(objects []*unstructured.Unstructured, selectors []policyv1alpha1.ResourceSelector) []keys.ClusterWideKey {
+	result := make([]keys.ClusterWideKey, 0)
+	for _, object := range objects {
+		converted, err := helper.ToUnstructured(object)
+		if err != nil {
+			continue
+		}
+		candidate := converted.DeepCopy()
+		for _, selector := range selectors {
+			if util.ResourceMatches(candidate, selector) {
+				result = append(result, waitingKey(candidate.GetAPIVersion(), candidate.GetKind(), candidate.GetNamespace(), candidate.GetName()))
+				break
+			}
+		}
+	}
+	return result
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`ResourceDetector.GetMatching` currently scans every entry in `waitingObjects` for each PropagationPolicy or ClusterPropagationPolicy reconciliation. For every candidate it retrieves the informer-cached object, converts it, deep-copies it, and then evaluates the selector. Even an exact `namespace + name` selector therefore pays O(number of waiting objects) CPU and allocation cost.

This PR replaces the key-only map with a synchronized waiting-object store that:

- keeps immutable label snapshots instead of repeatedly fetching and deep-copying informer objects;
- indexes waiting keys by GVK, GVK/namespace, and GVK/name;
- resolves an exact namespace/name selector directly by its complete key;
- refreshes label snapshots and requests one retry when labels change, preserving the concurrent policy/resource safety behavior;
- preserves the existing `ResourceMatches` semantics, including name precedence, multi-selector union, and deduplication.

The primary optimization is the exact-name path. Label selectors still evaluate the narrowest applicable GVK/namespace candidate bucket; this PR avoids object fetch/deep-copy overhead but does not introduce a label inverted index.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

### Test environment and workload

| Item | Specification |
|---|---|
| Control plane | Existing three-node Kubernetes test control plane |
| Karmada Controller manager | 2 replicas, 1 active leader, 0 restarts during valid cases |
| Karmada / Go / Kubernetes dependencies | Karmada `master`; Go 1.26.5; `k8s.io/* v0.36.2` |
| Policy workers | PP concurrency 1; CPP concurrency 1 |
| Member clusters | 0, to isolate detector-to-Binding behavior |
| Data per independent case | 24,564 custom resources followed by 11,216 policies |
| Selector shape | exact `apiVersion + kind + namespace + name` for PP and exact `apiVersion + kind + name` for CPP; one policy matched one resource |
| Injection rate | resources 150/s; policies 100/s |
| Guardrails | 45-minute case cutoff, API/leader/restart/resource monitoring |
| Profiling | 120-second CPU profiles plus backlog-to-post `alloc_space` deltas |

CPP and PP were independent reproductions of the same `GetMatching` hotspot, not a comparison of policy scopes.

### Live same-scale results

| Path | Before | After | Throughput | p50 | p95 | p99 |
|---|---:|---:|---:|---:|---:|---:|
| CPP | 9,250/11,216 (82.47%) at 2,478s cutoff | 11,216/11,216 in 184s | 3.733/s → 60.957/s (16.33x) | 1,303.5s → 4s | 2,288.55s → 60s | 2,367s → 69s (-97.08%) |
| PP | 8,122/11,216 (72.41%) at 2,466s cutoff | 11,216/11,216 in 215s | 3.294/s → 52.167/s (15.84x) | 1,276s → 9s | 2,283.95s → 88s | 2,365s → 100s (-95.77%) |

### pprof evidence

| Path | `GetMatching` cumulative CPU | `GetMatching` cumulative allocation | `DeepCopyJSONValue` cumulative CPU | `DeepCopyJSONValue` cumulative allocation |
|---|---:|---:|---:|---:|
| CPP | 51.84% → 0.029% | 81.09% → 0.0018% | 39.70% → 0.24% | 77.92% → 0.30% |
| PP | 51.84% → 0.019% | 81.68% → 0.0017% | 37.04% → 0.25% | 77.21% → 0.26% |

CPU cumulative percentages overlap and are not additive. Allocation shares use backlog-to-post deltas.

#### CPU flame graphs

| Path | Before | After |
|---|---|---|
| CPP | <img width="960" alt="CPP before GetMatching optimization flame graph" src="https://github.com/user-attachments/assets/73f0d772-ab30-444f-a905-a078d2d197f2" /> | <img width="960" alt="CPP after GetMatching optimization flame graph" src="https://github.com/user-attachments/assets/3cc9a5f2-d01a-4625-a502-eb42e163e731" /> |
| PP | <img width="960" alt="PP before GetMatching optimization flame graph" src="https://github.com/user-attachments/assets/d071b2a6-000b-440c-ac73-bf3db696d430" /> | <img width="960" alt="PP after GetMatching optimization flame graph" src="https://github.com/user-attachments/assets/486354ef-ac12-4773-8c60-b7bb886c628b" /> |

Before optimization, the wide stack is `GetMatching → GetUnstructuredObject → DeepCopyJSONValue`; after optimization it is no longer visible as a dominant stack.

### Follow-up validation: mixed ResourceSelectors on the optimized build

To cover the label-matching paths without changing the primary exact-name before/after comparison above, an additional optimized-only test was run on the same control plane and at the same scale: 24,564 resources followed by 11,216 policies for each independent CPP and PP case.

| Selector type | Policies per path | Matching contract |
|---|---:|---|
| Exact name | 3,739 | `apiVersion + kind + [namespace] + name` |
| `matchLabels` | 3,739 | unique `perf.karmada.io/selector-id` label |
| `matchExpressions(In)` | 3,738 | unique `perf.karmada.io/selector-id` label |

Every selector was independently verified to match exactly one resource. The three selector types were interleaved deterministically in the shared policy worker queue.

#### Mixed-selector results

| Path | Completion | First policy to last Binding | Throughput | Optimized exact-name throughput | Change | p50 / p95 / p99 / max |
|---|---:|---:|---:|---:|---:|---:|
| CPP | 11,216/11,216 | 442s | 25.38/s | 60.96/s | -58.37% | 141 / 308 / 325 / 330s |
| PP | 11,216/11,216 | 497s | 22.57/s | 52.17/s | -56.74% | 172 / 361 / 380 / 385s |

All exact-name and mixed-selector cases on the optimized build reached 100%, so this comparison is not affected by right-censoring. The per-selector p99 values were identical within each path (CPP 325s; PP 380s). This does not mean their direct execution costs are equal: interleaved label scans block the shared policy worker queue, so exact-name policies in the same run also experience head-of-line waiting.

#### Mixed-selector pprof evidence

| Cumulative CPU stack | CPP | PP |
|---|---:|---:|
| `GetMatching` | 22.38% | 23.60% |
| `LabelSelectorAsSelector` | 16.85% | 15.43% |
| `waitingObjectStore.candidates` | 10.63% | 11.79% |
| GC background marking | 34.02% | 31.71% |

The exact-name index remains effective, but label selectors still compile selectors and copy/scan the narrowest GVK/namespace candidate bucket. The mixed flame graphs show the wider `GetMatching wai tingObjectStore.Match/candidates labels.Mat ches` branch. This is a remaining optimization boundary, not a regression of the exact-name fast path.

CPP ended with `CASE_COMPLETE`. PP produced its final Binding at `11:07:41Z`; an external platform rollout started afterward at `11:07:43Z` (webhook) and `11:08:05Z` (controller manager). Therefore all PP results and the 120-second backlog CPU profile came from the optimized image, while the post-allocation snapshot is unavailable and is not claimed.

#### Mixed-selector evidence attachments

The attached evidence bundle contains the full report payload, reviewed metrics, all 22,432 policy-to-Binding latency rows, pprof hotspot summaries, raw CPP/PP CPU profiles, rendered flame graphs, cleanup/postflight proof, and SHA-256 checksums.
l interleaved label scans block the shared policy worker queue so exact-name policies in the same run also experience head-of-line waiting.

#### Mixed-selector pprof evidence

 Cumulative CPU stack  CPP  PP 
---------
 GetMatching  22.38%  23.60% 
 LabelSelectorAsSelector  16.85%  15.43% 
 waitingObjectStore.candidates  10.63%  11.79% 
 GC background marking  34.02%  31.71% 

The exact-name index remains effective but label selectors still compile selectors and copy/scan the narrowest GVK/namespace candidate bucket. The mixed flame graphs show the wider GetMatching - waitingObjectStore.Match/candidates - labels.Matches branch. This is a remaining optimization boundary not a regression of the exact-name fast path.

CPP ended with CASECOMPLETE. PP produced its final Binding at 110741Z an external platform rollout started afterward at 110743Z webhook and 110805Z controller manager. Therefore all PP results and the 120-second backlog CPU profile came from the optimized image while the post-allocation snapshot is unavailable and is not claimed.

#### Mixed-selector evidence attachments

The attached evidence bundle contains the full report payload reviewed metrics all 22432 policy-to-Binding latency rows pprof hotspot summaries raw CPP/PP CPU profiles rendered flame graphs cleanup/postflight proof and SHA-256 checksums.
<img width="2400" height="1080" alt="pp-mixed-selector-cpu-flamegraph" src="https://github.com/user-attachments/assets/5ebdddba-9022-4ce0-93f9-927d0dacb9a8" />
<img width="2400" height="1080" alt="cpp-mixed-selector-cpu-flamegraph" src="https://github.com/user-attachments/assets/2a5ca902-8fd3-4cc7-93c3-eb782b33b206" />

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-controller-manager`: Improved ResourceDetector policy matching performance by indexing waiting objects and avoiding full object fetch and deep-copy scans.
```