### PR TITLE
feat: strip managedFields from dynamic informer caches

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -262,7 +262,7 @@ func run(ctx context.Context, opts *options.Options) error {
 func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *options.Options) error {
 	restConfig := mgr.GetConfig()
 	dynamicClientSet := dynamic.NewForConfigOrDie(restConfig)
-	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, 0)
+	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, 0, fedinformer.StripUnusedFields)
 	controlPlaneKubeClientSet := kubeclientset.NewForConfigOrDie(restConfig)
 
 	// We need a service lister to build a resource interpreter with `ClusterIPServiceResolver`

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -853,7 +853,7 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *
 		return
 	}
 
-	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, opts.ResyncPeriod.Duration)
+	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, opts.ResyncPeriod.Duration, fedinformer.StripUnusedFields)
 	// We need a service lister to build a resource interpreter with `ClusterIPServiceResolver`
 	// witch allows connection to the customized interpreter webhook without a cluster DNS service.
 	sharedFactory := informers.NewSharedInformerFactory(kubeClientSet, opts.ResyncPeriod.Duration)
@@ -969,7 +969,7 @@ func setupClusterAPIClusterDetector(ctx context.Context, mgr controllerruntime.M
 		ControllerPlaneConfig: mgr.GetConfig(),
 		ClusterAPIConfig:      clusterAPIRestConfig,
 		ClusterAPIClient:      clusterAPIClient,
-		InformerManager:       genericmanager.NewSingleClusterInformerManager(ctx, dynamic.NewForConfigOrDie(clusterAPIRestConfig), 0),
+		InformerManager:       genericmanager.NewSingleClusterInformerManager(ctx, dynamic.NewForConfigOrDie(clusterAPIRestConfig), 0, fedinformer.StripUnusedFields),
 		ConcurrentReconciles:  3,
 	}
 	if err := mgr.Add(clusterAPIClusterDetector); err != nil {

--- a/pkg/controllers/binding/binding_controller_test.go
+++ b/pkg/controllers/binding/binding_controller_test.go
@@ -41,6 +41,7 @@ import (
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	testing2 "github.com/karmada-io/karmada/pkg/search/proxy/testing"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/indexregistry"
@@ -63,7 +64,7 @@ func makeFakeRBCByResource(rs *workv1alpha2.ObjectReference) (*ResourceBindingCo
 		return &ResourceBindingController{
 			Client:          c,
 			RESTMapper:      testing2.RestMapper,
-			InformerManager: genericmanager.NewSingleClusterInformerManager(context.TODO(), tempDyClient, 0),
+			InformerManager: genericmanager.NewSingleClusterInformerManager(context.TODO(), tempDyClient, 0, fedinformer.StripUnusedFields),
 			DynamicClient:   tempDyClient,
 		}, nil
 	}

--- a/pkg/controllers/binding/cluster_resource_binding_controller_test.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/events"
 	testing2 "github.com/karmada-io/karmada/pkg/search/proxy/testing"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/indexregistry"
@@ -62,7 +63,7 @@ func makeFakeCRBCByResource(rs *workv1alpha2.ObjectReference) (*ClusterResourceB
 		return &ClusterResourceBindingController{
 			Client:          c,
 			RESTMapper:      testing2.RestMapper,
-			InformerManager: genericmanager.NewSingleClusterInformerManager(context.TODO(), tempDyClient, 0),
+			InformerManager: genericmanager.NewSingleClusterInformerManager(context.TODO(), tempDyClient, 0, fedinformer.StripUnusedFields),
 			DynamicClient:   tempDyClient,
 		}, nil
 	}

--- a/pkg/controllers/execution/execution_controller_test.go
+++ b/pkg/controllers/execution/execution_controller_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/objectwatcher"
@@ -354,7 +355,7 @@ func TestExecutionController_NewGVRInformerRequeuesWorkForMemberResourceChangedB
 		return false, nil, nil
 	})
 
-	informerManager := genericmanager.NewMultiClusterInformerManager(ctx)
+	informerManager := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 	clusterClientSetFunc := func(string, client.Client, *util.ClientOption) (*util.DynamicClusterClient, error) {
 		return &util.DynamicClusterClient{
 			ClusterName:      clusterName,
@@ -449,7 +450,7 @@ func newController(work *workv1alpha1.Work, recorder *record.FakeRecorder) Contr
 		WithInterceptorFuncs(withGVKInterceptor(clientScheme)).
 		Build()
 	dynamicClientSet := dynamicfake.NewSimpleDynamicClient(scheme.Scheme, pod)
-	informerManager := genericmanager.NewMultiClusterInformerManager(context.Background())
+	informerManager := genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields)
 	informerManager.ForCluster(cluster.Name, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 	informerManager.Start(cluster.Name)
 	informerManager.WaitForCacheSync(cluster.Name)

--- a/pkg/controllers/status/crb_status_controller_test.go
+++ b/pkg/controllers/status/crb_status_controller_test.go
@@ -36,6 +36,7 @@ import (
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/indexregistry"
@@ -46,7 +47,7 @@ func generateCRBStatusController() *CRBStatusController {
 	defer cancel()
 	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}})
-	m := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0)
+	m := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0, fedinformer.StripUnusedFields)
 	m.Lister(corev1.SchemeGroupVersion.WithResource("namespaces"))
 	m.Start()
 	m.WaitForCacheSync()

--- a/pkg/controllers/status/rb_status_controller_test.go
+++ b/pkg/controllers/status/rb_status_controller_test.go
@@ -37,6 +37,7 @@ import (
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/indexregistry"
@@ -47,7 +48,7 @@ func generateRBStatusController() *RBStatusController {
 	defer cancel()
 	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "default"}})
-	m := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0)
+	m := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0, fedinformer.StripUnusedFields)
 	m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 	m.Start()
 	m.WaitForCacheSync()

--- a/pkg/controllers/status/work_status_controller_test.go
+++ b/pkg/controllers/status/work_status_controller_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
@@ -766,7 +767,7 @@ func newWorkStatusController(cluster *clusterv1alpha1.Cluster, dynamicClientSets
 		// Generate ResourceInterpreter and ObjectWatcher
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		m := genericmanager.NewMultiClusterInformerManager(ctx)
+		m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 		m.ForCluster(clusterName, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 		m.Start(clusterName)
 		m.WaitForCacheSync(clusterName)
@@ -816,7 +817,7 @@ func TestWorkStatusController_getSingleClusterManager(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newWorkStatusController(cluster)
-			m := genericmanager.NewMultiClusterInformerManager(ctx)
+			m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 			if tt.rightClusterName {
 				m.ForCluster(clusterName, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 			} else {
@@ -1014,7 +1015,7 @@ func TestWorkStatusController_registerInformersAndStart(t *testing.T) {
 	work := testhelper.NewWork("work", "default", workUID, raw)
 
 	t.Run("normal case", func(t *testing.T) {
-		m := genericmanager.NewMultiClusterInformerManager(ctx)
+		m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 		m.ForCluster(clusterName, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 		m.Start(clusterName)
 		m.WaitForCacheSync(clusterName)
@@ -1026,7 +1027,7 @@ func TestWorkStatusController_registerInformersAndStart(t *testing.T) {
 
 	t.Run("failed to getSingleClusterManager", func(t *testing.T) {
 		c := newWorkStatusController(cluster)
-		m := genericmanager.NewMultiClusterInformerManager(ctx)
+		m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 		m.ForCluster("test", dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 		m.Start(clusterName)
 		m.WaitForCacheSync(clusterName)
@@ -1040,7 +1041,7 @@ func TestWorkStatusController_registerInformersAndStart(t *testing.T) {
 	t.Run("failed to getGVRsFromWork", func(t *testing.T) {
 		work.Spec.Workload.Manifests[0].RawExtension.Raw = []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod","namespace":"default"}},`)
 
-		m := genericmanager.NewMultiClusterInformerManager(ctx)
+		m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 		m.ForCluster(clusterName, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 		m.Start(clusterName)
 		m.WaitForCacheSync(clusterName)

--- a/pkg/controllers/status/work_status_controller_test.go
+++ b/pkg/controllers/status/work_status_controller_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -105,7 +106,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "secret1"},
 						Data:       map[string][]byte{clusterv1alpha1.SecretTokenKey: []byte("token"), clusterv1alpha1.SecretCADataKey: testCA},
 					}).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSet,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -132,7 +133,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			name: "work not exists",
 			c: &WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -159,7 +160,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			name: "work's DeletionTimestamp isn't zero",
 			c: &WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -188,7 +189,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			name: "work's status is not applied",
 			c: &WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -215,7 +216,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			name: "failed to get cluster name",
 			c: &WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -242,7 +243,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			name: "failed to get cluster",
 			c: &WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster1", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -269,7 +270,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			name: "cluster is not ready",
 			c: &WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionFalse)).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -338,7 +339,7 @@ func TestWorkStatusController_getEventHandler(t *testing.T) {
 
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionFalse)).Build(),
-		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -353,7 +354,7 @@ func TestWorkStatusController_getEventHandler(t *testing.T) {
 func TestWorkStatusController_RunWorkQueue(_ *testing.T) {
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionFalse)).Build(),
-		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -780,7 +781,7 @@ func TestWorkStatusController_buildResourceInformers(t *testing.T) {
 func newWorkStatusController(cluster *clusterv1alpha1.Cluster, dynamicClientSets ...*dynamicfake.FakeDynamicClient) *WorkStatusController {
 	c := &WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(cluster).WithStatusSubresource(&workv1alpha1.Work{}).Build(),
-		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -810,7 +811,7 @@ func newWorkStatusController(cluster *clusterv1alpha1.Cluster, dynamicClientSets
 		// Generate ResourceInterpreter and ObjectWatcher
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		m := genericmanager.NewMultiClusterInformerManager(ctx)
+		m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 		m.ForCluster(clusterName, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 		m.Start(clusterName)
 		m.WaitForCacheSync(clusterName)
@@ -823,7 +824,7 @@ func newWorkStatusController(cluster *clusterv1alpha1.Cluster, dynamicClientSets
 func TestWorkStatusController_buildStatusIdentifier(t *testing.T) {
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -883,7 +884,7 @@ func TestWorkStatusController_buildStatusIdentifier(t *testing.T) {
 func TestWorkStatusController_mergeStatus(t *testing.T) {
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		RateLimiterOptions:          ratelimiterflag.Options{},

--- a/pkg/dependenciesdistributor/dependencies_distributor_test.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor_test.go
@@ -47,6 +47,7 @@ import (
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
 	"github.com/karmada-io/karmada/pkg/util/names"
@@ -1233,7 +1234,7 @@ func Test_removeOrphanAttachedBindings(t *testing.T) {
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1379,7 +1380,7 @@ func Test_handleDependentResource(t *testing.T) {
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1487,7 +1488,7 @@ func Test_handleDependentResource(t *testing.T) {
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1566,7 +1567,7 @@ func Test_handleDependentResource(t *testing.T) {
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1936,7 +1937,7 @@ func Test_syncScheduleResultToAttachedBindings_doesNotWaitForInformerCacheSync(t
 		scheme.Scheme,
 		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}},
 	)
-	baseInformerManager := genericmanager.NewSingleClusterInformerManager(context.TODO(), dynamicClient, 0)
+	baseInformerManager := genericmanager.NewSingleClusterInformerManager(context.TODO(), dynamicClient, 0, fedinformer.StripUnusedFields)
 	baseInformerManager.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 	trackingManager := &trackingInformerManager{SingleClusterInformerManager: baseInformerManager}
 
@@ -2025,7 +2026,7 @@ func Test_findOrphanAttachedBindings(t *testing.T) {
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -2122,7 +2123,7 @@ func Test_findOrphanAttachedBindings(t *testing.T) {
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -2231,7 +2232,7 @@ func TestDependenciesDistributor_findOrphanAttachedBindingsByDependencies(t *tes
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"bar": "bar"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -2282,7 +2283,7 @@ func TestDependenciesDistributor_findOrphanAttachedBindingsByDependencies(t *tes
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"bar": "foo"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()

--- a/pkg/detector/policy_test.go
+++ b/pkg/detector/policy_test.go
@@ -34,6 +34,7 @@ import (
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 )
 
@@ -152,7 +153,7 @@ func Test_cleanPPUnmatchedRBs(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -286,7 +287,7 @@ func Test_cleanUnmatchedRBs(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -420,7 +421,7 @@ func Test_cleanUnmatchedCRBs(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -653,7 +654,7 @@ func Test_removeRBsClaimMetadata(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -877,7 +878,7 @@ func Test_removeCRBsClaimMetadata(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -1099,7 +1100,7 @@ func Test_removeResourceClaimMetadataIfNotMatched(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,

--- a/pkg/detector/preemption_test.go
+++ b/pkg/detector/preemption_test.go
@@ -35,6 +35,7 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 )
 
@@ -345,7 +346,7 @@ func TestHandleDeprioritizedPropagationPolicy(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.objects...)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -626,7 +627,7 @@ func TestHandleDeprioritizedClusterPropagationPolicy(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.objects...)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,

--- a/pkg/estimator/server/server.go
+++ b/pkg/estimator/server/server.go
@@ -127,7 +127,7 @@ func NewEstimatorServer(
 	_ = informerFactory.Core().V1().Pods().Informer().SetTransform(fedinformer.StripUnusedFields)
 	_ = informerFactory.Apps().V1().ReplicaSets().Informer().SetTransform(fedinformer.StripUnusedFields)
 
-	es.informerManager = genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0)
+	es.informerManager = genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0, fedinformer.StripUnusedFields)
 	for _, gvr := range supportedGVRs {
 		es.informerManager.Lister(gvr)
 	}

--- a/pkg/karmadactl/promote/promote.go
+++ b/pkg/karmadactl/promote/promote.go
@@ -55,6 +55,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native/prune"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/thirdparty"
 	u "github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/names"
@@ -455,7 +456,7 @@ func (o *CommandPromoteOption) promoteDeps(memberClusterFactory cmdutil.Factory,
 	defer cancel()
 	dynamicClientSet := dynamicClientBuilder(config)
 
-	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, 0)
+	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, 0, fedinformer.StripUnusedFields)
 	controlPlaneKubeClientSet := kubeClientBuilder(config)
 	sharedFactory := informers.NewSharedInformerFactory(controlPlaneKubeClientSet, 0)
 	serviceLister := sharedFactory.Core().V1().Services().Lister()

--- a/pkg/resourceinterpreter/customized/declarative/configmanager/manager_test.go
+++ b/pkg/resourceinterpreter/customized/declarative/configmanager/manager_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 )
@@ -128,7 +129,7 @@ func Test_interpreterConfigManager_LuaScriptAccessors(t *testing.T) {
 			defer cancel()
 
 			client := fake.NewSimpleDynamicClient(gclient.NewSchema(), tt.args.customizations...)
-			informer := genericmanager.NewSingleClusterInformerManager(ctx, client, 0)
+			informer := genericmanager.NewSingleClusterInformerManager(ctx, client, 0, fedinformer.StripUnusedFields)
 			configManager := NewInterpreterConfigManager(informer)
 
 			informer.Start()

--- a/pkg/search/controllers_test.go
+++ b/pkg/search/controllers_test.go
@@ -41,6 +41,7 @@ import (
 	informerfactory "github.com/karmada-io/karmada/pkg/generated/informers/externalversions"
 	"github.com/karmada-io/karmada/pkg/search/backendstore"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 )
 
@@ -589,7 +590,7 @@ func createController(ctx context.Context, restConfig *rest.Config, factory info
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new controller, got: %v", err)
 	}
-	newController.InformerManager = genericmanager.NewMultiClusterInformerManager(ctx)
+	newController.InformerManager = genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 	return newController, nil
 }
 

--- a/pkg/util/fedinformer/genericmanager/multi-cluster-manager.go
+++ b/pkg/util/fedinformer/genericmanager/multi-cluster-manager.go
@@ -23,6 +23,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 )
 
 var (
@@ -34,7 +37,7 @@ var (
 // GetInstance returns a shared MultiClusterInformerManager instance.
 func GetInstance() MultiClusterInformerManager {
 	once.Do(func() {
-		instance = NewMultiClusterInformerManager(ctx)
+		instance = NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 	})
 	return instance
 }
@@ -74,17 +77,19 @@ type MultiClusterInformerManager interface {
 }
 
 // NewMultiClusterInformerManager constructs a new instance of multiClusterInformerManagerImpl.
-func NewMultiClusterInformerManager(ctx context.Context) MultiClusterInformerManager {
+func NewMultiClusterInformerManager(ctx context.Context, transformFunc cache.TransformFunc) MultiClusterInformerManager {
 	return &multiClusterInformerManagerImpl{
-		managers: make(map[string]SingleClusterInformerManager),
-		ctx:      ctx,
+		managers:      make(map[string]SingleClusterInformerManager),
+		ctx:           ctx,
+		transformFunc: transformFunc,
 	}
 }
 
 type multiClusterInformerManagerImpl struct {
-	managers map[string]SingleClusterInformerManager
-	ctx      context.Context
-	lock     sync.RWMutex
+	managers      map[string]SingleClusterInformerManager
+	ctx           context.Context
+	transformFunc cache.TransformFunc
+	lock          sync.RWMutex
 }
 
 func (m *multiClusterInformerManagerImpl) getManager(cluster string) (SingleClusterInformerManager, bool) {
@@ -103,7 +108,7 @@ func (m *multiClusterInformerManagerImpl) ForCluster(cluster string, client dyna
 		return manager
 	}
 
-	manager := NewSingleClusterInformerManager(m.ctx, client, defaultResync)
+	manager := NewSingleClusterInformerManager(m.ctx, client, defaultResync, m.transformFunc)
 	m.managers[cluster] = manager
 	return manager
 }

--- a/pkg/util/fedinformer/genericmanager/single-cluster-manager.go
+++ b/pkg/util/fedinformer/genericmanager/single-cluster-manager.go
@@ -75,10 +75,11 @@ type SingleClusterInformerManager interface {
 
 // NewSingleClusterInformerManager constructs a new instance of singleClusterInformerManagerImpl.
 // defaultResync with value '0' means no re-sync.
-func NewSingleClusterInformerManager(ctx context.Context, client dynamic.Interface, defaultResync time.Duration) SingleClusterInformerManager {
+func NewSingleClusterInformerManager(ctx context.Context, client dynamic.Interface, defaultResync time.Duration, transformFunc cache.TransformFunc) SingleClusterInformerManager {
 	ctx, cancel := context.WithCancel(ctx)
 	return &singleClusterInformerManagerImpl{
 		informerFactory: dynamicinformer.NewDynamicSharedInformerFactory(client, defaultResync),
+		transformFunc:   transformFunc,
 		ctx:             ctx,
 		cancel:          cancel,
 		client:          client,
@@ -90,6 +91,11 @@ type singleClusterInformerManagerImpl struct {
 	cancel context.CancelFunc
 
 	informerFactory dynamicinformer.DynamicSharedInformerFactory
+
+	// transformFunc is applied to every newly created informer via SetTransform
+	// before the informer starts, mutating each object before it is stored in
+	// the cache (e.g. to strip unneeded fields and reduce memory usage).
+	transformFunc cache.TransformFunc
 
 	// initializedInformers caches the informers that have been created by the
 	// informer factory, used to avoid the lock contention in the informer factory
@@ -163,8 +169,7 @@ func (s *singleClusterInformerManagerImpl) appendHandler(resource schema.GroupVe
 	if currentHandlers, ok := s.handlers.Load(resource); ok {
 		handlers = currentHandlers.([]cache.ResourceEventHandler)
 	}
-	// Publish a new slice so concurrent lock-free readers never observe a slice being modified.
-	s.handlers.Store(resource, append(slices.Clone(handlers), handler))
+	s.handlers.Store(resource, append(handlers, handler))
 }
 
 // getOrCreateInformer returns the informer for the given resource, creating it
@@ -190,6 +195,15 @@ func (s *singleClusterInformerManagerImpl) createInformer(resource schema.GroupV
 	}
 
 	resourceInformer := s.informerFactory.ForResource(resource)
+	if s.transformFunc != nil {
+		// SetTransform returns an error only if the informer has already started.
+		// Since createInformer and Start are serialized by s.lock, the newly created informer
+		// cannot have started at this point, so the error is not expected here.
+		if err := resourceInformer.Informer().SetTransform(s.transformFunc); err != nil {
+			klog.ErrorS(err, "Failed to set transform", "resource", resource.String())
+			return resourceInformer
+		}
+	}
 	s.initializedInformers.Store(resource, resourceInformer)
 	return resourceInformer
 }

--- a/pkg/util/fedinformer/genericmanager/single-cluster-manager.go
+++ b/pkg/util/fedinformer/genericmanager/single-cluster-manager.go
@@ -74,12 +74,13 @@ type SingleClusterInformerManager interface {
 
 // NewSingleClusterInformerManager constructs a new instance of singleClusterInformerManagerImpl.
 // defaultResync with value '0' means no re-sync.
-func NewSingleClusterInformerManager(ctx context.Context, client dynamic.Interface, defaultResync time.Duration) SingleClusterInformerManager {
+func NewSingleClusterInformerManager(ctx context.Context, client dynamic.Interface, defaultResync time.Duration, transformFunc cache.TransformFunc) SingleClusterInformerManager {
 	ctx, cancel := context.WithCancel(ctx)
 	return &singleClusterInformerManagerImpl{
 		informerFactory: dynamicinformer.NewDynamicSharedInformerFactory(client, defaultResync),
 		handlers:        make(map[schema.GroupVersionResource][]cache.ResourceEventHandler),
 		syncedInformers: make(map[schema.GroupVersionResource]struct{}),
+		transformFunc:   transformFunc,
 		ctx:             ctx,
 		cancel:          cancel,
 		client:          client,
@@ -96,6 +97,10 @@ type singleClusterInformerManagerImpl struct {
 
 	handlers map[schema.GroupVersionResource][]cache.ResourceEventHandler
 
+	transformFunc cache.TransformFunc
+
+	transformedInformers sync.Map
+
 	client dynamic.Interface
 
 	lock sync.RWMutex
@@ -110,7 +115,9 @@ func (s *singleClusterInformerManagerImpl) ForResource(resource schema.GroupVers
 		return
 	}
 
-	_, err := s.informerFactory.ForResource(resource).Informer().AddEventHandler(handler)
+	i := s.informerFactory.ForResource(resource).Informer()
+	s.setTransformOnce(resource, i)
+	_, err := i.AddEventHandler(handler)
 	if err != nil {
 		klog.Errorf("Failed to add handler for resource(%s): %v", resource.String(), err)
 		return
@@ -144,7 +151,9 @@ func (s *singleClusterInformerManagerImpl) isHandlerExist(resource schema.GroupV
 }
 
 func (s *singleClusterInformerManagerImpl) Lister(resource schema.GroupVersionResource) cache.GenericLister {
-	return s.informerFactory.ForResource(resource).Lister()
+	resourceInformer := s.informerFactory.ForResource(resource)
+	s.setTransformOnce(resource, resourceInformer.Informer())
+	return resourceInformer.Lister()
 }
 
 func (s *singleClusterInformerManagerImpl) appendHandler(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) {
@@ -153,6 +162,16 @@ func (s *singleClusterInformerManagerImpl) appendHandler(resource schema.GroupVe
 
 	// assume the handler not exist in it, caller should ensure for that.
 	s.handlers[resource] = append(handlers, handler)
+}
+
+func (s *singleClusterInformerManagerImpl) setTransformOnce(resource schema.GroupVersionResource, informer cache.SharedIndexInformer) {
+	if s.transformFunc == nil {
+		return
+	}
+	if _, loaded := s.transformedInformers.LoadOrStore(resource, struct{}{}); loaded {
+		return
+	}
+	_ = informer.SetTransform(s.transformFunc)
 }
 
 func (s *singleClusterInformerManagerImpl) Start() {
@@ -175,9 +194,10 @@ func (s *singleClusterInformerManagerImpl) WaitForCacheSyncWithTimeout(cacheSync
 }
 
 func (s *singleClusterInformerManagerImpl) waitForCacheSync(ctx context.Context) map[schema.GroupVersionResource]bool {
+	res := s.informerFactory.WaitForCacheSync(ctx.Done())
+
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	res := s.informerFactory.WaitForCacheSync(ctx.Done())
 	for resource, synced := range res {
 		if _, exist := s.syncedInformers[resource]; !exist && synced {
 			s.syncedInformers[resource] = struct{}{}

--- a/pkg/util/fedinformer/genericmanager/single-cluster-manager_test.go
+++ b/pkg/util/fedinformer/genericmanager/single-cluster-manager_test.go
@@ -18,13 +18,19 @@ package genericmanager
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
@@ -35,11 +41,79 @@ var testResourceGVR = schema.GroupVersionResource{
 	Resource: "widgets",
 }
 
+func TestSingleClusterInformerManagerAppliesTransform(t *testing.T) {
+	tests := []struct {
+		name          string
+		observeObject func(t *testing.T, manager SingleClusterInformerManager) *unstructured.Unstructured
+	}{
+		{
+			name: "ForResource",
+			observeObject: func(t *testing.T, manager SingleClusterInformerManager) *unstructured.Unstructured {
+				observed := make(chan any, 1)
+				manager.ForResource(testResourceGVR, cache.ResourceEventHandlerFuncs{
+					AddFunc: func(obj any) {
+						observed <- obj
+					},
+				})
+				manager.Start()
+				waitForTestInformerSync(t, manager)
+
+				select {
+				case obj := <-observed:
+					resource, ok := obj.(*unstructured.Unstructured)
+					if !ok {
+						t.Fatalf("got object type %T, want *unstructured.Unstructured", obj)
+					}
+					return resource
+				case <-time.After(5 * time.Second):
+					t.Fatal("timed out waiting for informer add event")
+					return nil
+				}
+			},
+		},
+		{
+			name: "Lister",
+			observeObject: func(t *testing.T, manager SingleClusterInformerManager) *unstructured.Unstructured {
+				lister := manager.Lister(testResourceGVR)
+				if lister == nil {
+					t.Fatal("expected a lister")
+				}
+				manager.Start()
+				waitForTestInformerSync(t, manager)
+
+				obj, err := lister.ByNamespace("default").Get("widget")
+				if err != nil {
+					t.Fatalf("failed to get object from informer cache: %v", err)
+				}
+				resource, ok := obj.(*unstructured.Unstructured)
+				if !ok {
+					t.Fatalf("got object type %T, want *unstructured.Unstructured", obj)
+				}
+				return resource
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+				runtime.NewScheme(),
+				map[schema.GroupVersionResource]string{testResourceGVR: "WidgetList"},
+				newTransformTestObject(),
+			)
+			manager := NewSingleClusterInformerManager(t.Context(), client, 0, stripManagedFields)
+			t.Cleanup(manager.Stop)
+
+			assertTransformedTestObject(t, tt.observeObject(t, manager))
+		})
+	}
+}
+
 func TestSingleClusterInformerManagerCreateInformerRechecksInitializedInformer(t *testing.T) {
 	cachedInformer := newRecordingGenericInformer()
 	factoryInformer := newRecordingGenericInformer()
 	factory := &recordingDynamicInformerFactory{informer: factoryInformer}
-	manager := newTestSingleClusterInformerManager(t, factory)
+	manager := newTestSingleClusterInformerManager(t, factory, stripManagedFields)
 	manager.initializedInformers.Store(testResourceGVR, cachedInformer)
 
 	got := manager.createInformer(testResourceGVR)
@@ -49,12 +123,15 @@ func TestSingleClusterInformerManagerCreateInformerRechecksInitializedInformer(t
 	if got := factory.forResourceCalls.Load(); got != 0 {
 		t.Fatalf("factory.ForResource() called %d times, want 0", got)
 	}
+	if got := factoryInformer.informer.setTransformCalls.Load(); got != 0 {
+		t.Fatalf("SetTransform() called %d times, want 0", got)
+	}
 }
 
 func TestSingleClusterInformerManagerCachedLookupSkipsLock(t *testing.T) {
 	genericInformer := newRecordingGenericInformer()
 	factory := &recordingDynamicInformerFactory{informer: genericInformer}
-	manager := newTestSingleClusterInformerManager(t, factory)
+	manager := newTestSingleClusterInformerManager(t, factory, stripManagedFields)
 
 	got := manager.Lister(testResourceGVR)
 	if got != genericInformer.lister {
@@ -91,12 +168,15 @@ func TestSingleClusterInformerManagerCachedLookupSkipsLock(t *testing.T) {
 	if got := factory.forResourceCalls.Load(); got != 1 {
 		t.Fatalf("factory.ForResource() called %d times, want 1", got)
 	}
+	if got := genericInformer.informer.setTransformCalls.Load(); got != 1 {
+		t.Fatalf("SetTransform() called %d times, want 1", got)
+	}
 }
 
 func TestSingleClusterInformerManagerConcurrentHandlerRegistration(t *testing.T) {
 	genericInformer := newRecordingGenericInformer()
 	factory := &recordingDynamicInformerFactory{informer: genericInformer}
-	manager := newTestSingleClusterInformerManager(t, factory)
+	manager := newTestSingleClusterInformerManager(t, factory, nil)
 	handler := &testResourceEventHandler{}
 
 	const goroutines = 32
@@ -134,7 +214,7 @@ func TestSingleClusterInformerManagerConcurrentHandlerRegistration(t *testing.T)
 func TestSingleClusterInformerManagerSerializesInitializationWithStart(t *testing.T) {
 	genericInformer := newRecordingGenericInformer()
 	factory := &recordingDynamicInformerFactory{informer: genericInformer}
-	manager := newTestSingleClusterInformerManager(t, factory)
+	manager := newTestSingleClusterInformerManager(t, factory, stripManagedFields)
 
 	factoryEntered := make(chan struct{})
 	releaseFactory := make(chan struct{})
@@ -152,8 +232,17 @@ func TestSingleClusterInformerManagerSerializesInitializationWithStart(t *testin
 	genericInformer.onInformer = func() {
 		assertMutexHeld(t, &manager.lock, "GenericInformer.Informer")
 	}
+	var transformInstalled atomic.Bool
+	genericInformer.informer.onSetTransform = func() {
+		assertMutexHeld(t, &manager.lock, "SetTransform")
+		transformInstalled.Store(true)
+	}
+	var startBeforeTransform atomic.Bool
 	var startBeforeInformerPublished atomic.Bool
 	factory.onStart = func() {
+		if !transformInstalled.Load() {
+			startBeforeTransform.Store(true)
+		}
 		if _, exists := manager.initializedInformers.Load(testResourceGVR); !exists {
 			startBeforeInformerPublished.Store(true)
 		}
@@ -191,6 +280,9 @@ func TestSingleClusterInformerManagerSerializesInitializationWithStart(t *testin
 	if startReturnedBeforeInitialization {
 		t.Fatal("Start returned before informer initialization completed")
 	}
+	if startBeforeTransform.Load() {
+		t.Fatal("factory.Start() ran before SetTransform() completed")
+	}
 	if startBeforeInformerPublished.Load() {
 		t.Fatal("factory.Start() ran before the initialized informer was published")
 	}
@@ -201,7 +293,7 @@ func TestSingleClusterInformerManagerSerializesInitializationWithStart(t *testin
 
 func TestSingleClusterInformerManagerStartUsesLifecycleLock(t *testing.T) {
 	factory := &recordingDynamicInformerFactory{informer: newRecordingGenericInformer()}
-	manager := newTestSingleClusterInformerManager(t, factory)
+	manager := newTestSingleClusterInformerManager(t, factory, nil)
 	factory.onStart = func() {
 		assertMutexHeld(t, &manager.lock, "factory.Start")
 	}
@@ -213,9 +305,136 @@ func TestSingleClusterInformerManagerStartUsesLifecycleLock(t *testing.T) {
 	}
 }
 
+func TestSingleClusterInformerManagerPublishesInformerAfterTransform(t *testing.T) {
+	genericInformer := newRecordingGenericInformer()
+	factory := &recordingDynamicInformerFactory{informer: genericInformer}
+	manager := newTestSingleClusterInformerManager(t, factory, stripManagedFields)
+
+	transformEntered := make(chan struct{})
+	releaseTransform := make(chan struct{})
+	var releaseTransformOnce sync.Once
+	release := func() {
+		releaseTransformOnce.Do(func() { close(releaseTransform) })
+	}
+	t.Cleanup(release)
+	genericInformer.informer.onSetTransform = func() {
+		close(transformEntered)
+		<-releaseTransform
+	}
+
+	initializationDone := make(chan informers.GenericInformer, 1)
+	go func() {
+		initializationDone <- manager.getOrCreateInformer(testResourceGVR)
+	}()
+	waitForTestSignal(t, transformEntered, "SetTransform")
+
+	_, publishedBeforeTransform := manager.initializedInformers.Load(testResourceGVR)
+	release()
+	resourceInformer := waitForTestValue(t, initializationDone, "informer initialization")
+	if publishedBeforeTransform {
+		t.Fatal("informer was published before SetTransform() completed")
+	}
+	if resourceInformer != genericInformer {
+		t.Fatal("getOrCreateInformer() returned a different GenericInformer")
+	}
+	initializedInformer, exists := manager.initializedInformers.Load(testResourceGVR)
+	if !exists {
+		t.Fatal("informer was not published after SetTransform() completed")
+	}
+	if initializedInformer != genericInformer {
+		t.Fatal("initializedInformers contains a different GenericInformer")
+	}
+}
+
+func TestSingleClusterInformerManagerRetriesFailedTransformWithoutPublishing(t *testing.T) {
+	wantErr := errors.New("failed to install transform")
+	genericInformer := newRecordingGenericInformer()
+	genericInformer.informer.setTransformErr = wantErr
+	factory := &recordingDynamicInformerFactory{informer: genericInformer}
+	manager := newTestSingleClusterInformerManager(t, factory, stripManagedFields)
+
+	if resourceInformer := manager.getOrCreateInformer(testResourceGVR); resourceInformer != genericInformer {
+		t.Fatal("failed transform should still return the underlying GenericInformer")
+	}
+	if _, exists := manager.initializedInformers.Load(testResourceGVR); exists {
+		t.Fatal("failed transform must not publish an initialized informer")
+	}
+
+	if got := manager.Lister(testResourceGVR); got != genericInformer.lister {
+		t.Fatal("Lister() should preserve access to the underlying informer after a transform failure")
+	}
+	handler := &testResourceEventHandler{}
+	manager.ForResource(testResourceGVR, handler)
+	if !manager.IsHandlerExist(testResourceGVR, handler) {
+		t.Fatal("ForResource() should still register the handler after a transform failure")
+	}
+	if got := factory.forResourceCalls.Load(); got != 3 {
+		t.Fatalf("factory.ForResource() called %d times, want 3", got)
+	}
+	if got := genericInformer.informer.setTransformCalls.Load(); got != 3 {
+		t.Fatalf("SetTransform() called %d times, want 3", got)
+	}
+	if got := genericInformer.informer.addEventHandlerCalls.Load(); got != 1 {
+		t.Fatalf("AddEventHandler() called %d times, want 1", got)
+	}
+	if _, exists := manager.initializedInformers.Load(testResourceGVR); exists {
+		t.Fatal("failed transform must not publish an initialized informer after retries")
+	}
+}
+
+func newTransformTestObject() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.io/v1",
+		"kind":       "Widget",
+		"metadata": map[string]any{
+			"namespace": "default",
+			"name":      "widget",
+		},
+		"spec":   map[string]any{"value": "keep-spec"},
+		"status": map[string]any{"value": "keep-status"},
+	}}
+	obj.SetManagedFields([]metav1.ManagedFieldsEntry{{
+		Manager:    "test-manager",
+		Operation:  metav1.ManagedFieldsOperationUpdate,
+		APIVersion: "example.io/v1",
+		FieldsType: "FieldsV1",
+	}})
+	return obj
+}
+
+func stripManagedFields(obj any) (any, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	accessor.SetManagedFields(nil)
+	return obj, nil
+}
+
+func assertTransformedTestObject(t *testing.T, obj *unstructured.Unstructured) {
+	t.Helper()
+	if len(obj.GetManagedFields()) != 0 {
+		t.Fatalf("managedFields were not stripped: %v", obj.GetManagedFields())
+	}
+	if got, _, _ := unstructured.NestedString(obj.Object, "spec", "value"); got != "keep-spec" {
+		t.Fatalf("spec value = %q, want %q", got, "keep-spec")
+	}
+	if got, _, _ := unstructured.NestedString(obj.Object, "status", "value"); got != "keep-status" {
+		t.Fatalf("status value = %q, want %q", got, "keep-status")
+	}
+}
+
+func waitForTestInformerSync(t *testing.T, manager SingleClusterInformerManager) {
+	t.Helper()
+	if synced := manager.WaitForCacheSyncWithTimeout(5 * time.Second); !synced[testResourceGVR] {
+		t.Fatalf("informer failed to sync: %v", synced)
+	}
+}
+
 func newTestSingleClusterInformerManager(
 	t *testing.T,
 	factory dynamicinformer.DynamicSharedInformerFactory,
+	transform cache.TransformFunc,
 ) *singleClusterInformerManagerImpl {
 	t.Helper()
 	ctx, cancel := context.WithCancel(t.Context())
@@ -224,6 +443,7 @@ func newTestSingleClusterInformerManager(
 		ctx:             ctx,
 		cancel:          cancel,
 		informerFactory: factory,
+		transformFunc:   transform,
 	}
 }
 
@@ -286,7 +506,10 @@ func (i *recordingGenericInformer) Lister() cache.GenericLister {
 type recordingSharedIndexInformer struct {
 	cache.SharedIndexInformer
 
+	setTransformCalls    atomic.Int64
 	addEventHandlerCalls atomic.Int64
+	setTransformErr      error
+	onSetTransform       func()
 }
 
 type testResourceEventHandler struct{}
@@ -294,6 +517,14 @@ type testResourceEventHandler struct{}
 func (*testResourceEventHandler) OnAdd(_ any, _ bool) {}
 func (*testResourceEventHandler) OnUpdate(_, _ any)   {}
 func (*testResourceEventHandler) OnDelete(_ any)      {}
+
+func (i *recordingSharedIndexInformer) SetTransform(_ cache.TransformFunc) error {
+	i.setTransformCalls.Add(1)
+	if i.onSetTransform != nil {
+		i.onSetTransform()
+	}
+	return i.setTransformErr
+}
 
 func (i *recordingSharedIndexInformer) AddEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
 	i.addEventHandlerCalls.Add(1)

--- a/pkg/util/helper/binding_test.go
+++ b/pkg/util/helper/binding_test.go
@@ -40,6 +40,7 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
@@ -1006,7 +1007,7 @@ func TestFetchWorkload(t *testing.T) {
 			args: args{
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: meta.NewDefaultRESTMapper(nil),
 				resource:   workv1alpha2.ObjectReference{APIVersion: "v1", Kind: "Pod"},
@@ -1019,7 +1020,7 @@ func TestFetchWorkload(t *testing.T) {
 			args: args{
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: func() meta.RESTMapper {
 					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
@@ -1042,7 +1043,7 @@ func TestFetchWorkload(t *testing.T) {
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 					&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}}),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: func() meta.RESTMapper {
 					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
@@ -1073,7 +1074,7 @@ func TestFetchWorkload(t *testing.T) {
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}})
-					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1107,7 +1108,7 @@ func TestFetchWorkload(t *testing.T) {
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node"}}),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: func() meta.RESTMapper {
 					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
@@ -1136,7 +1137,7 @@ func TestFetchWorkload(t *testing.T) {
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node"}})
-					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("nodes"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1203,7 +1204,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 			args: args{
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: meta.NewDefaultRESTMapper(nil),
 				resource:   workv1alpha2.ObjectReference{APIVersion: "v1", Kind: "Pod"},
@@ -1217,7 +1218,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 					&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"foo": "foo"}}}),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: func() meta.RESTMapper {
 					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
@@ -1241,7 +1242,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"bar": "foo"}}})
-					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1269,7 +1270,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node", Labels: map[string]string{"bar": "bar"}}}),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: func() meta.RESTMapper {
 					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
@@ -1293,7 +1294,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node", Labels: map[string]string{"bar": "foo"}}})
-					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("nodes"))
 					m.Start()
 					m.WaitForCacheSync()

--- a/pkg/util/helper/cache_test.go
+++ b/pkg/util/helper/cache_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
 )
@@ -50,7 +51,7 @@ func TestGetObjectFromCache(t *testing.T) {
 			args: args{
 				restMapper: meta.NewDefaultRESTMapper(nil),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					return genericmanager.NewMultiClusterInformerManager(ctx)
+					return genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 				},
 				fedKey: keys.FederatedKey{Cluster: "cluster", ClusterWideKey: keys.ClusterWideKey{
 					Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod",
@@ -68,7 +69,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					return genericmanager.NewMultiClusterInformerManager(ctx)
+					return genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 				},
 				fedKey: keys.FederatedKey{Cluster: "cluster", ClusterWideKey: keys.ClusterWideKey{
 					Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod",
@@ -86,7 +87,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					m := genericmanager.NewMultiClusterInformerManager(ctx)
+					m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme), 0)
 					return m
 				},
@@ -106,7 +107,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					m := genericmanager.NewMultiClusterInformerManager(ctx)
+					m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}},
 					), 0)
@@ -133,7 +134,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					m := genericmanager.NewMultiClusterInformerManager(ctx)
+					m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme), 0).
 						Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start("cluster")
@@ -156,7 +157,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					m := genericmanager.NewMultiClusterInformerManager(ctx)
+					m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}},
 					), 0).Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
@@ -210,7 +211,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 			args: args{
 				restMapper: meta.NewDefaultRESTMapper(nil),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				cwk: &keys.ClusterWideKey{Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod"},
 			},
@@ -226,7 +227,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				cwk: &keys.ClusterWideKey{Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod"},
 			},
@@ -243,7 +244,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := fake.NewSimpleDynamicClient(scheme.Scheme, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}})
-					return genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 				},
 				cwk: &keys.ClusterWideKey{Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod"},
 			},
@@ -264,7 +265,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					m := genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start()
 					m.WaitForCacheSync()
@@ -285,7 +286,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := fake.NewSimpleDynamicClient(scheme.Scheme, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}})
-					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start()
 					m.WaitForCacheSync()

--- a/pkg/util/helper/cache_test.go
+++ b/pkg/util/helper/cache_test.go
@@ -35,6 +35,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
@@ -57,7 +58,7 @@ func TestRegisterInformerHandlerAndCheckSynced(t *testing.T) {
 		{
 			name: "registers missing handler and starts informer",
 			manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-				m := genericmanager.NewMultiClusterInformerManager(ctx)
+				m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 				m.ForCluster(cluster.Name, dynamicClient, 0)
 				return m
 			},
@@ -69,7 +70,7 @@ func TestRegisterInformerHandlerAndCheckSynced(t *testing.T) {
 		{
 			name: "returns synced when handler exists and informer synced",
 			manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-				m := genericmanager.NewMultiClusterInformerManager(ctx)
+				m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 				m.ForCluster(cluster.Name, dynamicClient, 0).ForResource(gvr, handler)
 				m.Start(cluster.Name)
 				m.WaitForCacheSync(cluster.Name)
@@ -83,7 +84,7 @@ func TestRegisterInformerHandlerAndCheckSynced(t *testing.T) {
 		{
 			name: "creates manager with cluster client when missing",
 			manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-				return genericmanager.NewMultiClusterInformerManager(ctx)
+				return genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 			},
 			clusterClientSetFunc: func(clusterName string, _ client.Client, _ *util.ClientOption) (*util.DynamicClusterClient, error) {
 				return &util.DynamicClusterClient{ClusterName: clusterName, DynamicClientSet: dynamicClient}, nil
@@ -93,7 +94,7 @@ func TestRegisterInformerHandlerAndCheckSynced(t *testing.T) {
 		{
 			name: "returns error when cluster client creation fails",
 			manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-				return genericmanager.NewMultiClusterInformerManager(ctx)
+				return genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 			},
 			clusterClientSetFunc: func(string, client.Client, *util.ClientOption) (*util.DynamicClusterClient, error) {
 				return nil, errors.New("failed to build dynamic client")
@@ -149,7 +150,7 @@ func TestGetObjectFromCache(t *testing.T) {
 			args: args{
 				restMapper: meta.NewDefaultRESTMapper(nil),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					return genericmanager.NewMultiClusterInformerManager(ctx)
+					return genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 				},
 				fedKey: keys.FederatedKey{Cluster: "cluster", ClusterWideKey: keys.ClusterWideKey{
 					Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod",
@@ -167,7 +168,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					return genericmanager.NewMultiClusterInformerManager(ctx)
+					return genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 				},
 				fedKey: keys.FederatedKey{Cluster: "cluster", ClusterWideKey: keys.ClusterWideKey{
 					Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod",
@@ -185,7 +186,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					m := genericmanager.NewMultiClusterInformerManager(ctx)
+					m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme), 0)
 					return m
 				},
@@ -205,7 +206,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					m := genericmanager.NewMultiClusterInformerManager(ctx)
+					m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}},
 					), 0)
@@ -232,7 +233,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					m := genericmanager.NewMultiClusterInformerManager(ctx)
+					m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme), 0).
 						Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start("cluster")
@@ -255,7 +256,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					m := genericmanager.NewMultiClusterInformerManager(ctx)
+					m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}},
 					), 0).Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
@@ -309,7 +310,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 			args: args{
 				restMapper: meta.NewDefaultRESTMapper(nil),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				cwk: &keys.ClusterWideKey{Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod"},
 			},
@@ -325,7 +326,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				cwk: &keys.ClusterWideKey{Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod"},
 			},
@@ -342,7 +343,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := fake.NewSimpleDynamicClient(scheme.Scheme, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}})
-					return genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 				},
 				cwk: &keys.ClusterWideKey{Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod"},
 			},
@@ -363,7 +364,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					m := genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start()
 					m.WaitForCacheSync()
@@ -384,7 +385,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := fake.NewSimpleDynamicClient(scheme.Scheme, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}})
-					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start()
 					m.WaitForCacheSync()

--- a/pkg/util/testing/mock_manager.go
+++ b/pkg/util/testing/mock_manager.go
@@ -24,13 +24,14 @@ import (
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 )
 
 // NewSingleClusterInformerManagerByRS will build a fake SingleClusterInformerManager and can add resource.
 func NewSingleClusterInformerManagerByRS(src string, obj runtime.Object) genericmanager.SingleClusterInformerManager {
 	c := fakedynamic.NewSimpleDynamicClient(scheme.Scheme, obj)
-	m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+	m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 	m.Lister(corev1.SchemeGroupVersion.WithResource(src))
 	m.Start()
 	m.WaitForCacheSync()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds configurable cache transforms to the single- and multi-cluster dynamic informer managers and applies each configured transform once before the informer starts.

Karmada controllers, agent, scheduler estimator, and `karmadactl promote` now use `StripUnusedFields` to remove `managedFields` from cached objects and reduce cache memory usage.

In a karmada-controller-manager that distributes 20,000 deployments to two member clusters, tests showed that this optimization reduced peak memory usage from **5G** to **3.4G**.

<img width="1537" height="854" alt="image" src="https://github.com/user-attachments/assets/eba2c7f9-4182-40b8-adcc-b446b4030232" />


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

```release-note
`karmada-controller-manager`/`karmada-agent`/`karmada-scheduler-estimator`: Stripped `managedFields` from dynamic informer caches to reduce memory usage.
```