### PR TITLE
fix: avoid int64 overflow in assumed workload deduction

### DIFF
--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -131,13 +131,15 @@ func deductAssumedWorkloadsFromSummary(resourceSummary *clusterv1alpha1.Resource
 			for resName, qty := range comp.ReplicaRequirements.ResourceRequest {
 				// Use MilliValue only for CPU (millicores are its natural unit).
 				// For all other resources (memory, extended resources, etc.) use Value() to
-				// avoid the ×1000 amplification that MilliValue introduces, which can overflow
-				// int64 for large quantities (e.g. 1Ti memory × 10000 replicas).
+				// avoid the ×1000 amplification that MilliValue introduces.
+				// The multiplication is clamped to math.MaxInt64 instead of being left to wrap,
+				// since a wrapped negative total would make Allocating understate demand and let
+				// getMaximumReplicasBasedOnClusterSummary report more capacity than actually exists.
 				var total resource.Quantity
 				if resName == corev1.ResourceCPU {
-					total = *resource.NewMilliQuantity(qty.MilliValue()*replicas, qty.Format)
+					total = *resource.NewMilliQuantity(saturatingMulInt64(qty.MilliValue(), replicas), qty.Format)
 				} else {
-					total = *resource.NewQuantity(qty.Value()*replicas, qty.Format)
+					total = *resource.NewQuantity(saturatingMulInt64(qty.Value(), replicas), qty.Format)
 				}
 				if existing, ok := resourceSummary.Allocating[resName]; ok {
 					existing.Add(total)
@@ -419,6 +421,19 @@ func availableResourceMap(resourceSummary *clusterv1alpha1.ResourceSummary) map[
 		available[key] = quantityAsInt64(a)
 	}
 	return available
+}
+
+// saturatingMulInt64 multiplies two non-negative int64 values, returning math.MaxInt64
+// instead of wrapping if the exact product would overflow int64.
+func saturatingMulInt64(a, b int64) int64 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	result := a * b
+	if result/b != a {
+		return math.MaxInt64
+	}
+	return result
 }
 
 // Converts quantity into an int representation depending on format

--- a/pkg/estimator/client/general_test.go
+++ b/pkg/estimator/client/general_test.go
@@ -19,6 +19,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -861,6 +862,32 @@ func TestDeductAssumedWorkloadsFromSummary(t *testing.T) {
 			},
 		},
 		{
+			// Validates that an extended-resource product overflowing int64 is clamped to
+			// math.MaxInt64 rather than wrapping around to a negative value. A wrapped negative
+			// value would let getMaximumReplicasBasedOnClusterSummary add it back to the available
+			// capacity, making a larger assumed workload appear to free up room instead of using it.
+			name:    "extended resource product overflowing int64 is clamped, not wrapped",
+			summary: clusterv1alpha1.ResourceSummary{},
+			assumedWorkloads: []AssumedWorkload{
+				{
+					Components: []workv1alpha2.Component{
+						{
+							Replicas: 3,
+							ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+								ResourceRequest: corev1.ResourceList{
+									"example.com/device": resource.MustParse("4Ei"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantAllocating: corev1.ResourceList{
+				corev1.ResourcePods:  resource.MustParse("3"),
+				"example.com/device": *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
+			},
+		},
+		{
 			name: "existing Allocating values are accumulated, not replaced",
 			summary: clusterv1alpha1.ResourceSummary{
 				Allocating: corev1.ResourceList{
@@ -904,6 +931,48 @@ func TestDeductAssumedWorkloadsFromSummary(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAssumedWorkloadDeductionIsMonotonic validates that folding an assumed in-flight workload
+// into a ResourceSummary never raises the maximum-replicas estimate computed from it, even when
+// the per-replica resource request is large enough that replicas × request overflows int64.
+func TestAssumedWorkloadDeductionIsMonotonic(t *testing.T) {
+	const extendedResource = corev1.ResourceName("example.com/device")
+
+	newSummary := func() *clusterv1alpha1.ResourceSummary {
+		return &clusterv1alpha1.ResourceSummary{
+			Allocatable: corev1.ResourceList{
+				extendedResource:    resource.MustParse("64"),
+				corev1.ResourcePods: resource.MustParse("110"),
+			},
+			Allocated: corev1.ResourceList{},
+		}
+	}
+	replicaRequirements := &workv1alpha2.ReplicaRequirements{
+		ResourceRequest: corev1.ResourceList{extendedResource: resource.MustParse("1")},
+	}
+
+	baseline := getMaximumReplicasBasedOnClusterSummary(newSummary(), replicaRequirements)
+	assert.Equal(t, int64(64), baseline)
+
+	withAssumed := newSummary()
+	deductAssumedWorkloadsFromSummary(withAssumed, []AssumedWorkload{
+		{
+			Components: []workv1alpha2.Component{
+				{
+					Replicas: 3,
+					ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{extendedResource: resource.MustParse("4Ei")},
+					},
+				},
+			},
+		},
+	})
+	got := getMaximumReplicasBasedOnClusterSummary(withAssumed, replicaRequirements)
+
+	assert.LessOrEqual(t, got, baseline,
+		"assuming an in-flight workload must not raise the estimate: got %d with the workload assumed, %d without it", got, baseline)
+	assert.Equal(t, int64(0), got, "a cluster with 64 devices and 3×4Ei assumed has no room left")
 }
 
 func TestMaxAvailableReplicasGeneral(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`deductAssumedWorkloadsFromSummary` folds an assumed in-flight workload's per-replica resource request into `ResourceSummary.Allocating` by multiplying it by the replica count using plain int64 arithmetic. For a large enough per-replica request the multiplication wraps into a negative total, and `getMaximumReplicasBasedOnClusterSummary` then subtracts that negative value from the available capacity — adding it back instead of removing it. A heavier assumed workload can end up making a cluster look like it has *more* room, not less.

This clamps the multiplication to `math.MaxInt64` instead of letting it wrap, keeping the result inside the same plain int64 arithmetic the rest of the estimator already relies on.

**Which issue(s) this PR fixes**:

Fixes #7818

**Special notes for your reviewer**:

Added a regression test (`TestAssumedWorkloadDeductionIsMonotonic`) that reproduces the exact scenario from the issue and fails against the old code with the same wrapped value reported there (`4611686018427387968`).

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```