### PR TITLE
prune: strip Service nodePort from member-cluster propagation

### DIFF
--- a/pkg/resourceinterpreter/default/native/prune/prune.go
+++ b/pkg/resourceinterpreter/default/native/prune/prune.go
@@ -183,7 +183,7 @@ func removeServiceAccountIrrelevantField(workload *unstructured.Unstructured) er
 	return nil
 }
 
-// removeServiceIrrelevantField removes member cluster specific fields from Service (e.g. clusterIP, clusterIPs)
+// removeServiceIrrelevantField removes member cluster specific fields from Service (e.g. clusterIP, clusterIPs, nodePort)
 func removeServiceIrrelevantField(workload *unstructured.Unstructured) error {
 	// In the case spec.clusterIP is set to `None`, means user want a headless service,  then it shouldn't be removed.
 	clusterIP, exist, _ := unstructured.NestedString(workload.Object, "spec", "clusterIP")
@@ -191,6 +191,23 @@ func removeServiceIrrelevantField(workload *unstructured.Unstructured) error {
 		unstructured.RemoveNestedField(workload.Object, "spec", "clusterIP")
 		unstructured.RemoveNestedField(workload.Object, "spec", "clusterIPs")
 	}
+
+	// spec.ports[*].nodePort is allocated by kube-apiserver. Each member cluster allocates from its
+	// own --service-node-port-range, so the value assigned in the Karmada control plane is not
+	// guaranteed to be free in a given member cluster and must be re-allocated per cluster.
+	ports, exist, _ := unstructured.NestedSlice(workload.Object, "spec", "ports")
+	if exist {
+		for i := range ports {
+			port, ok := ports[i].(map[string]any)
+			if !ok {
+				continue
+			}
+			delete(port, "nodePort")
+			ports[i] = port
+		}
+		_ = unstructured.SetNestedSlice(workload.Object, ports, "spec", "ports")
+	}
+
 	return nil
 }
 

--- a/pkg/resourceinterpreter/default/native/prune/prune_test.go
+++ b/pkg/resourceinterpreter/default/native/prune/prune_test.go
@@ -114,6 +114,104 @@ func TestRemoveIrrelevantField(t *testing.T) {
 			},
 		},
 		{
+			name: "remove service nodePort from spec.ports[*] with multiple ports",
+			workload: &unstructured.Unstructured{
+				Object: map[string]any{
+					"kind": util.ServiceKind,
+					"spec": map[string]any{
+						"type":       "NodePort",
+						"clusterIP":  "10.10.10.10",
+						"clusterIPs": []string{"10.10.10.10"},
+						"ports": []any{
+							map[string]any{
+								"name":       "http",
+								"protocol":   "TCP",
+								"port":       int64(80),
+								"targetPort": int64(80),
+								"nodePort":   int64(32410),
+							},
+							map[string]any{
+								"name":       "https",
+								"protocol":   "TCP",
+								"port":       int64(443),
+								"targetPort": int64(443),
+								"nodePort":   int64(32412),
+							},
+						},
+					},
+				},
+			},
+			unexpectedFields: []field{
+				{"spec", "ports"},
+			},
+			unexpectedResource: "nodePort",
+			shouldNotRemoveFields: []field{
+				{"spec", "ports"},
+			},
+			shouldNotRemoveResource: "name",
+			containsFunc:            portContainsField,
+		},
+		{
+			name: "remove service nodePort from spec.ports[*] with single port",
+			workload: &unstructured.Unstructured{
+				Object: map[string]any{
+					"kind": util.ServiceKind,
+					"spec": map[string]any{
+						"type":       "NodePort",
+						"clusterIP":  "10.10.10.10",
+						"clusterIPs": []string{"10.10.10.10"},
+						"ports": []any{
+							map[string]any{
+								"name":       "http",
+								"protocol":   "TCP",
+								"port":       int64(80),
+								"targetPort": int64(80),
+								"nodePort":   int64(30080),
+							},
+						},
+					},
+				},
+			},
+			unexpectedFields: []field{
+				{"spec", "ports"},
+			},
+			unexpectedResource: "nodePort",
+			shouldNotRemoveFields: []field{
+				{"spec", "ports"},
+			},
+			shouldNotRemoveResource: "name",
+			containsFunc:            portContainsField,
+		},
+		{
+			name: "headless service preserved when stripping nodePort",
+			workload: &unstructured.Unstructured{
+				Object: map[string]any{
+					"kind": util.ServiceKind,
+					"spec": map[string]any{
+						"type":      "ClusterIP",
+						"clusterIP": "None",
+						"ports": []any{
+							map[string]any{
+								"name":       "http",
+								"protocol":   "TCP",
+								"port":       int64(80),
+								"targetPort": int64(80),
+							},
+						},
+					},
+				},
+			},
+			unexpectedFields: []field{
+				{"spec", "ports"},
+			},
+			unexpectedResource: "nodePort",
+			shouldNotRemoveFields: []field{
+				{"spec", "ports"},
+			},
+			shouldNotRemoveResource: "name",
+			containsFunc:            portContainsField,
+		},
+		{
 			name: "remove job irrelevant fields",
 			workload: &unstructured.Unstructured{
 				Object: map[string]any{
@@ -173,16 +271,7 @@ func TestRemoveIrrelevantField(t *testing.T) {
 			unexpectedResource:      "foo-token-6pgxf",
 			shouldNotRemoveFields:   []field{{"secrets"}},
 			shouldNotRemoveResource: "foo-dockercfg-zdr2j",
-			containsFunc: func(obj any, resource string) bool {
-				maps, _ := obj.([]any)
-
-				for _, m := range maps {
-					if m.(map[string]any)["name"] == resource {
-						return true
-					}
-				}
-				return false
-			},
+			containsFunc:            namedEntryContains,
 		},
 		{
 			name: "remove service-account token secret irrelevant fields",
@@ -332,4 +421,34 @@ func getShouldNotRemoveFields(t *test) ([]field, error) {
 		}
 	}
 	return shouldNotRemoveFields, nil
+}
+
+// portContainsField reports whether obj is a slice of port-maps and at least
+// one of them has the given resource as a key. Used by the Service nodePort
+// cases to check that a field was (or was not) stripped from spec.ports[*].
+func portContainsField(obj any, resource string) bool {
+	ports, ok := obj.([]any)
+	if !ok {
+		return false
+	}
+	for _, p := range ports {
+		m, _ := p.(map[string]any)
+		if _, ok := m[resource]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// namedEntryContains reports whether obj is a slice of maps and at least one
+// has its "name" field equal to resource. Used by the ServiceAccount case to
+// check that a specific named entry was (or was not) removed from .secrets.
+func namedEntryContains(obj any, resource string) bool {
+	entries, _ := obj.([]any)
+	for _, e := range entries {
+		if m, ok := e.(map[string]any); ok && m["name"] == resource {
+			return true
+		}
+	}
+	return false
 }

--- a/test/e2e/suites/base/resource_test.go
+++ b/test/e2e/suites/base/resource_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -242,7 +241,6 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 		})
 
 		ginkgo.It("NodePort service apply status collection testing", func() {
-			nodePorts := sets.NewInt32()
 			// collect the NodePort of the service in member clusters.
 			ginkgo.By("Update service status in member clusters", func() {
 
@@ -253,14 +251,11 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 						memberSvc, err := clusterClient.CoreV1().Services(serviceNamespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
 						g.Expect(err).NotTo(gomega.HaveOccurred())
 						for _, servicePort := range memberSvc.Spec.Ports {
-							nodePorts.Insert(servicePort.NodePort)
+							g.Expect(servicePort.NodePort).To(gomega.BeNumerically(">", 0))
 						}
 					}, pollTimeout, pollInterval).Should(gomega.Succeed())
 				}
-				// check service nodePort
-				gomega.Expect(nodePorts.Len() == 1).Should(gomega.BeTrue())
 			})
-			klog.Infof("svcNodePort: %v", nodePorts.List()[0])
 
 			ginkgo.By("check service ResourceBindings apply status ", func() {
 				gomega.Eventually(func(g gomega.Gomega) (metav1.ConditionStatus, error) {


### PR DESCRIPTION
## What this PR does

Extends `removeServiceIrrelevantField` to also strip `spec.ports[*].nodePort`. `nodePort` should be allocated by the member-cluster kube-apiserver, not propagated from the control plane — same rationale as the existing `clusterIP` / `clusterIPs` stripping in this function.

Fixes #7823

## Why

A federated `Service` whose spec contains `spec.ports[*].nodePort` (allocated by the Karmada kube-apiserver) gets dispatched unchanged. When a member cluster already has that NodePort taken, `Work` apply fails with `provided port is already allocated`.

The conflict is at the member-cluster kube-apiserver level: it honors the requested `nodePort` and tries to allocate that exact port. Each member cluster allocates from its own `--service-node-port-range`, so a port free in the control plane is not guaranteed free in any given member cluster.

## What changes

`pkg/resourceinterpreter/default/native/prune/prune.go` — strip `nodePort` from every entry of `spec.ports`, right after the existing `clusterIP` / `clusterIPs` strip. Once stripped, the member-cluster kube-apiserver receives a spec without `nodePort` and allocates one from its own `--service-node-port-range` — no collision. Headless / ClusterIP Services are untouched (no `nodePort` to strip; existing `clusterIP=None` branch preserved).

## Tests

Three new cases in `TestRemoveIrrelevantField`:

- Service with two ports carrying `nodePort` → both stripped, port `name`/`port`/`targetPort` preserved
- Service with one port carrying `nodePort` → stripped, port metadata preserved
- Headless (`clusterIP=None`) without `nodePort` → no-op

Existing `remove service irrelevant fields` case stays unchanged. `go test ./pkg/resourceinterpreter/default/native/prune/...` passes.
