### PR TITLE
docs: add release notes for v1.19.0-beta.0 and patch releases

### DIFF
--- a/docs/CHANGELOG/CHANGELOG-1.16.md
+++ b/docs/CHANGELOG/CHANGELOG-1.16.md
@@ -2,12 +2,18 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [v1.16.7](#v1167)
-  - [Downloads for v1.16.7](#downloads-for-v1167)
-  - [Changelog since v1.16.6](#changelog-since-v1166)
+- [v1.16.8](#v1168)
+  - [Downloads for v1.16.8](#downloads-for-v1168)
+  - [Changelog since v1.16.7](#changelog-since-v1167)
     - [Changes by Kind](#changes-by-kind)
       - [Bug Fixes](#bug-fixes)
       - [Others](#others)
+- [v1.16.7](#v1167)
+  - [Downloads for v1.16.7](#downloads-for-v1167)
+  - [Changelog since v1.16.6](#changelog-since-v1166)
+    - [Changes by Kind](#changes-by-kind-1)
+      - [Bug Fixes](#bug-fixes-1)
+      - [Others](#others-1)
 - [v1.16.6](#v1166)
   - [Downloads for v1.16.6](#downloads-for-v1166)
   - [Changelog since v1.16.5](#changelog-since-v1165)
@@ -123,6 +129,22 @@
     - [Instrumentation](#instrumentation-4)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# v1.16.8
+## Downloads for v1.16.8
+
+Download v1.16.8 in the [v1.16.8 release page](https://github.com/karmada-io/karmada/releases/tag/v1.16.8).
+
+## Changelog since v1.16.7
+
+### Changes by Kind
+
+#### Bug Fixes
+- `karmada-controller-manager`: Fixed an issue where the taint-manager eviction queue would enqueue bindings with indefinite taint tolerations. ([#7775](https://github.com/karmada-io/karmada/pull/7775), @karmada-bot)
+- `karmada-controller-manager`: Fixed an issue where `Cluster.status.remedyActions` could remain stale after an associated `Remedy` resource was removed. ([#7790](https://github.com/karmada-io/karmada/pull/7790), @karmada-bot)
+
+#### Others
+None.
 
 # v1.16.7
 ## Downloads for v1.16.7

--- a/docs/CHANGELOG/CHANGELOG-1.17.md
+++ b/docs/CHANGELOG/CHANGELOG-1.17.md
@@ -2,12 +2,18 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [v1.17.4](#v1174)
-  - [Downloads for v1.17.4](#downloads-for-v1174)
-  - [Changelog since v1.17.3](#changelog-since-v1173)
+- [v1.17.5](#v1175)
+  - [Downloads for v1.17.5](#downloads-for-v1175)
+  - [Changelog since v1.17.4](#changelog-since-v1174)
     - [Changes by Kind](#changes-by-kind)
       - [Bug Fixes](#bug-fixes)
       - [Others](#others)
+- [v1.17.4](#v1174)
+  - [Downloads for v1.17.4](#downloads-for-v1174)
+  - [Changelog since v1.17.3](#changelog-since-v1173)
+    - [Changes by Kind](#changes-by-kind-1)
+      - [Bug Fixes](#bug-fixes-1)
+      - [Others](#others-1)
 - [v1.17.3](#v1173)
   - [Downloads for v1.17.3](#downloads-for-v1173)
   - [Changelog since v1.17.2](#changelog-since-v1172)
@@ -108,6 +114,22 @@
     - [Performance](#performance-4)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# v1.17.5
+## Downloads for v1.17.5
+
+Download v1.17.5 in the [v1.17.5 release page](https://github.com/karmada-io/karmada/releases/tag/v1.17.5).
+
+## Changelog since v1.17.4
+
+### Changes by Kind
+
+#### Bug Fixes
+- `karmada-controller-manager`: Fixed an issue where the taint-manager eviction queue would enqueue bindings with indefinite taint tolerations. ([#7773](https://github.com/karmada-io/karmada/pull/7773), @karmada-bot)
+- `karmada-controller-manager`: Fixed an issue where `Cluster.status.remedyActions` could remain stale after an associated `Remedy` resource was removed. ([#7789](https://github.com/karmada-io/karmada/pull/7789), @karmada-bot)
+
+#### Others
+None.
 
 # v1.17.4
 ## Downloads for v1.17.4

--- a/docs/CHANGELOG/CHANGELOG-1.18.md
+++ b/docs/CHANGELOG/CHANGELOG-1.18.md
@@ -2,12 +2,18 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [v1.18.1](#v1181)
-  - [Downloads for v1.18.1](#downloads-for-v1181)
-  - [Changelog since v1.18.0](#changelog-since-v1180)
+- [v1.18.2](#v1182)
+  - [Downloads for v1.18.2](#downloads-for-v1182)
+  - [Changelog since v1.18.1](#changelog-since-v1181)
     - [Changes by Kind](#changes-by-kind)
       - [Bug Fixes](#bug-fixes)
       - [Others](#others)
+- [v1.18.1](#v1181)
+  - [Downloads for v1.18.1](#downloads-for-v1181)
+  - [Changelog since v1.18.0](#changelog-since-v1180)
+    - [Changes by Kind](#changes-by-kind-1)
+      - [Bug Fixes](#bug-fixes-1)
+      - [Others](#others-1)
 - [v1.18.0](#v1180)
   - [Downloads for v1.18.0](#downloads-for-v1180)
   - [Urgent Update Notes](#urgent-update-notes)
@@ -88,6 +94,21 @@
     - [Performance](#performance-4)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+# v1.18.2
+## Downloads for v1.18.2
+
+Download v1.18.2 in the [v1.18.2 release page](https://github.com/karmada-io/karmada/releases/tag/v1.18.2).
+
+## Changelog since v1.18.1
+
+### Changes by Kind
+
+#### Bug Fixes
+- `karmada-controller-manager`: Fixed an issue where the taint-manager eviction queue would enqueue bindings with indefinite taint tolerations. ([#7772](https://github.com/karmada-io/karmada/pull/7772), @karmada-bot)
+- `karmada-controller-manager`: Fixed an issue where `Cluster.status.remedyActions` could remain stale after an associated `Remedy` resource was removed. ([#7788](https://github.com/karmada-io/karmada/pull/7788), @karmada-bot)
+
+#### Others
+None.
 
 # v1.18.1
 ## Downloads for v1.18.1

--- a/docs/CHANGELOG/CHANGELOG-1.19.md
+++ b/docs/CHANGELOG/CHANGELOG-1.19.md
@@ -2,9 +2,9 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [v1.19.0-alpha.1](#v1190-alpha1)
-  - [Downloads for v1.19.0-alpha.1](#downloads-for-v1190-alpha1)
-  - [Changelog since v1.19.0-alpha.0](#changelog-since-v1190-alpha0)
+- [v1.19.0-beta.0](#v1190-beta0)
+  - [Downloads for v1.19.0-beta.0](#downloads-for-v1190-beta0)
+  - [Changelog since v1.19.0-alpha.1](#changelog-since-v1190-alpha1)
   - [Urgent Update Notes](#urgent-update-notes)
   - [Changes by Kind](#changes-by-kind)
     - [API Changes](#api-changes)
@@ -18,7 +18,66 @@
     - [Instrumentation](#instrumentation)
     - [Performance](#performance)
 
+- [v1.19.0-alpha.1](#v1190-alpha1)
+  - [Downloads for v1.19.0-alpha.1](#downloads-for-v1190-alpha1)
+  - [Changelog since v1.19.0-alpha.0](#changelog-since-v1190-alpha0)
+  - [Urgent Update Notes](#urgent-update-notes)
+  - [Changes by Kind](#changes-by-kind-1)
+    - [API Changes](#api-changes-1)
+    - [Features & Enhancements](#features--enhancements-1)
+    - [Deprecation](#deprecation-1)
+    - [Bug Fixes](#bug-fixes-1)
+    - [Security](#security-1)
+  - [Other](#other-1)
+    - [Dependencies](#dependencies-1)
+    - [Helm Charts](#helm-charts-1)
+    - [Instrumentation](#instrumentation-1)
+    - [Performance](#performance)
+
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# v1.19.0-beta.0
+## Downloads for v1.19.0-beta.0
+
+Download v1.19.0-beta.0 in the [v1.19.0-beta.0 release page](https://github.com/karmada-io/karmada/releases/tag/v1.19.0-beta.0).
+
+## Changelog since v1.19.0-alpha.1
+
+## Urgent Update Notes
+None.
+
+## Changes by Kind
+
+### API Changes
+None.
+
+### Features & Enhancements
+None.
+
+### Deprecation
+None.
+
+### Bug Fixes
+- `karmada-controller-manager`: Fixed an issue where the taint-manager eviction queue would enqueue bindings with indefinite taint tolerations. ([#7613](https://github.com/karmada-io/karmada/pull/7613), @mszacillo)
+- `karmada-controller-manager`: Fixed an issue where `Cluster.status.remedyActions` could remain stale after an associated `Remedy` resource was removed. ([#7777](https://github.com/karmada-io/karmada/pull/7777), @ranxi2001)
+- `karmada-scheduler`: Fixed the issue that WorkloadRebalancer-triggered rescheduling did not reevaluate multiple `clusterAffinities` in policy order starting from the first term. ([#5425](https://github.com/karmada-io/karmada/pull/5425), @bharathguvvala)
+
+### Security
+None.
+
+## Other
+### Dependencies
+- Karmada is now built with Golang v1.26.5. ([#7786](https://github.com/karmada-io/karmada/pull/7786), @SipengShen01)
+
+### Helm Charts
+- `Helm chart`: Added helm index for `v1.17.4`. ([#7701](https://github.com/karmada-io/karmada/pull/7701), @github-actions)
+- `Helm chart`: Added helm index for `v1.18.1`. ([#7700](https://github.com/karmada-io/karmada/pull/7700), @github-actions)
+
+### Instrumentation
+None.
+
+### Performance
+None.
 
 # v1.19.0-alpha.1
 ## Downloads for v1.19.0-alpha.1


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR updates the changelog and release-note documentation to complete the missing table of contents entries and add the newly introduced release sections for v1.16.8, v1.17.5, v1.18.2, and v1.19.0-beta.0. It improves the readability and navigation of the release notes without changing any product behavior.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

This is a documentation-only change. No code logic or runtime behavior is affected.

**Does this PR introduce a user-facing change?**:

No.

```release-note
NONE