### PR TITLE
fix(search): impersonate caller in karmada proxy plugin instead of using own credentials

### DIFF
--- a/pkg/search/proxy/framework/plugins/karmada/karmada.go
+++ b/pkg/search/proxy/framework/plugins/karmada/karmada.go
@@ -18,10 +18,14 @@ package karmada
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"path"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	restclient "k8s.io/client-go/rest"
 
 	"github.com/karmada-io/karmada/pkg/search/proxy/framework"
@@ -78,14 +82,31 @@ func (p *Karmada) SupportRequest(_ framework.ProxyRequest) bool {
 }
 
 // Connect implements Plugin
-func (p *Karmada) Connect(_ context.Context, request framework.ProxyRequest) (http.Handler, error) {
+func (p *Karmada) Connect(_ context.Context, proxyRequest framework.ProxyRequest) (http.Handler, error) {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		requester, exist := request.UserFrom(req.Context())
+		if !exist {
+			responsewriters.InternalError(rw, req, errors.New("no user found for request"))
+			return
+		}
+
+		// Impersonate the original requester instead of proxying with this
+		// plugin's own (usually highly privileged) credentials, so that the
+		// karmada-apiserver enforces the requester's own RBAC permissions
+		// rather than amplifying them.
+		req.Header.Set(authenticationv1.ImpersonateUserHeader, requester.GetName())
+		for _, group := range requester.GetGroups() {
+			if !proxy.SkipGroup(group) {
+				req.Header.Add(authenticationv1.ImpersonateGroupHeader, group)
+			}
+		}
+
 		location, transport := p.resourceLocation()
-		location.Path = path.Join(location.Path, request.ProxyPath)
+		location.Path = path.Join(location.Path, proxyRequest.ProxyPath)
 		location.RawQuery = req.URL.RawQuery
 
 		handler := proxy.NewThrottledUpgradeAwareProxyHandler(
-			location, transport, true, false, request.Responder)
+			location, transport, true, false, proxyRequest.Responder)
 		handler.ServeHTTP(rw, req)
 	}), nil
 }

--- a/pkg/search/proxy/framework/plugins/karmada/karmada_test.go
+++ b/pkg/search/proxy/framework/plugins/karmada/karmada_test.go
@@ -20,9 +20,13 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	restclient "k8s.io/client-go/rest"
 
 	"github.com/karmada-io/karmada/pkg/search/proxy/framework"
@@ -43,7 +47,9 @@ func Test_karmadaProxy(t *testing.T) {
 	}
 
 	type want struct {
-		path string
+		path          string
+		requestGroups []string
+		wantGroups    []string
 	}
 
 	tests := []struct {
@@ -58,7 +64,9 @@ func Test_karmadaProxy(t *testing.T) {
 				path: "proxy",
 			},
 			want: want{
-				path: "/proxy",
+				path:          "/proxy",
+				requestGroups: []string{"team-a", "system:authenticated"},
+				wantGroups:    []string{"team-a"},
 			},
 		},
 		{
@@ -68,7 +76,9 @@ func Test_karmadaProxy(t *testing.T) {
 				path: "proxy",
 			},
 			want: want{
-				path: "/api/proxy",
+				path:          "/api/proxy",
+				requestGroups: []string{"team-a", "system:authenticated"},
+				wantGroups:    []string{"team-a"},
 			},
 		},
 	}
@@ -99,12 +109,14 @@ func Test_karmadaProxy(t *testing.T) {
 				return
 			}
 
-			request, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+			httpRequest, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
 			if err != nil {
 				t.Error(err)
 				return
 			}
-			h.ServeHTTP(response, request)
+			requester := &user.DefaultInfo{Name: "test-user", Groups: tt.want.requestGroups}
+			httpRequest = httpRequest.WithContext(request.WithUser(httpRequest.Context(), requester))
+			h.ServeHTTP(response, httpRequest)
 
 			if t.Failed() {
 				return
@@ -119,6 +131,41 @@ func Test_karmadaProxy(t *testing.T) {
 				t.Errorf("path got = %v, want = %v", gotRequest.URL.Path, tt.want.path)
 				return
 			}
+
+			if got := gotRequest.Header.Get(authenticationv1.ImpersonateUserHeader); got != requester.GetName() {
+				t.Errorf("impersonate user header got = %v, want = %v", got, requester.GetName())
+			}
+
+			if got := gotRequest.Header.Values(authenticationv1.ImpersonateGroupHeader); !reflect.DeepEqual(got, tt.want.wantGroups) {
+				t.Errorf("impersonate group header got = %v, want = %v", got, tt.want.wantGroups)
+			}
 		})
+	}
+}
+
+func Test_karmadaProxy_NoUser(t *testing.T) {
+	restConfig := &restclient.Config{Host: "http://localhost", Timeout: time.Second}
+	p, err := New(pluginruntime.PluginDependency{RestConfig: restConfig})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response := httptest.NewRecorder()
+	h, err := p.Connect(context.TODO(), framework.ProxyRequest{
+		ProxyPath: "proxy",
+		Responder: utiltest.NewResponder(response),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	httpRequest, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.ServeHTTP(response, httpRequest)
+
+	if response.Code != http.StatusInternalServerError {
+		t.Errorf("status code got = %v, want = %v", response.Code, http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The `karmada` search-proxy plugin (the fallback plugin that proxies requests to
karmada-apiserver when the `cache` and `cluster` plugins don't handle them) proxied
every request using its own credentials (`dep.RestConfig`), without impersonating the
original caller. In every current deployment path (karmadactl init, karmada-operator,
and the Helm chart), the kubeconfig karmada-search runs with is signed for
`system:masters`, i.e. it is cluster-admin-equivalent. Because the plugin never
forwarded caller identity, a request that reached this fallback plugin was executed
against karmada-apiserver as `system:masters` regardless of the caller's own RBAC
permissions — e.g. a read-only user's request falling through to this plugin would be
authorized as cluster-admin on the karmada control plane.

This mirrors the exact impersonation pattern already used elsewhere in this codebase
for the same purpose (`pkg/util/proxy/proxy.go`'s `newProxyHandler`, used for member
cluster proxying, and `pkg/registry/cluster/storage/aggregate.go`): extract the
original requester from the request context and set the `Impersonate-User` /
`Impersonate-Group` headers (skipping the `system:authenticated`/`system:unauthenticated`
pseudo-groups via the already-exported `proxy.SkipGroup` helper) before proxying, so
karmada-apiserver authorizes the request as the real caller instead of as the plugin's
own credentials.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

No RBAC manifest changes are needed: karmada-search's kubeconfig is provisioned as a
`system:masters` credential in all three deployment paths (karmadactl init, the
karmada-operator, and the Helm chart), which bypasses RBAC (including impersonation
checks) entirely, so the existing credential already has implicit permission to
impersonate any user.

Validation:
- `go build ./pkg/search/...`
- `go test -count=1 ./pkg/search/...` (all pass, including the new/updated
  `Test_karmadaProxy` and `Test_karmadaProxy_NoUser` cases in
  `pkg/search/proxy/framework/plugins/karmada/karmada_test.go`)
- Confirmed the new tests are a genuine regression test: reverting only the
  `karmada.go` change and re-running the same tests fails them (missing
  `Impersonate-User`/`Impersonate-Group` headers, and a 200 instead of a 500 when no
  user is present in the request context); restoring the fix makes them pass again.
- `gofmt -l`, `hack/verify-license.sh`, `hack/verify-import-aliases.sh`, and
  `golangci-lint run ./pkg/search/proxy/framework/plugins/karmada/...` all pass with
  no issues.
- Not run: a live multi-cluster e2e reproduction (no live karmada-search deployment
  was available in this environment). The fix and its RBAC-safety reasoning were
  verified by tracing the code paths that provision karmada-search's credentials
  instead.

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-search`: Fixed the issue that the `karmada` search-proxy plugin used its own (cluster-admin-equivalent) credentials instead of impersonating the caller, which could let a request bypass the caller's own RBAC restrictions on the karmada control plane.
```

Fixes #5485