### PR TITLE
scheduler: move flush-completed bindings to activeQ in priority order

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -17,6 +17,7 @@ limitations under the License.
 package queue
 
 import (
+	"sort"
 	"sync"
 	"time"
 
@@ -202,6 +203,7 @@ func (bq *prioritySchedulingQueue) flushBackoffQCompleted() {
 	bq.lock.Lock()
 	defer bq.lock.Unlock()
 
+	var bindingsToMove []*QueuedBindingInfo
 	for {
 		bInfo, ok := bq.backoffQ.Peek()
 		if !ok || bInfo == nil {
@@ -210,11 +212,21 @@ func (bq *prioritySchedulingQueue) flushBackoffQCompleted() {
 		if bq.isBindingBackingoff(bInfo) {
 			break
 		}
-		_, err := bq.backoffQ.Pop()
+		popped, err := bq.backoffQ.Pop()
 		if err != nil {
 			klog.ErrorS(err, "Unable to pop binding from backoff queue despite backoff completion", "binding", bInfo.NamespacedKey)
 			break
 		}
+		bindingsToMove = append(bindingsToMove, popped)
+	}
+
+	// backoffQ is ordered by backoff-completion time (see lessBackoffCompletedWithPriority),
+	// so the bindings above are collected in expiry order. Re-order the eligible batch by the
+	// same Less function as activeQ before inserting, so that within a single flush a
+	// higher-priority binding is pushed (and therefore popped by the worker) before
+	// lower-priority ones. This keeps the backoffQ readiness gating unchanged.
+	sortBindingsByPriority(bindingsToMove)
+	for _, bInfo := range bindingsToMove {
 		bq.moveToActiveQ(bInfo)
 	}
 }
@@ -280,9 +292,23 @@ func (bq *prioritySchedulingQueue) flushUnschedulableBindingsLeftover() {
 		}
 	}
 
+	// Order the eligible batch by the same Less function as activeQ before inserting, so that
+	// higher-priority bindings are pushed first within a single flush. Iterating the map above
+	// yields a non-deterministic order, so without this the batch could enter activeQ in an
+	// arbitrary order.
+	sortBindingsByPriority(bindingsToMove)
 	for _, bInfo := range bindingsToMove {
 		bq.moveToActiveQ(bInfo)
 	}
+}
+
+// sortBindingsByPriority orders bindings using the same Less function as activeQ so that,
+// within a single flush, higher-priority bindings are inserted into activeQ (and therefore
+// popped by the scheduler worker) before lower-priority ones.
+func sortBindingsByPriority(bindings []*QueuedBindingInfo) {
+	sort.Slice(bindings, func(i, j int) bool {
+		return Less(bindings[i], bindings[j])
+	})
 }
 
 func (bq *prioritySchedulingQueue) Push(bindingInfo *QueuedBindingInfo) {

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -234,3 +234,90 @@ func TestBackoffQueueOrdering(t *testing.T) {
 		})
 	}
 }
+
+// recordingActiveQueue is a test double for ActiveQueue that records the order in which
+// bindings are pushed, so tests can assert the insertion order produced by the flush funcs.
+type recordingActiveQueue struct {
+	pushed []*QueuedBindingInfo
+}
+
+func (r *recordingActiveQueue) Push(bindingInfo *QueuedBindingInfo) {
+	r.pushed = append(r.pushed, bindingInfo)
+}
+func (r *recordingActiveQueue) Pop() (*QueuedBindingInfo, bool) { return nil, false }
+func (r *recordingActiveQueue) Len() int                        { return len(r.pushed) }
+func (r *recordingActiveQueue) Done(*QueuedBindingInfo)         {}
+func (r *recordingActiveQueue) Has(string) bool                 { return false }
+func (r *recordingActiveQueue) ShutDown()                       {}
+
+func (r *recordingActiveQueue) pushedKeys() []string {
+	keys := make([]string, 0, len(r.pushed))
+	for _, bInfo := range r.pushed {
+		keys = append(keys, bInfo.NamespacedKey)
+	}
+	return keys
+}
+
+// TestFlushBackoffQCompletedPriorityOrder verifies that within a single flush, backoff-completed
+// bindings are moved into activeQ in priority order (not backoff-expiry order), while bindings
+// still within their backoff period stay in backoffQ.
+func TestFlushBackoffQCompletedPriorityOrder(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	activeQ := &recordingActiveQueue{}
+	bq := &prioritySchedulingQueue{
+		clock:                         fakeClock,
+		bindingInitialBackoffDuration: DefaultBindingInitialBackoffDuration,
+		bindingMaxBackoffDuration:     DefaultBindingMaxBackoffDuration,
+		activeQ:                       activeQ,
+		unschedulableBindings:         newUnschedulableBindings(metrics.NewUnschedulableBindingsRecorder()),
+	}
+	bq.backoffQ = heap.NewWithRecorder(BindingKeyFunc, bq.lessBackoffCompletedWithPriority, metrics.NewBackoffBindingsRecorder())
+
+	// lowEarly completes its backoff earliest but has the lowest priority; highLate completes
+	// later but has the highest priority. Without priority-ordering the flush, lowEarly (earlier
+	// expiry) would be moved to activeQ first.
+	lowEarly := &QueuedBindingInfo{NamespacedKey: "lowEarly", Priority: 1, Timestamp: fakeClock.Now().Add(-10 * time.Second), Attempts: 1}
+	highLate := &QueuedBindingInfo{NamespacedKey: "highLate", Priority: 10, Timestamp: fakeClock.Now().Add(-2 * time.Second), Attempts: 1}
+	// notReady is still within its backoff period and must stay in backoffQ.
+	notReady := &QueuedBindingInfo{NamespacedKey: "notReady", Priority: 100, Timestamp: fakeClock.Now(), Attempts: 3}
+	bq.backoffQ.AddOrUpdate(lowEarly)
+	bq.backoffQ.AddOrUpdate(highLate)
+	bq.backoffQ.AddOrUpdate(notReady)
+
+	bq.flushBackoffQCompleted()
+
+	assert.Equal(t, []string{"highLate", "lowEarly"}, activeQ.pushedKeys(), "completed bindings should enter activeQ in priority order")
+	assert.Equal(t, 1, bq.backoffQ.Len(), "binding still backing off should remain in backoffQ")
+	assert.True(t, bq.backoffQ.Has(notReady), "notReady should remain in backoffQ")
+}
+
+// TestFlushUnschedulableBindingsLeftoverPriorityOrder verifies that bindings which have exceeded
+// the unschedulable timeout are moved into activeQ in priority order, while bindings still within
+// the timeout are left in unschedulableBindings.
+func TestFlushUnschedulableBindingsLeftoverPriorityOrder(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	activeQ := &recordingActiveQueue{}
+	bq := &prioritySchedulingQueue{
+		clock:                 fakeClock,
+		activeQ:               activeQ,
+		unschedulableBindings: newUnschedulableBindings(metrics.NewUnschedulableBindingsRecorder()),
+	}
+	bq.bindingMaxInUnschedulableBindingsDuration = DefaultBindingMaxInUnschedulableBindingsDuration
+	bq.backoffQ = heap.NewWithRecorder(BindingKeyFunc, bq.lessBackoffCompletedWithPriority, metrics.NewBackoffBindingsRecorder())
+
+	stale := fakeClock.Now().Add(-10 * time.Minute)
+	low := &QueuedBindingInfo{NamespacedKey: "low", Priority: 1, Timestamp: stale}
+	med := &QueuedBindingInfo{NamespacedKey: "med", Priority: 5, Timestamp: stale}
+	high := &QueuedBindingInfo{NamespacedKey: "high", Priority: 10, Timestamp: stale}
+	// fresh is still within the timeout and must not be moved.
+	fresh := &QueuedBindingInfo{NamespacedKey: "fresh", Priority: 100, Timestamp: fakeClock.Now()}
+	for _, bInfo := range []*QueuedBindingInfo{low, med, high, fresh} {
+		bq.unschedulableBindings.addOrUpdate(bInfo)
+	}
+
+	bq.flushUnschedulableBindingsLeftover()
+
+	assert.Equal(t, []string{"high", "med", "low"}, activeQ.pushedKeys(), "leftover bindings should enter activeQ in priority order")
+	assert.NotNil(t, bq.unschedulableBindings.get("fresh"), "binding within the timeout should remain in unschedulableBindings")
+	assert.Nil(t, bq.unschedulableBindings.get("high"), "moved binding should be removed from unschedulableBindings")
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When bindings become eligible to retry (for example after resource/quota contention clears), they should enter the active queue in priority order so that higher-priority bindings are attempted first.

Currently, within a single flush:
- `flushBackoffQCompleted()` moves the backoff-completed bindings into `activeQ` in backoff-expiry order, and
- `flushUnschedulableBindingsLeftover()` moves the timed-out bindings in map-iteration (non-deterministic) order.

Because each move wakes the scheduler worker, a lower-priority binding can be inserted into `activeQ` and popped before a higher-priority binding from the same batch, resulting in priority inversion.

This PR sorts the eligible batch using the same `Less` function as `activeQ` before moving the bindings, so higher-priority bindings are inserted (and therefore popped) first. The backoffQ readiness ordering (`lessBackoffCompletedWithPriority`) is unchanged — this only reorders bindings already deemed eligible in the current flush. Note this is a best-effort improvement and does not provide strict priority guarantees (with a single scheduler worker the ordering window affects at most one binding per flush).

**Which issue(s) this PR fixes**:

Fixes #7802

**Special notes for your reviewer**:

- No change to the backoffQ comparator (`lessBackoffCompletedWithPriority`); the readiness gating is preserved. Only the order in which the already-eligible batch is moved into `activeQ` changes.
- Added unit tests using a recording fake `ActiveQueue` to assert the insertion order — `activeQ` is itself a priority heap, so popping it after a flush would otherwise mask the batch ordering:
  - `TestFlushBackoffQCompletedPriorityOrder`: an earlier-completing low-priority binding vs a later-completing high-priority binding → asserts the high-priority binding is inserted first, and a binding still within its backoff period stays in `backoffQ`.
  - `TestFlushUnschedulableBindingsLeftoverPriorityOrder`: multiple timed-out bindings of different priorities → asserts priority-ordered insertion, and a binding still within the timeout stays in `unschedulableBindings`.

Test report:
```
$ go test ./pkg/scheduler/internal/queue/...
ok      github.com/karmada-io/karmada/pkg/scheduler/internal/queue
```

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-scheduler`: Within a single flush, bindings whose backoff or unschedulable timeout has completed are now moved into the active queue in priority order, so higher-priority bindings are retried first (best-effort).
```
