### PR TITLE
feat: Retain only metadata for member cluster resources not mapped to an existing Work

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -262,7 +262,7 @@ func run(ctx context.Context, opts *options.Options) error {
 func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *options.Options) error {
 	restConfig := mgr.GetConfig()
 	dynamicClientSet := dynamic.NewForConfigOrDie(restConfig)
-	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, 0)
+	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, 0, fedinformer.StripUnusedFields)
 	controlPlaneKubeClientSet := kubeclientset.NewForConfigOrDie(restConfig)
 
 	// We need a service lister to build a resource interpreter with `ClusterIPServiceResolver`

--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -349,7 +349,7 @@ func startExecutionController(ctx controllerscontext.Context) (bool, error) {
 		EventRecorder:        ctx.Mgr.GetEventRecorderFor(execution.ControllerName), //nolint:staticcheck // Note: GetEventRecorderFor is deprecated in controller-runtime v0.23.0 in favor of GetEventRecorder. This changes event API from v1 events to events.k8s.io. We need to migrate carefully, especially considering the impact on users and RBAC permission changes in installation/deployment tools.
 		RESTMapper:           ctx.Mgr.GetRESTMapper(),
 		ObjectWatcher:        ctx.ObjectWatcher,
-		InformerManager:      genericmanager.GetInstance(),
+		InformerManager:      genericmanager.NewMultiClusterInformerManager(ctx.Context, fedinformer.NewWorkMappingTransformFunc(ctx.Mgr.GetClient())),
 		RateLimiterOptions:   ctx.Opts.RateLimiterOptions,
 		ClusterClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		ClusterClientOption:  ctx.ClusterClientOption,
@@ -365,7 +365,7 @@ func startWorkStatusController(ctx controllerscontext.Context) (bool, error) {
 		Client:                      ctx.Mgr.GetClient(),
 		EventRecorder:               ctx.Mgr.GetEventRecorderFor(status.WorkStatusControllerName), //nolint:staticcheck // Note: GetEventRecorderFor is deprecated in controller-runtime v0.23.0 in favor of GetEventRecorder. This changes event API from v1 events to events.k8s.io. We need to migrate carefully, especially considering the impact on users and RBAC permission changes in installation/deployment tools.
 		RESTMapper:                  ctx.Mgr.GetRESTMapper(),
-		InformerManager:             genericmanager.GetInstance(),
+		InformerManager:             genericmanager.NewMultiClusterInformerManager(ctx.Context, fedinformer.NewWorkMappingTransformFunc(ctx.Mgr.GetClient())),
 		Context:                     ctx.Context,
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		ClusterClientOption:         ctx.ClusterClientOption,

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -853,7 +853,7 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *
 		return
 	}
 
-	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, opts.ResyncPeriod.Duration)
+	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, opts.ResyncPeriod.Duration, fedinformer.StripUnusedFields)
 	// We need a service lister to build a resource interpreter with `ClusterIPServiceResolver`
 	// witch allows connection to the customized interpreter webhook without a cluster DNS service.
 	sharedFactory := informers.NewSharedInformerFactory(kubeClientSet, opts.ResyncPeriod.Duration)
@@ -969,7 +969,7 @@ func setupClusterAPIClusterDetector(ctx context.Context, mgr controllerruntime.M
 		ControllerPlaneConfig: mgr.GetConfig(),
 		ClusterAPIConfig:      clusterAPIRestConfig,
 		ClusterAPIClient:      clusterAPIClient,
-		InformerManager:       genericmanager.NewSingleClusterInformerManager(ctx, dynamic.NewForConfigOrDie(clusterAPIRestConfig), 0),
+		InformerManager:       genericmanager.NewSingleClusterInformerManager(ctx, dynamic.NewForConfigOrDie(clusterAPIRestConfig), 0, fedinformer.StripUnusedFields),
 		ConcurrentReconciles:  3,
 	}
 	if err := mgr.Add(clusterAPIClusterDetector); err != nil {

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -461,7 +461,7 @@ func startExecutionController(ctx controllerscontext.Context) (enabled bool, err
 		RESTMapper:           ctx.Mgr.GetRESTMapper(),
 		ObjectWatcher:        ctx.ObjectWatcher,
 		WorkPredicateFunc:    helper.WorkWithinPushClusterPredicate(ctx.Mgr),
-		InformerManager:      genericmanager.GetInstance(),
+		InformerManager:      genericmanager.NewMultiClusterInformerManager(ctx.Context, fedinformer.NewWorkMappingTransformFunc(ctx.Mgr.GetClient())),
 		RateLimiterOptions:   ctx.Opts.RateLimiterOptions,
 		ClusterClientSetFunc: util.NewClusterDynamicClientSet,
 		ClusterClientOption:  ctx.ClusterClientOption,
@@ -473,17 +473,16 @@ func startExecutionController(ctx controllerscontext.Context) (enabled bool, err
 }
 
 func startWorkStatusController(ctx controllerscontext.Context) (enabled bool, err error) {
-	opts := ctx.Opts
 	workStatusController := &status.WorkStatusController{
 		Client:                      ctx.Mgr.GetClient(),
 		EventRecorder:               ctx.Mgr.GetEventRecorderFor(status.WorkStatusControllerName), //nolint:staticcheck // Note: GetEventRecorderFor is deprecated in controller-runtime v0.23.0 in favor of GetEventRecorder. This changes event API from v1 events to events.k8s.io. We need to migrate carefully, especially considering the impact on users and RBAC permission changes in installation/deployment tools.
 		RESTMapper:                  ctx.Mgr.GetRESTMapper(),
-		InformerManager:             genericmanager.GetInstance(),
+		InformerManager:             genericmanager.NewMultiClusterInformerManager(ctx.Context, fedinformer.NewWorkMappingTransformFunc(ctx.Mgr.GetClient())),
 		Context:                     ctx.Context,
 		WorkPredicateFunc:           helper.WorkWithinPushClusterPredicate(ctx.Mgr),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSet,
 		ClusterClientOption:         ctx.ClusterClientOption,
-		ConcurrentWorkStatusSyncs:   opts.ConcurrentWorkSyncs,
+		ConcurrentWorkStatusSyncs:   ctx.Opts.ConcurrentWorkSyncs,
 		RateLimiterOptions:          ctx.Opts.RateLimiterOptions,
 		ResourceInterpreter:         ctx.ResourceInterpreter,
 	}

--- a/pkg/controllers/binding/binding_controller_test.go
+++ b/pkg/controllers/binding/binding_controller_test.go
@@ -41,6 +41,7 @@ import (
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	testing2 "github.com/karmada-io/karmada/pkg/search/proxy/testing"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/indexregistry"
@@ -63,7 +64,7 @@ func makeFakeRBCByResource(rs *workv1alpha2.ObjectReference) (*ResourceBindingCo
 		return &ResourceBindingController{
 			Client:          c,
 			RESTMapper:      testing2.RestMapper,
-			InformerManager: genericmanager.NewSingleClusterInformerManager(context.TODO(), tempDyClient, 0),
+			InformerManager: genericmanager.NewSingleClusterInformerManager(context.TODO(), tempDyClient, 0, fedinformer.StripUnusedFields),
 			DynamicClient:   tempDyClient,
 		}, nil
 	}

--- a/pkg/controllers/binding/cluster_resource_binding_controller_test.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/events"
 	testing2 "github.com/karmada-io/karmada/pkg/search/proxy/testing"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/indexregistry"
@@ -62,7 +63,7 @@ func makeFakeCRBCByResource(rs *workv1alpha2.ObjectReference) (*ClusterResourceB
 		return &ClusterResourceBindingController{
 			Client:          c,
 			RESTMapper:      testing2.RestMapper,
-			InformerManager: genericmanager.NewSingleClusterInformerManager(context.TODO(), tempDyClient, 0),
+			InformerManager: genericmanager.NewSingleClusterInformerManager(context.TODO(), tempDyClient, 0, fedinformer.StripUnusedFields),
 			DynamicClient:   tempDyClient,
 		}, nil
 	}

--- a/pkg/controllers/execution/execution_controller_test.go
+++ b/pkg/controllers/execution/execution_controller_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/objectwatcher"
@@ -354,7 +355,7 @@ func TestExecutionController_NewGVRInformerRequeuesWorkForMemberResourceChangedB
 		return false, nil, nil
 	})
 
-	informerManager := genericmanager.NewMultiClusterInformerManager(ctx)
+	informerManager := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 	clusterClientSetFunc := func(string, client.Client, *util.ClientOption) (*util.DynamicClusterClient, error) {
 		return &util.DynamicClusterClient{
 			ClusterName:      clusterName,
@@ -449,7 +450,7 @@ func newController(work *workv1alpha1.Work, recorder *record.FakeRecorder) Contr
 		WithInterceptorFuncs(withGVKInterceptor(clientScheme)).
 		Build()
 	dynamicClientSet := dynamicfake.NewSimpleDynamicClient(scheme.Scheme, pod)
-	informerManager := genericmanager.NewMultiClusterInformerManager(context.Background())
+	informerManager := genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields)
 	informerManager.ForCluster(cluster.Name, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 	informerManager.Start(cluster.Name)
 	informerManager.WaitForCacheSync(cluster.Name)

--- a/pkg/controllers/status/crb_status_controller_test.go
+++ b/pkg/controllers/status/crb_status_controller_test.go
@@ -36,6 +36,7 @@ import (
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/indexregistry"
@@ -46,7 +47,7 @@ func generateCRBStatusController() *CRBStatusController {
 	defer cancel()
 	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}})
-	m := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0)
+	m := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0, fedinformer.StripUnusedFields)
 	m.Lister(corev1.SchemeGroupVersion.WithResource("namespaces"))
 	m.Start()
 	m.WaitForCacheSync()

--- a/pkg/controllers/status/rb_status_controller_test.go
+++ b/pkg/controllers/status/rb_status_controller_test.go
@@ -37,6 +37,7 @@ import (
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/indexregistry"
@@ -47,7 +48,7 @@ func generateRBStatusController() *RBStatusController {
 	defer cancel()
 	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "default"}})
-	m := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0)
+	m := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0, fedinformer.StripUnusedFields)
 	m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 	m.Start()
 	m.WaitForCacheSync()

--- a/pkg/controllers/status/work_status_controller_test.go
+++ b/pkg/controllers/status/work_status_controller_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -105,7 +106,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "secret1"},
 						Data:       map[string][]byte{clusterv1alpha1.SecretTokenKey: []byte("token"), clusterv1alpha1.SecretCADataKey: testCA},
 					}).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSet,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -132,7 +133,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			name: "work not exists",
 			c: &WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -159,7 +160,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			name: "work's DeletionTimestamp isn't zero",
 			c: &WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -188,7 +189,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			name: "work's status is not applied",
 			c: &WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -215,7 +216,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			name: "failed to get cluster name",
 			c: &WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -242,7 +243,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			name: "failed to get cluster",
 			c: &WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster1", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -269,7 +270,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			name: "cluster is not ready",
 			c: &WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionFalse)).Build(),
-				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+				InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -338,7 +339,7 @@ func TestWorkStatusController_getEventHandler(t *testing.T) {
 
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionFalse)).Build(),
-		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -353,7 +354,7 @@ func TestWorkStatusController_getEventHandler(t *testing.T) {
 func TestWorkStatusController_RunWorkQueue(_ *testing.T) {
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionFalse)).Build(),
-		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -780,7 +781,7 @@ func TestWorkStatusController_buildResourceInformers(t *testing.T) {
 func newWorkStatusController(cluster *clusterv1alpha1.Cluster, dynamicClientSets ...*dynamicfake.FakeDynamicClient) *WorkStatusController {
 	c := &WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(cluster).WithStatusSubresource(&workv1alpha1.Work{}).Build(),
-		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -810,7 +811,7 @@ func newWorkStatusController(cluster *clusterv1alpha1.Cluster, dynamicClientSets
 		// Generate ResourceInterpreter and ObjectWatcher
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		m := genericmanager.NewMultiClusterInformerManager(ctx)
+		m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 		m.ForCluster(clusterName, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 		m.Start(clusterName)
 		m.WaitForCacheSync(clusterName)
@@ -823,7 +824,7 @@ func newWorkStatusController(cluster *clusterv1alpha1.Cluster, dynamicClientSets
 func TestWorkStatusController_buildStatusIdentifier(t *testing.T) {
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -883,7 +884,7 @@ func TestWorkStatusController_buildStatusIdentifier(t *testing.T) {
 func TestWorkStatusController_mergeStatus(t *testing.T) {
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
-		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background()),
+		InformerManager:             genericmanager.NewMultiClusterInformerManager(context.Background(), fedinformer.StripUnusedFields),
 		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		RateLimiterOptions:          ratelimiterflag.Options{},

--- a/pkg/dependenciesdistributor/dependencies_distributor_test.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor_test.go
@@ -47,6 +47,7 @@ import (
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
 	"github.com/karmada-io/karmada/pkg/util/names"
@@ -1233,7 +1234,7 @@ func Test_removeOrphanAttachedBindings(t *testing.T) {
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1379,7 +1380,7 @@ func Test_handleDependentResource(t *testing.T) {
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1487,7 +1488,7 @@ func Test_handleDependentResource(t *testing.T) {
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1566,7 +1567,7 @@ func Test_handleDependentResource(t *testing.T) {
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1936,7 +1937,7 @@ func Test_syncScheduleResultToAttachedBindings_doesNotWaitForInformerCacheSync(t
 		scheme.Scheme,
 		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}},
 	)
-	baseInformerManager := genericmanager.NewSingleClusterInformerManager(context.TODO(), dynamicClient, 0)
+	baseInformerManager := genericmanager.NewSingleClusterInformerManager(context.TODO(), dynamicClient, 0, fedinformer.StripUnusedFields)
 	baseInformerManager.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 	trackingManager := &trackingInformerManager{SingleClusterInformerManager: baseInformerManager}
 
@@ -2025,7 +2026,7 @@ func Test_findOrphanAttachedBindings(t *testing.T) {
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -2122,7 +2123,7 @@ func Test_findOrphanAttachedBindings(t *testing.T) {
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -2231,7 +2232,7 @@ func TestDependenciesDistributor_findOrphanAttachedBindingsByDependencies(t *tes
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"bar": "bar"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -2282,7 +2283,7 @@ func TestDependenciesDistributor_findOrphanAttachedBindingsByDependencies(t *tes
 				InformerManager: func() genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"bar": "foo"}}})
-					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()

--- a/pkg/detector/policy_test.go
+++ b/pkg/detector/policy_test.go
@@ -34,6 +34,7 @@ import (
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 )
 
@@ -152,7 +153,7 @@ func Test_cleanPPUnmatchedRBs(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -286,7 +287,7 @@ func Test_cleanUnmatchedRBs(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -420,7 +421,7 @@ func Test_cleanUnmatchedCRBs(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -653,7 +654,7 @@ func Test_removeRBsClaimMetadata(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -877,7 +878,7 @@ func Test_removeCRBsClaimMetadata(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -1099,7 +1100,7 @@ func Test_removeResourceClaimMetadataIfNotMatched(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,

--- a/pkg/detector/preemption_test.go
+++ b/pkg/detector/preemption_test.go
@@ -35,6 +35,7 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 )
 
@@ -345,7 +346,7 @@ func TestHandleDeprioritizedPropagationPolicy(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.objects...)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -626,7 +627,7 @@ func TestHandleDeprioritizedClusterPropagationPolicy(t *testing.T) {
 			fakeClient := tt.setupClient().Build()
 			ctx := t.Context()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.objects...)
-			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0, fedinformer.StripUnusedFields)
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,

--- a/pkg/estimator/server/server.go
+++ b/pkg/estimator/server/server.go
@@ -127,7 +127,7 @@ func NewEstimatorServer(
 	_ = informerFactory.Core().V1().Pods().Informer().SetTransform(fedinformer.StripUnusedFields)
 	_ = informerFactory.Apps().V1().ReplicaSets().Informer().SetTransform(fedinformer.StripUnusedFields)
 
-	es.informerManager = genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0)
+	es.informerManager = genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0, fedinformer.StripUnusedFields)
 	for _, gvr := range supportedGVRs {
 		es.informerManager.Lister(gvr)
 	}

--- a/pkg/karmadactl/promote/promote.go
+++ b/pkg/karmadactl/promote/promote.go
@@ -55,6 +55,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native/prune"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/thirdparty"
 	u "github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/names"
@@ -455,7 +456,7 @@ func (o *CommandPromoteOption) promoteDeps(memberClusterFactory cmdutil.Factory,
 	defer cancel()
 	dynamicClientSet := dynamicClientBuilder(config)
 
-	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, 0)
+	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, 0, fedinformer.StripUnusedFields)
 	controlPlaneKubeClientSet := kubeClientBuilder(config)
 	sharedFactory := informers.NewSharedInformerFactory(controlPlaneKubeClientSet, 0)
 	serviceLister := sharedFactory.Core().V1().Services().Lister()

--- a/pkg/resourceinterpreter/customized/declarative/configmanager/manager_test.go
+++ b/pkg/resourceinterpreter/customized/declarative/configmanager/manager_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 )
@@ -128,7 +129,7 @@ func Test_interpreterConfigManager_LuaScriptAccessors(t *testing.T) {
 			defer cancel()
 
 			client := fake.NewSimpleDynamicClient(gclient.NewSchema(), tt.args.customizations...)
-			informer := genericmanager.NewSingleClusterInformerManager(ctx, client, 0)
+			informer := genericmanager.NewSingleClusterInformerManager(ctx, client, 0, fedinformer.StripUnusedFields)
 			configManager := NewInterpreterConfigManager(informer)
 
 			informer.Start()

--- a/pkg/search/controllers_test.go
+++ b/pkg/search/controllers_test.go
@@ -41,6 +41,7 @@ import (
 	informerfactory "github.com/karmada-io/karmada/pkg/generated/informers/externalversions"
 	"github.com/karmada-io/karmada/pkg/search/backendstore"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 )
 
@@ -589,7 +590,7 @@ func createController(ctx context.Context, restConfig *rest.Config, factory info
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new controller, got: %v", err)
 	}
-	newController.InformerManager = genericmanager.NewMultiClusterInformerManager(ctx)
+	newController.InformerManager = genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 	return newController, nil
 }
 

--- a/pkg/util/fedinformer/genericmanager/multi-cluster-manager.go
+++ b/pkg/util/fedinformer/genericmanager/multi-cluster-manager.go
@@ -23,6 +23,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 )
 
 var (
@@ -34,7 +37,7 @@ var (
 // GetInstance returns a shared MultiClusterInformerManager instance.
 func GetInstance() MultiClusterInformerManager {
 	once.Do(func() {
-		instance = NewMultiClusterInformerManager(ctx)
+		instance = NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 	})
 	return instance
 }
@@ -74,17 +77,19 @@ type MultiClusterInformerManager interface {
 }
 
 // NewMultiClusterInformerManager constructs a new instance of multiClusterInformerManagerImpl.
-func NewMultiClusterInformerManager(ctx context.Context) MultiClusterInformerManager {
+func NewMultiClusterInformerManager(ctx context.Context, transformFunc cache.TransformFunc) MultiClusterInformerManager {
 	return &multiClusterInformerManagerImpl{
-		managers: make(map[string]SingleClusterInformerManager),
-		ctx:      ctx,
+		managers:      make(map[string]SingleClusterInformerManager),
+		ctx:           ctx,
+		transformFunc: transformFunc,
 	}
 }
 
 type multiClusterInformerManagerImpl struct {
-	managers map[string]SingleClusterInformerManager
-	ctx      context.Context
-	lock     sync.RWMutex
+	managers      map[string]SingleClusterInformerManager
+	ctx           context.Context
+	transformFunc cache.TransformFunc
+	lock          sync.RWMutex
 }
 
 func (m *multiClusterInformerManagerImpl) getManager(cluster string) (SingleClusterInformerManager, bool) {
@@ -103,7 +108,7 @@ func (m *multiClusterInformerManagerImpl) ForCluster(cluster string, client dyna
 		return manager
 	}
 
-	manager := NewSingleClusterInformerManager(m.ctx, client, defaultResync)
+	manager := NewSingleClusterInformerManager(m.ctx, client, defaultResync, m.transformFunc)
 	m.managers[cluster] = manager
 	return manager
 }

--- a/pkg/util/fedinformer/genericmanager/single-cluster-manager.go
+++ b/pkg/util/fedinformer/genericmanager/single-cluster-manager.go
@@ -18,6 +18,7 @@ package genericmanager
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"sync"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -74,12 +76,13 @@ type SingleClusterInformerManager interface {
 
 // NewSingleClusterInformerManager constructs a new instance of singleClusterInformerManagerImpl.
 // defaultResync with value '0' means no re-sync.
-func NewSingleClusterInformerManager(ctx context.Context, client dynamic.Interface, defaultResync time.Duration) SingleClusterInformerManager {
+func NewSingleClusterInformerManager(ctx context.Context, client dynamic.Interface, defaultResync time.Duration, transformFunc cache.TransformFunc) SingleClusterInformerManager {
 	ctx, cancel := context.WithCancel(ctx)
 	return &singleClusterInformerManagerImpl{
 		informerFactory: dynamicinformer.NewDynamicSharedInformerFactory(client, defaultResync),
 		handlers:        make(map[schema.GroupVersionResource][]cache.ResourceEventHandler),
 		syncedInformers: make(map[schema.GroupVersionResource]struct{}),
+		transformFunc:   transformFunc,
 		ctx:             ctx,
 		cancel:          cancel,
 		client:          client,
@@ -96,6 +99,16 @@ type singleClusterInformerManagerImpl struct {
 
 	handlers map[schema.GroupVersionResource][]cache.ResourceEventHandler
 
+	transformFunc cache.TransformFunc
+
+	// initializedInformers contains GenericInformers whose transform has been installed. It also keeps
+	// steady-state informer lookups from taking informerFactory's lock for an already known resource.
+	initializedInformers sync.Map
+
+	// informerLifecycleLock serializes the first initialization of an informer with Start.
+	// Cache hits in initializedInformers do not take this lock.
+	informerLifecycleLock sync.Mutex
+
 	client dynamic.Interface
 
 	lock sync.RWMutex
@@ -110,7 +123,12 @@ func (s *singleClusterInformerManagerImpl) ForResource(resource schema.GroupVers
 		return
 	}
 
-	_, err := s.informerFactory.ForResource(resource).Informer().AddEventHandler(handler)
+	resourceInformer, err := s.informerForResource(resource)
+	if err != nil {
+		klog.ErrorS(err, "Failed to initialize informer", "resource", resource.String())
+	}
+
+	_, err = resourceInformer.Informer().AddEventHandler(handler)
 	if err != nil {
 		klog.Errorf("Failed to add handler for resource(%s): %v", resource.String(), err)
 		return
@@ -144,7 +162,11 @@ func (s *singleClusterInformerManagerImpl) isHandlerExist(resource schema.GroupV
 }
 
 func (s *singleClusterInformerManagerImpl) Lister(resource schema.GroupVersionResource) cache.GenericLister {
-	return s.informerFactory.ForResource(resource).Lister()
+	resourceInformer, err := s.informerForResource(resource)
+	if err != nil {
+		klog.ErrorS(err, "Failed to initialize informer", "resource", resource.String())
+	}
+	return resourceInformer.Lister()
 }
 
 func (s *singleClusterInformerManagerImpl) appendHandler(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) {
@@ -155,7 +177,39 @@ func (s *singleClusterInformerManagerImpl) appendHandler(resource schema.GroupVe
 	s.handlers[resource] = append(handlers, handler)
 }
 
+func (s *singleClusterInformerManagerImpl) informerForResource(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+	if resourceInformer, exists := s.initializedInformers.Load(resource); exists {
+		return resourceInformer.(informers.GenericInformer), nil
+	}
+	return s.informerForResourceSlowPath(resource)
+}
+
+// informerForResourceSlowPath handles the cache-miss path. It rechecks initializedInformers after acquiring
+// informerLifecycleLock because another caller may have initialized the informer while this caller was waiting.
+func (s *singleClusterInformerManagerImpl) informerForResourceSlowPath(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+	s.informerLifecycleLock.Lock()
+	defer s.informerLifecycleLock.Unlock()
+
+	if resourceInformer, exists := s.initializedInformers.Load(resource); exists {
+		return resourceInformer.(informers.GenericInformer), nil
+	}
+
+	resourceInformer := s.informerFactory.ForResource(resource)
+	informer := resourceInformer.Informer()
+	if s.transformFunc != nil {
+		if err := informer.SetTransform(s.transformFunc); err != nil {
+			return resourceInformer, fmt.Errorf("failed to set transform for resource %s: %w", resource.String(), err)
+		}
+	}
+
+	s.initializedInformers.Store(resource, resourceInformer)
+	return resourceInformer, nil
+}
+
 func (s *singleClusterInformerManagerImpl) Start() {
+	s.informerLifecycleLock.Lock()
+	defer s.informerLifecycleLock.Unlock()
+
 	s.informerFactory.Start(s.ctx.Done())
 }
 

--- a/pkg/util/fedinformer/genericmanager/single-cluster-manager_test.go
+++ b/pkg/util/fedinformer/genericmanager/single-cluster-manager_test.go
@@ -1,0 +1,536 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericmanager
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+var testResourceGVR = schema.GroupVersionResource{
+	Group:    "example.io",
+	Version:  "v1",
+	Resource: "widgets",
+}
+
+func TestSingleClusterInformerManagerAppliesTransform(t *testing.T) {
+	tests := []struct {
+		name          string
+		observeObject func(t *testing.T, manager SingleClusterInformerManager) *unstructured.Unstructured
+	}{
+		{
+			name: "ForResource",
+			observeObject: func(t *testing.T, manager SingleClusterInformerManager) *unstructured.Unstructured {
+				observed := make(chan any, 1)
+				manager.ForResource(testResourceGVR, cache.ResourceEventHandlerFuncs{
+					AddFunc: func(obj any) {
+						observed <- obj
+					},
+				})
+				manager.Start()
+				waitForTestInformerSync(t, manager)
+
+				select {
+				case obj := <-observed:
+					resource, ok := obj.(*unstructured.Unstructured)
+					if !ok {
+						t.Fatalf("got object type %T, want *unstructured.Unstructured", obj)
+					}
+					return resource
+				case <-time.After(5 * time.Second):
+					t.Fatal("timed out waiting for informer add event")
+					return nil
+				}
+			},
+		},
+		{
+			name: "Lister",
+			observeObject: func(t *testing.T, manager SingleClusterInformerManager) *unstructured.Unstructured {
+				lister := manager.Lister(testResourceGVR)
+				if lister == nil {
+					t.Fatal("expected a lister")
+				}
+				manager.Start()
+				waitForTestInformerSync(t, manager)
+
+				obj, err := lister.ByNamespace("default").Get("widget")
+				if err != nil {
+					t.Fatalf("failed to get object from informer cache: %v", err)
+				}
+				resource, ok := obj.(*unstructured.Unstructured)
+				if !ok {
+					t.Fatalf("got object type %T, want *unstructured.Unstructured", obj)
+				}
+				return resource
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+				runtime.NewScheme(),
+				map[schema.GroupVersionResource]string{testResourceGVR: "WidgetList"},
+				newTransformTestObject(),
+			)
+			manager := NewSingleClusterInformerManager(t.Context(), client, 0, stripManagedFields)
+			t.Cleanup(manager.Stop)
+
+			assertTransformedTestObject(t, tt.observeObject(t, manager))
+		})
+	}
+}
+
+func TestSingleClusterInformerManagerSlowPathRechecksInitializedInformer(t *testing.T) {
+	cachedInformer := newRecordingGenericInformer()
+	factoryInformer := newRecordingGenericInformer()
+	factory := &recordingDynamicInformerFactory{informer: factoryInformer}
+	manager := newTestSingleClusterInformerManager(t, factory, stripManagedFields)
+	manager.initializedInformers.Store(testResourceGVR, cachedInformer)
+
+	got, err := manager.informerForResourceSlowPath(testResourceGVR)
+	if err != nil {
+		t.Fatalf("informerForResourceSlowPath() returned an unexpected error: %v", err)
+	}
+	if got != cachedInformer {
+		t.Fatal("slow path did not reuse the informer initialized by another caller")
+	}
+	if got := factory.forResourceCalls.Load(); got != 0 {
+		t.Fatalf("factory.ForResource() called %d times, want 0", got)
+	}
+	if got := factoryInformer.informer.setTransformCalls.Load(); got != 0 {
+		t.Fatalf("SetTransform() called %d times, want 0", got)
+	}
+}
+
+func TestSingleClusterInformerManagerCachedLookupSkipsLifecycleLock(t *testing.T) {
+	genericInformer := newRecordingGenericInformer()
+	factory := &recordingDynamicInformerFactory{informer: genericInformer}
+	manager := newTestSingleClusterInformerManager(t, factory, stripManagedFields)
+
+	if got := manager.Lister(testResourceGVR); got != genericInformer.lister {
+		t.Fatal("Lister() returned a different lister during initialization")
+	}
+
+	manager.informerLifecycleLock.Lock()
+	lockHeld := true
+	defer func() {
+		if lockHeld {
+			manager.informerLifecycleLock.Unlock()
+		}
+	}()
+
+	lookupResult := make(chan cache.GenericLister, 1)
+	go func() {
+		lookupResult <- manager.Lister(testResourceGVR)
+	}()
+
+	select {
+	case got := <-lookupResult:
+		manager.informerLifecycleLock.Unlock()
+		lockHeld = false
+		if got != genericInformer.lister {
+			t.Fatal("cached lookup returned a different lister")
+		}
+	case <-time.After(time.Second):
+		manager.informerLifecycleLock.Unlock()
+		lockHeld = false
+		waitForTestValue(t, lookupResult, "cached lookup after releasing informerLifecycleLock")
+		t.Fatal("cached lookup blocked on informerLifecycleLock")
+	}
+
+	if got := factory.forResourceCalls.Load(); got != 1 {
+		t.Fatalf("factory.ForResource() called %d times, want 1", got)
+	}
+	if got := genericInformer.informer.setTransformCalls.Load(); got != 1 {
+		t.Fatalf("SetTransform() called %d times, want 1", got)
+	}
+}
+
+func TestSingleClusterInformerManagerSerializesInitializationWithStart(t *testing.T) {
+	genericInformer := newRecordingGenericInformer()
+	factory := &recordingDynamicInformerFactory{informer: genericInformer}
+	manager := newTestSingleClusterInformerManager(t, factory, stripManagedFields)
+
+	factoryEntered := make(chan struct{})
+	releaseFactory := make(chan struct{})
+	var releaseFactoryOnce sync.Once
+	release := func() {
+		releaseFactoryOnce.Do(func() { close(releaseFactory) })
+	}
+	t.Cleanup(release)
+
+	factory.onForResource = func() {
+		assertMutexHeld(t, &manager.informerLifecycleLock, "factory.ForResource")
+		close(factoryEntered)
+		<-releaseFactory
+	}
+	genericInformer.onInformer = func() {
+		assertMutexHeld(t, &manager.informerLifecycleLock, "GenericInformer.Informer")
+	}
+	var transformInstalled atomic.Bool
+	genericInformer.informer.onSetTransform = func() {
+		assertMutexHeld(t, &manager.informerLifecycleLock, "SetTransform")
+		transformInstalled.Store(true)
+	}
+	var startBeforeTransform atomic.Bool
+	var startBeforeInformerPublished atomic.Bool
+	factory.onStart = func() {
+		if !transformInstalled.Load() {
+			startBeforeTransform.Store(true)
+		}
+		if _, exists := manager.initializedInformers.Load(testResourceGVR); !exists {
+			startBeforeInformerPublished.Store(true)
+		}
+	}
+
+	initializationDone := make(chan error, 1)
+	go func() {
+		_, err := manager.informerForResource(testResourceGVR)
+		initializationDone <- err
+	}()
+	waitForTestSignal(t, factoryEntered, "factory.ForResource")
+
+	startAttempted := make(chan struct{})
+	startDone := make(chan struct{})
+	go func() {
+		close(startAttempted)
+		manager.Start()
+		close(startDone)
+	}()
+	waitForTestSignal(t, startAttempted, "Start attempt")
+
+	startReturnedBeforeInitialization := false
+	select {
+	case <-startDone:
+		startReturnedBeforeInitialization = true
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+	if err := waitForTestValue(t, initializationDone, "informer initialization"); err != nil {
+		t.Fatalf("informerForResource() returned an unexpected error: %v", err)
+	}
+	if !startReturnedBeforeInitialization {
+		waitForTestSignal(t, startDone, "Start")
+	}
+
+	if startReturnedBeforeInitialization {
+		t.Fatal("Start returned before informer initialization completed")
+	}
+	if startBeforeTransform.Load() {
+		t.Fatal("factory.Start() ran before SetTransform() completed")
+	}
+	if startBeforeInformerPublished.Load() {
+		t.Fatal("factory.Start() ran before the initialized informer was published")
+	}
+	if got := factory.startCalls.Load(); got != 1 {
+		t.Fatalf("factory.Start() called %d times, want 1", got)
+	}
+}
+
+func TestSingleClusterInformerManagerStartUsesLifecycleLock(t *testing.T) {
+	factory := &recordingDynamicInformerFactory{informer: newRecordingGenericInformer()}
+	manager := newTestSingleClusterInformerManager(t, factory, stripManagedFields)
+	factory.onStart = func() {
+		assertMutexHeld(t, &manager.informerLifecycleLock, "factory.Start")
+	}
+
+	manager.Start()
+
+	if got := factory.startCalls.Load(); got != 1 {
+		t.Fatalf("factory.Start() called %d times, want 1", got)
+	}
+}
+
+func TestSingleClusterInformerManagerPublishesInformerAfterTransform(t *testing.T) {
+	genericInformer := newRecordingGenericInformer()
+	factory := &recordingDynamicInformerFactory{informer: genericInformer}
+	manager := newTestSingleClusterInformerManager(t, factory, stripManagedFields)
+
+	transformEntered := make(chan struct{})
+	releaseTransform := make(chan struct{})
+	var releaseTransformOnce sync.Once
+	release := func() {
+		releaseTransformOnce.Do(func() { close(releaseTransform) })
+	}
+	t.Cleanup(release)
+	genericInformer.informer.onSetTransform = func() {
+		close(transformEntered)
+		<-releaseTransform
+	}
+
+	type initializationResult struct {
+		informer informers.GenericInformer
+		err      error
+	}
+	initializationDone := make(chan initializationResult, 1)
+	go func() {
+		informer, err := manager.informerForResource(testResourceGVR)
+		initializationDone <- initializationResult{informer: informer, err: err}
+	}()
+	waitForTestSignal(t, transformEntered, "SetTransform")
+
+	_, publishedBeforeTransform := manager.initializedInformers.Load(testResourceGVR)
+	release()
+	result := waitForTestValue(t, initializationDone, "informer initialization")
+	if result.err != nil {
+		t.Fatalf("informerForResource() returned an unexpected error: %v", result.err)
+	}
+	if publishedBeforeTransform {
+		t.Fatal("informer was published before SetTransform() completed")
+	}
+	if result.informer != genericInformer {
+		t.Fatal("informerForResource() returned a different GenericInformer")
+	}
+	initializedInformer, exists := manager.initializedInformers.Load(testResourceGVR)
+	if !exists {
+		t.Fatal("informer was not published after SetTransform() completed")
+	}
+	if initializedInformer != genericInformer {
+		t.Fatal("initializedInformers contains a different GenericInformer")
+	}
+}
+
+func TestSingleClusterInformerManagerRetriesFailedTransformWithoutPublishing(t *testing.T) {
+	wantErr := errors.New("failed to install transform")
+	genericInformer := newRecordingGenericInformer()
+	genericInformer.informer.setTransformErr = wantErr
+	factory := &recordingDynamicInformerFactory{informer: genericInformer}
+	manager := newTestSingleClusterInformerManager(t, factory, stripManagedFields)
+
+	resourceInformer, err := manager.informerForResource(testResourceGVR)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("informerForResource() error = %v, want %v", err, wantErr)
+	}
+	if resourceInformer != genericInformer {
+		t.Fatal("failed transform should still return the underlying GenericInformer")
+	}
+	if _, exists := manager.initializedInformers.Load(testResourceGVR); exists {
+		t.Fatal("failed transform must not publish an initialized informer")
+	}
+
+	if got := manager.Lister(testResourceGVR); got != genericInformer.lister {
+		t.Fatal("Lister() should preserve access to the underlying informer after a transform failure")
+	}
+	handler := &cache.ResourceEventHandlerFuncs{}
+	manager.ForResource(testResourceGVR, handler)
+	if !manager.IsHandlerExist(testResourceGVR, handler) {
+		t.Fatal("ForResource() should still register the handler after a transform failure")
+	}
+	if got := factory.forResourceCalls.Load(); got != 3 {
+		t.Fatalf("factory.ForResource() called %d times, want 3", got)
+	}
+	if got := genericInformer.informer.setTransformCalls.Load(); got != 3 {
+		t.Fatalf("SetTransform() called %d times, want 3", got)
+	}
+	if got := genericInformer.informer.addEventHandlerCalls.Load(); got != 1 {
+		t.Fatalf("AddEventHandler() called %d times, want 1", got)
+	}
+	if _, exists := manager.initializedInformers.Load(testResourceGVR); exists {
+		t.Fatal("failed transform must not publish an initialized informer after retries")
+	}
+}
+
+func newTransformTestObject() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.io/v1",
+		"kind":       "Widget",
+		"metadata": map[string]any{
+			"namespace": "default",
+			"name":      "widget",
+		},
+		"spec":   map[string]any{"value": "keep-spec"},
+		"status": map[string]any{"value": "keep-status"},
+	}}
+	obj.SetManagedFields([]metav1.ManagedFieldsEntry{{
+		Manager:    "test-manager",
+		Operation:  metav1.ManagedFieldsOperationUpdate,
+		APIVersion: "example.io/v1",
+		FieldsType: "FieldsV1",
+	}})
+	return obj
+}
+
+func stripManagedFields(obj any) (any, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	accessor.SetManagedFields(nil)
+	return obj, nil
+}
+
+func assertTransformedTestObject(t *testing.T, obj *unstructured.Unstructured) {
+	t.Helper()
+	if len(obj.GetManagedFields()) != 0 {
+		t.Fatalf("managedFields were not stripped: %v", obj.GetManagedFields())
+	}
+	if got, _, _ := unstructured.NestedString(obj.Object, "spec", "value"); got != "keep-spec" {
+		t.Fatalf("spec value = %q, want %q", got, "keep-spec")
+	}
+	if got, _, _ := unstructured.NestedString(obj.Object, "status", "value"); got != "keep-status" {
+		t.Fatalf("status value = %q, want %q", got, "keep-status")
+	}
+}
+
+func waitForTestInformerSync(t *testing.T, manager SingleClusterInformerManager) {
+	t.Helper()
+	if synced := manager.WaitForCacheSyncWithTimeout(5 * time.Second); !synced[testResourceGVR] {
+		t.Fatalf("informer failed to sync: %v", synced)
+	}
+}
+
+func newTestSingleClusterInformerManager(
+	t *testing.T,
+	factory dynamicinformer.DynamicSharedInformerFactory,
+	transform cache.TransformFunc,
+) *singleClusterInformerManagerImpl {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	return &singleClusterInformerManagerImpl{
+		ctx:             ctx,
+		cancel:          cancel,
+		informerFactory: factory,
+		syncedInformers: make(map[schema.GroupVersionResource]struct{}),
+		handlers:        make(map[schema.GroupVersionResource][]cache.ResourceEventHandler),
+		transformFunc:   transform,
+	}
+}
+
+func assertMutexHeld(t *testing.T, mutex *sync.Mutex, operation string) {
+	t.Helper()
+	if mutex.TryLock() {
+		mutex.Unlock()
+		t.Errorf("informerLifecycleLock is not held during %s", operation)
+	}
+}
+
+type recordingDynamicInformerFactory struct {
+	informer informers.GenericInformer
+
+	forResourceCalls atomic.Int64
+	startCalls       atomic.Int64
+	onForResource    func()
+	onStart          func()
+}
+
+func (f *recordingDynamicInformerFactory) ForResource(_ schema.GroupVersionResource) informers.GenericInformer {
+	f.forResourceCalls.Add(1)
+	if f.onForResource != nil {
+		f.onForResource()
+	}
+	return f.informer
+}
+
+func (f *recordingDynamicInformerFactory) Start(_ <-chan struct{}) {
+	f.startCalls.Add(1)
+	if f.onStart != nil {
+		f.onStart()
+	}
+}
+
+func (f *recordingDynamicInformerFactory) WaitForCacheSync(_ <-chan struct{}) map[schema.GroupVersionResource]bool {
+	return nil
+}
+
+func (f *recordingDynamicInformerFactory) Shutdown() {}
+
+type recordingGenericInformer struct {
+	informer   *recordingSharedIndexInformer
+	lister     cache.GenericLister
+	onInformer func()
+}
+
+func (i *recordingGenericInformer) Informer() cache.SharedIndexInformer {
+	if i.onInformer != nil {
+		i.onInformer()
+	}
+	return i.informer
+}
+
+func (i *recordingGenericInformer) Lister() cache.GenericLister {
+	return i.lister
+}
+
+// recordingSharedIndexInformer implements only the SharedIndexInformer methods exercised by these tests.
+type recordingSharedIndexInformer struct {
+	cache.SharedIndexInformer
+
+	setTransformCalls    atomic.Int64
+	addEventHandlerCalls atomic.Int64
+	setTransformErr      error
+	onSetTransform       func()
+}
+
+func (i *recordingSharedIndexInformer) SetTransform(_ cache.TransformFunc) error {
+	i.setTransformCalls.Add(1)
+	if i.onSetTransform != nil {
+		i.onSetTransform()
+	}
+	return i.setTransformErr
+}
+
+func (i *recordingSharedIndexInformer) AddEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	i.addEventHandlerCalls.Add(1)
+	return nil, nil
+}
+
+func newRecordingGenericInformer() *recordingGenericInformer {
+	return &recordingGenericInformer{
+		informer: &recordingSharedIndexInformer{},
+		lister: cache.NewGenericLister(
+			cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}),
+			testResourceGVR.GroupResource(),
+		),
+	}
+}
+
+func waitForTestSignal(t *testing.T, signal <-chan struct{}, operation string) {
+	t.Helper()
+	waitForTestValue(t, signal, operation)
+}
+
+func waitForTestValue[T any](t *testing.T, values <-chan T, operation string) T {
+	t.Helper()
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", operation)
+		var zero T
+		return zero
+	}
+}
+
+var _ dynamicinformer.DynamicSharedInformerFactory = (*recordingDynamicInformerFactory)(nil)
+var _ informers.GenericInformer = (*recordingGenericInformer)(nil)

--- a/pkg/util/fedinformer/transform.go
+++ b/pkg/util/fedinformer/transform.go
@@ -17,13 +17,20 @@ limitations under the License.
 package fedinformer
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
 
 // StripUnusedFields is the transform function for shared informers,
@@ -41,6 +48,28 @@ func StripUnusedFields(obj any) (any, error) {
 	// ManagedFields is large and we never use it
 	accessor.SetManagedFields(nil)
 	return obj, nil
+}
+
+// RetainMetadataFields keeps only type and object metadata on informer objects.
+func RetainMetadataFields(obj any) (any, error) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	unstructuredObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return obj, nil
+	}
+	return metadataOnlyUnstructured(unstructuredObj), nil
+}
+
+func metadataOnlyUnstructured(obj *unstructured.Unstructured) *unstructured.Unstructured {
+	obj.Object = map[string]any{
+		"apiVersion": obj.GetAPIVersion(),
+		"kind":       obj.GetKind(),
+		"metadata":   obj.Object["metadata"],
+	}
+	return obj
 }
 
 // NodeTransformFunc is the dedicated transform function for Node objects.
@@ -117,4 +146,53 @@ func PodTransformFunc(obj any) (any, error) {
 		},
 	}
 	return aggregatedPod, nil
+}
+
+// NewWorkMappingTransformFunc keeps complete member-cluster objects only when
+// they are associated with an existing Work; unrelated objects retain metadata only.
+func NewWorkMappingTransformFunc(controlPlaneClient client.Reader) cache.TransformFunc {
+	return func(obj any) (any, error) {
+		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+			obj = tombstone.Obj
+		}
+
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			// shouldn't happen
+			return obj, nil
+		}
+		// ManagedFields is large and we never use it
+		accessor.SetManagedFields(nil)
+
+		mappedToWork, err := mapsToWork(controlPlaneClient, obj)
+		if err != nil {
+			return obj, err
+		}
+		if mappedToWork {
+			return obj, nil
+		}
+		return RetainMetadataFields(obj)
+	}
+}
+
+func mapsToWork(controlPlaneClient client.Reader, obj any) (bool, error) {
+	resource, err := meta.Accessor(obj)
+	if err != nil {
+		return false, nil
+	}
+	annotations := resource.GetAnnotations()
+	workNamespace, namespaceExists := annotations[workv1alpha2.WorkNamespaceAnnotation]
+	workName, nameExists := annotations[workv1alpha2.WorkNameAnnotation]
+	if !namespaceExists || !nameExists {
+		return false, nil
+	}
+
+	work := &workv1alpha1.Work{}
+	if err := controlPlaneClient.Get(context.Background(), client.ObjectKey{Namespace: workNamespace, Name: workName}, work); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return false, err
+		}
+		return false, nil
+	}
+	return true, nil
 }

--- a/pkg/util/fedinformer/transform_test.go
+++ b/pkg/util/fedinformer/transform_test.go
@@ -23,8 +23,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util/gclient"
 )
 
 func TestStripUnusedFields(t *testing.T) {
@@ -89,6 +93,37 @@ func TestStripUnusedFields(t *testing.T) {
 				t.Errorf("StripUnusedFields: got %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRetainMetadataFields(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"namespace": "default",
+			"name":      "pod",
+			"labels":    map[string]any{"app": "demo"},
+		},
+		"spec": map[string]any{"nodeName": "node1"},
+	}}
+
+	got, err := RetainMetadataFields(obj)
+	if err != nil {
+		t.Fatalf("RetainMetadataFields() error = %v", err)
+	}
+	gotObj, ok := got.(*unstructured.Unstructured)
+	if !ok {
+		t.Fatalf("expected *unstructured.Unstructured, got %T", got)
+	}
+	if gotObj.GetAPIVersion() != "v1" || gotObj.GetKind() != "Pod" {
+		t.Fatalf("type metadata was not retained: %#v", gotObj.Object)
+	}
+	if gotObj.GetNamespace() != "default" || gotObj.GetName() != "pod" || gotObj.GetLabels()["app"] != "demo" {
+		t.Fatalf("metadata was not retained: %#v", gotObj.Object)
+	}
+	if _, found, err := unstructured.NestedFieldNoCopy(gotObj.Object, "spec"); err != nil || found {
+		t.Fatalf("spec should not be retained, found=%v err=%v", found, err)
 	}
 }
 
@@ -274,4 +309,52 @@ func TestPodTransformFunc(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewWorkStatusTransformFunc(t *testing.T) {
+	controlPlaneClient := fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(
+		&workv1alpha1.Work{ObjectMeta: metav1.ObjectMeta{Namespace: "work-ns", Name: "work-name"}},
+	).Build()
+	transform := NewWorkMappingTransformFunc(controlPlaneClient)
+
+	newObject := func(workName string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"namespace": "default",
+				"name":      "demo",
+				"annotations": map[string]any{
+					workv1alpha2.WorkNamespaceAnnotation: "work-ns",
+					workv1alpha2.WorkNameAnnotation:      workName,
+				},
+			},
+			"spec": map[string]any{"replicas": int64(1)},
+		}}
+	}
+
+	t.Run("retain full object mapped to an existing Work", func(t *testing.T) {
+		got, err := transform(newObject("work-name"))
+		if err != nil {
+			t.Fatalf("transform() error = %v", err)
+		}
+		gotObj := got.(*unstructured.Unstructured)
+		if _, found, err := unstructured.NestedFieldNoCopy(gotObj.Object, "spec"); err != nil || !found {
+			t.Fatalf("spec should be retained, found=%v err=%v", found, err)
+		}
+	})
+
+	t.Run("retain metadata only when Work does not exist", func(t *testing.T) {
+		got, err := transform(newObject("missing"))
+		if err != nil {
+			t.Fatalf("transform() error = %v", err)
+		}
+		gotObj := got.(*unstructured.Unstructured)
+		if gotObj.GetName() != "demo" {
+			t.Fatalf("metadata was not retained: %#v", gotObj.Object)
+		}
+		if _, found, err := unstructured.NestedFieldNoCopy(gotObj.Object, "spec"); err != nil || found {
+			t.Fatalf("spec should not be retained, found=%v err=%v", found, err)
+		}
+	})
 }

--- a/pkg/util/helper/binding_test.go
+++ b/pkg/util/helper/binding_test.go
@@ -40,6 +40,7 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
@@ -1006,7 +1007,7 @@ func TestFetchWorkload(t *testing.T) {
 			args: args{
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: meta.NewDefaultRESTMapper(nil),
 				resource:   workv1alpha2.ObjectReference{APIVersion: "v1", Kind: "Pod"},
@@ -1019,7 +1020,7 @@ func TestFetchWorkload(t *testing.T) {
 			args: args{
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: func() meta.RESTMapper {
 					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
@@ -1042,7 +1043,7 @@ func TestFetchWorkload(t *testing.T) {
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 					&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}}),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: func() meta.RESTMapper {
 					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
@@ -1073,7 +1074,7 @@ func TestFetchWorkload(t *testing.T) {
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}})
-					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1107,7 +1108,7 @@ func TestFetchWorkload(t *testing.T) {
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node"}}),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: func() meta.RESTMapper {
 					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
@@ -1136,7 +1137,7 @@ func TestFetchWorkload(t *testing.T) {
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node"}})
-					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("nodes"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1203,7 +1204,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 			args: args{
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: meta.NewDefaultRESTMapper(nil),
 				resource:   workv1alpha2.ObjectReference{APIVersion: "v1", Kind: "Pod"},
@@ -1217,7 +1218,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 					&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"foo": "foo"}}}),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: func() meta.RESTMapper {
 					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
@@ -1241,7 +1242,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"bar": "foo"}}})
-					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
@@ -1269,7 +1270,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node", Labels: map[string]string{"bar": "bar"}}}),
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				restMapper: func() meta.RESTMapper {
 					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
@@ -1293,7 +1294,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node", Labels: map[string]string{"bar": "foo"}}})
-					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("nodes"))
 					m.Start()
 					m.WaitForCacheSync()

--- a/pkg/util/helper/cache_test.go
+++ b/pkg/util/helper/cache_test.go
@@ -35,6 +35,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
@@ -57,7 +58,7 @@ func TestRegisterInformerHandlerAndCheckSynced(t *testing.T) {
 		{
 			name: "registers missing handler and starts informer",
 			manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-				m := genericmanager.NewMultiClusterInformerManager(ctx)
+				m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 				m.ForCluster(cluster.Name, dynamicClient, 0)
 				return m
 			},
@@ -69,7 +70,7 @@ func TestRegisterInformerHandlerAndCheckSynced(t *testing.T) {
 		{
 			name: "returns synced when handler exists and informer synced",
 			manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-				m := genericmanager.NewMultiClusterInformerManager(ctx)
+				m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 				m.ForCluster(cluster.Name, dynamicClient, 0).ForResource(gvr, handler)
 				m.Start(cluster.Name)
 				m.WaitForCacheSync(cluster.Name)
@@ -83,7 +84,7 @@ func TestRegisterInformerHandlerAndCheckSynced(t *testing.T) {
 		{
 			name: "creates manager with cluster client when missing",
 			manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-				return genericmanager.NewMultiClusterInformerManager(ctx)
+				return genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 			},
 			clusterClientSetFunc: func(clusterName string, _ client.Client, _ *util.ClientOption) (*util.DynamicClusterClient, error) {
 				return &util.DynamicClusterClient{ClusterName: clusterName, DynamicClientSet: dynamicClient}, nil
@@ -93,7 +94,7 @@ func TestRegisterInformerHandlerAndCheckSynced(t *testing.T) {
 		{
 			name: "returns error when cluster client creation fails",
 			manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-				return genericmanager.NewMultiClusterInformerManager(ctx)
+				return genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 			},
 			clusterClientSetFunc: func(string, client.Client, *util.ClientOption) (*util.DynamicClusterClient, error) {
 				return nil, errors.New("failed to build dynamic client")
@@ -149,7 +150,7 @@ func TestGetObjectFromCache(t *testing.T) {
 			args: args{
 				restMapper: meta.NewDefaultRESTMapper(nil),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					return genericmanager.NewMultiClusterInformerManager(ctx)
+					return genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 				},
 				fedKey: keys.FederatedKey{Cluster: "cluster", ClusterWideKey: keys.ClusterWideKey{
 					Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod",
@@ -167,7 +168,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					return genericmanager.NewMultiClusterInformerManager(ctx)
+					return genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 				},
 				fedKey: keys.FederatedKey{Cluster: "cluster", ClusterWideKey: keys.ClusterWideKey{
 					Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod",
@@ -185,7 +186,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					m := genericmanager.NewMultiClusterInformerManager(ctx)
+					m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme), 0)
 					return m
 				},
@@ -205,7 +206,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					m := genericmanager.NewMultiClusterInformerManager(ctx)
+					m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}},
 					), 0)
@@ -232,7 +233,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					m := genericmanager.NewMultiClusterInformerManager(ctx)
+					m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme), 0).
 						Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start("cluster")
@@ -255,7 +256,7 @@ func TestGetObjectFromCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
-					m := genericmanager.NewMultiClusterInformerManager(ctx)
+					m := genericmanager.NewMultiClusterInformerManager(ctx, fedinformer.StripUnusedFields)
 					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}},
 					), 0).Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
@@ -309,7 +310,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 			args: args{
 				restMapper: meta.NewDefaultRESTMapper(nil),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				cwk: &keys.ClusterWideKey{Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod"},
 			},
@@ -325,7 +326,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 				},
 				cwk: &keys.ClusterWideKey{Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod"},
 			},
@@ -342,7 +343,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := fake.NewSimpleDynamicClient(scheme.Scheme, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}})
-					return genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					return genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 				},
 				cwk: &keys.ClusterWideKey{Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod"},
 			},
@@ -363,7 +364,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 					return m
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					m := genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start()
 					m.WaitForCacheSync()
@@ -384,7 +385,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := fake.NewSimpleDynamicClient(scheme.Scheme, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}})
-					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
+					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0, fedinformer.StripUnusedFields)
 					m.Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start()
 					m.WaitForCacheSync()

--- a/pkg/util/testing/mock_manager.go
+++ b/pkg/util/testing/mock_manager.go
@@ -24,13 +24,14 @@ import (
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 )
 
 // NewSingleClusterInformerManagerByRS will build a fake SingleClusterInformerManager and can add resource.
 func NewSingleClusterInformerManagerByRS(src string, obj runtime.Object) genericmanager.SingleClusterInformerManager {
 	c := fakedynamic.NewSimpleDynamicClient(scheme.Scheme, obj)
-	m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
+	m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0, fedinformer.StripUnusedFields)
 	m.Lister(corev1.SchemeGroupVersion.WithResource(src))
 	m.Start()
 	m.WaitForCacheSync()


### PR DESCRIPTION
**What type of PR is this?**


/kind feature


**What this PR does / why we need it**:

The member-cluster resource informer cache is directly used by both the work-status controller and the execution controller.

Currently, complete objects are stored in the cache, including resources that are not mapped to an existing `Work`. Retaining the `spec`, `status`, and other non-metadata fields of these resources is unnecessary:

- The work-status controller does not collect fields from a resource when there is no corresponding `Work`.
- If the execution controller later dispatches the resource, it constructs the desired object from the `Work` manifest. The absence of non-metadata fields in the cached object does not prevent the resource from being created or updated.

This PR adds an informer transform that:

- Retains complete objects when they are mapped to an existing `Work`.
- Retains only `apiVersion`, `kind`, and object metadata for resources that are not mapped to an existing `Work`.

This avoids retaining unused object content and reduces the memory consumed by the member-cluster resource cache.


Memory usage test:


<img width="1258" height="590" alt="6392aea768af7b3b2a8ada6969c0ff12" src="https://github.com/user-attachments/assets/aa382061-d711-4ff7-b90a-c44ea5b69fc7" />

In a fresh Karmada environment, only one Deployment was initially propagated to two member clusters to ensure that a Deployment informer was established for each cluster. Then, 40,000 Deployments were created in each member cluster, resulting in 80,000 test objects in total.

Under the same test conditions, the memory usage was:

- Current master: 1.86 GB
- With #7807 applied: 1.39 GB
- With this PR applied on top of #7807: 1.13 GB

Compared with the current master, this PR reduces the overall memory usage by approximately 39.2%. It also provides an additional reduction of approximately 18.7% on top of #7807.

**Which issue(s) this PR fixes**:

Fixes #<issue-number>

**Special notes for your reviewer**:

This PR is based on #7807 which adds transform function support to the dynamic informer manager. That prerequisite PR is expected to be merged first.

Test report:

```console
go test ./pkg/controllers/status ./pkg/util/fedinformer -count=1
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```