### PR TITLE
feat(scheduler): add --binding-update-debounce flag to collapse burst binding spec updates

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -104,6 +104,10 @@ type Options struct {
 
 	// RateLimiterOpts contains the options for rate limiter.
 	RateLimiterOpts ratelimiterflag.Options
+
+	// BindingUpdateDebounce delays scheduling after a ResourceBinding spec
+	// update so that updates arriving close together are handled in one pass.
+	BindingUpdateDebounce metav1.Duration
 }
 
 // NewOptions builds an default scheduler options.
@@ -164,6 +168,12 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 		fmt.Sprintf("A list of plugins to enable. '*' enables all build-in and customized plugins, 'foo' enables the plugin named 'foo', '*,-foo' disables the plugin named 'foo'.\nAll build-in plugins: %s.", strings.Join(frameworkplugins.NewInTreeRegistry().FactoryNames(), ",")))
 	fs.StringVar(&o.SchedulerName, "scheduler-name", scheduler.DefaultScheduler, "SchedulerName represents the name of the scheduler. default is 'default-scheduler'.")
 	features.FeatureGate.AddFlag(fs)
+	fs.DurationVar(&o.BindingUpdateDebounce.Duration, "binding-update-debounce", 0,
+		"Wait this long after a ResourceBinding spec update before scheduling it, so that "+
+			"updates arriving close together are collapsed into a single scheduling pass. "+
+			"Useful when a GitOps tool applies the workload and its PropagationPolicy in "+
+			"separate requests, which can otherwise expose a transient mismatch between "+
+			"replica count and placement. 0 disables the delay.")
 	o.ProfileOpts.AddFlags(fs)
 	o.RateLimiterOpts.AddFlags(fs)
 }

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -188,6 +188,7 @@ func run(ctx context.Context, opts *options.Options, registryOptions ...Option) 
 		scheduler.WithEnableSchedulerPlugin(opts.Plugins),
 		scheduler.WithSchedulerName(opts.SchedulerName),
 		scheduler.WithRateLimiterOptions(opts.RateLimiterOpts),
+		scheduler.WithBindingUpdateDebounce(opts.BindingUpdateDebounce),
 	)
 	if err != nil {
 		return fmt.Errorf("couldn't create scheduler: %w", err)

--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -213,7 +213,15 @@ func (s *Scheduler) onResourceBindingUpdate(old, cur any) {
 			klog.Errorf("couldn't get key for object %#v: %v", newRB, err)
 			return
 		}
-		s.queue.Add(key)
+
+		// Collapse bursts of spec updates into one scheduling pass. Only update
+		// events are delayed; adds and requeues (failover, cluster changes) stay
+		// on the fast path.
+		if s.bindingUpdateDebounce > 0 {
+			s.queue.AddAfter(key, s.bindingUpdateDebounce)
+		} else {
+			s.queue.Add(key)
+		}
 	}
 	metrics.CountSchedulerBindings(metrics.BindingUpdate)
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -108,6 +108,9 @@ type Scheduler struct {
 	Algorithm      core.ScheduleAlgorithm
 	schedulerCache schedulercache.Cache
 
+	// bindingUpdateDebounce, see WithBindingUpdateDebounce.
+	bindingUpdateDebounce time.Duration
+
 	eventRecorder record.EventRecorder
 
 	enableSchedulerEstimator            bool
@@ -143,6 +146,10 @@ type schedulerOptions struct {
 	plugins []string
 	// contains the options for rate limiter.
 	RateLimiterOptions ratelimiterflag.Options
+	// bindingUpdateDebounce delays scheduling after a ResourceBinding spec update,
+	// so that several updates arriving in quick succession are collapsed into a
+	// single scheduling pass. Zero disables the delay (previous behaviour).
+	bindingUpdateDebounce metav1.Duration
 	// schedulerEstimatorClientConfig contains the configuration of GRPC.
 	schedulerEstimatorClientConfig *grpcconnection.ClientConfig
 }
@@ -227,6 +234,26 @@ func WithOutOfTreeRegistry(registry runtime.Registry) Option {
 	}
 }
 
+// WithBindingUpdateDebounce sets how long to wait after a ResourceBinding spec
+// update before scheduling it.
+//
+// A workload's replica count and its placement live on two different objects
+// (e.g. Deployment/ReplicaSet and PropagationPolicy). GitOps tools apply those
+// objects in separate requests, so the detector may briefly observe a new
+// replica count alongside a stale placement (or vice versa) and write that
+// inconsistent pair into the ResourceBinding. Scheduling it immediately turns
+// the transient pair into real replica churn in member clusters.
+//
+// Delaying the scheduling pass lets those updates collapse: the queue keeps the
+// earliest ready time for a key, and the worker re-reads the binding from the
+// lister, so it observes the settled state. Set to a value comfortably above the
+// interval between the GitOps tool's individual apply calls.
+func WithBindingUpdateDebounce(d metav1.Duration) Option {
+	return func(o *schedulerOptions) {
+		o.bindingUpdateDebounce = d
+	}
+}
+
 // WithRateLimiterOptions sets the rateLimiterOptions for scheduler
 func WithRateLimiterOptions(rateLimiterOptions ratelimiterflag.Options) Option {
 	return func(o *schedulerOptions) {
@@ -266,17 +293,18 @@ func NewScheduler(dynamicClient dynamic.Interface, karmadaClient karmadaclientse
 	}
 
 	sched := &Scheduler{
-		DynamicClient:        dynamicClient,
-		KarmadaClient:        karmadaClient,
-		KubeClient:           kubeClient,
-		bindingLister:        bindingLister,
-		clusterBindingLister: clusterBindingLister,
-		clusterLister:        clusterLister,
-		informerFactory:      factory,
-		queue:                legacyQueue,
-		priorityQueue:        priorityQueue,
-		Algorithm:            algorithm,
-		schedulerCache:       schedulerCache,
+		DynamicClient:         dynamicClient,
+		KarmadaClient:         karmadaClient,
+		KubeClient:            kubeClient,
+		bindingLister:         bindingLister,
+		clusterBindingLister:  clusterBindingLister,
+		clusterLister:         clusterLister,
+		informerFactory:       factory,
+		queue:                 legacyQueue,
+		priorityQueue:         priorityQueue,
+		Algorithm:             algorithm,
+		schedulerCache:        schedulerCache,
+		bindingUpdateDebounce: options.bindingUpdateDebounce.Duration,
 	}
 
 	sched.clusterReconcileWorker = util.NewAsyncWorker(util.Options{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

A workload's replica count and its placement live on two different objects (e.g. a `Deployment` and its `PropagationPolicy`). GitOps tools apply those objects in separate requests, so the detector may briefly observe a new replica count alongside a stale placement (or vice versa) and write that inconsistent pair into the `ResourceBinding`. Scheduling that transient state immediately turns it into real replica churn in member clusters — replicas get scaled up/down and then corrected a moment later once the settled state arrives.

This PR adds a `--binding-update-debounce` flag to `karmada-scheduler`. When set to a non-zero duration, a `ResourceBinding` spec update is enqueued with `AddAfter` instead of `Add`, so updates arriving close together are collapsed into a single scheduling pass. The workqueue keeps the earliest ready time for a key, and the worker re-reads the binding from the lister when it runs, so it observes the settled state rather than the transient one.

Scope of the change:

- Only **update** events are delayed. Adds and requeues (failover, cluster changes) stay on the fast path.
- Defaults to `0`, which disables the delay and preserves the existing behaviour exactly.
- Users should set it comfortably above the interval between their GitOps tool's individual apply calls.

**Which issue(s) this PR fixes**:

Fixes #7805

**Special notes for your reviewer**:

- Existing `pkg/scheduler/...` unit tests pass; `go vet` and `gofmt` are clean.
- Happy to add a unit test covering the `AddAfter` path or to extend the same handling to `ClusterResourceBinding` / the priority queue path if reviewers think that's in scope — the current change is intentionally kept minimal.

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-scheduler`: Introduced `--binding-update-debounce` flag to delay scheduling after a ResourceBinding spec update, so that updates arriving close together are collapsed into a single scheduling pass. Defaults to 0, which keeps the previous behavior.
```
