### PR TITLE
feat: trigger rescheduling on component replica changes

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -263,7 +263,13 @@ func TestDoScheduleBinding(t *testing.T) {
 		{
 			name: "binding with component replicas changed",
 			binding: &workv1alpha2.ResourceBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-binding-components", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-binding-components",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.PolicyPlacementAnnotation: `{"replicaScheduling":{"replicaSchedulingType":"Divided"}}`,
+					},
+				},
 				Spec: workv1alpha2.ResourceBindingSpec{
 					Components: []workv1alpha2.Component{
 						{Name: "jobmanager", Replicas: 1},
@@ -423,7 +429,12 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 		{
 			name: "cluster binding with component replicas changed",
 			binding: &workv1alpha2.ClusterResourceBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-binding-components"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-binding-components",
+					Annotations: map[string]string{
+						util.PolicyPlacementAnnotation: `{"replicaScheduling":{"replicaSchedulingType":"Divided"}}`,
+					},
+				},
 				Spec: workv1alpha2.ResourceBindingSpec{
 					Components: []workv1alpha2.Component{
 						{Name: "jobmanager", Replicas: 1},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -186,6 +186,7 @@ func TestDoScheduleBinding(t *testing.T) {
 		expectError      bool
 		expectedClusters []workv1alpha2.TargetCluster
 		expectedEvent    string
+		enableComponents bool
 	}{
 		{
 			name: "binding with changed placement",
@@ -259,10 +260,43 @@ func TestDoScheduleBinding(t *testing.T) {
 			},
 			expectedEvent: "Normal ScheduleBindingSucceed",
 		},
+		{
+			name: "binding with component replicas changed",
+			binding: &workv1alpha2.ResourceBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-binding-components", Namespace: "default"},
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Components: []workv1alpha2.Component{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 6},
+					},
+					Clusters: []workv1alpha2.TargetCluster{{
+						Name: "cluster1",
+						Components: []workv1alpha2.TargetComponent{
+							{Name: "jobmanager", Replicas: 1},
+							{Name: "taskmanager", Replicas: 4},
+						},
+					}},
+					Placement: &policyv1alpha1.Placement{ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+						ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided,
+					}},
+				},
+			},
+			expectSchedule: true,
+			expectedClusters: []workv1alpha2.TargetCluster{{
+				Name: "cluster1",
+				Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6},
+				},
+			}},
+			expectedEvent:    "Normal ScheduleBindingSucceed",
+			enableComponents: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer setFeatureGateDuringTest(t, features.FeatureGate, features.MultiplePodTemplatesScheduling, tt.enableComponents)()
 			fakeClient := karmadafake.NewClientset(tt.binding)
 			fakeRecorder := record.NewFakeRecorder(10)
 			mockAlgorithm := &mockAlgorithm{
@@ -315,6 +349,7 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 		expectError      bool
 		expectedClusters []workv1alpha2.TargetCluster
 		expectedEvent    string
+		enableComponents bool
 	}{
 		{
 			name: "cluster binding with changed placement",
@@ -385,10 +420,43 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 			},
 			expectedEvent: "Normal ScheduleBindingSucceed",
 		},
+		{
+			name: "cluster binding with component replicas changed",
+			binding: &workv1alpha2.ClusterResourceBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-binding-components"},
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Components: []workv1alpha2.Component{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 6},
+					},
+					Clusters: []workv1alpha2.TargetCluster{{
+						Name: "cluster1",
+						Components: []workv1alpha2.TargetComponent{
+							{Name: "jobmanager", Replicas: 1},
+							{Name: "taskmanager", Replicas: 4},
+						},
+					}},
+					Placement: &policyv1alpha1.Placement{ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+						ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided,
+					}},
+				},
+			},
+			expectSchedule: true,
+			expectedClusters: []workv1alpha2.TargetCluster{{
+				Name: "cluster1",
+				Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6},
+				},
+			}},
+			expectedEvent:    "Normal ScheduleBindingSucceed",
+			enableComponents: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer setFeatureGateDuringTest(t, features.FeatureGate, features.MultiplePodTemplatesScheduling, tt.enableComponents)()
 			fakeClient := karmadafake.NewClientset(tt.binding)
 			fakeRecorder := record.NewFakeRecorder(10)
 			mockAlgorithm := &mockAlgorithm{

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -34,21 +34,37 @@ func GetBindingClusterNames(spec *workv1alpha2.ResourceBindingSpec) []string {
 	return clusterNames
 }
 
-// IsBindingReplicasChanged reports whether the desired scalar or per-component replicas differ from the accepted result.
+// ComponentScale describes how desired component replicas differ from the scheduled result.
+type ComponentScale int
+
+const (
+	// ComponentScaleUnknown indicates that the desired and scheduled snapshots cannot be compared safely.
+	ComponentScaleUnknown ComponentScale = iota
+	// ComponentScaleNone indicates that all component replicas are unchanged.
+	ComponentScaleNone
+	// ComponentScaleUp indicates that at least one component scaled up and none scaled down.
+	ComponentScaleUp
+	// ComponentScaleDown indicates that at least one component scaled down and none scaled up.
+	ComponentScaleDown
+	// ComponentScaleMixed indicates that some components scaled up while others scaled down.
+	ComponentScaleMixed
+)
+
+// IsBindingReplicasChanged reports whether the desired replicas differ from the scheduled result.
 func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, strategy *policyv1alpha1.ReplicaSchedulingStrategy) bool {
 	if strategy == nil {
 		return false
 	}
 
 	// Component-based workloads also need rescheduling after eviction. For multi-component workloads,
-	// compare the desired replicas with the component snapshot accepted by the scheduler.
+	// classify the desired replicas against the component snapshot produced by the scheduler.
 	if features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) && len(bindingSpec.Components) > 0 {
 		if len(bindingSpec.Clusters) == 0 {
 			return true
 		}
 		if len(bindingSpec.Components) > 1 && len(bindingSpec.Clusters) == 1 {
-			equal, comparable := ComponentReplicasEqual(bindingSpec.Components, bindingSpec.Clusters[0].Components)
-			if comparable && !equal {
+			scale := ClassifyComponentScale(bindingSpec.Components, bindingSpec.Clusters[0].Components)
+			if scale == ComponentScaleUp || scale == ComponentScaleDown || scale == ComponentScaleMixed {
 				return true
 			}
 		}
@@ -69,44 +85,64 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, str
 	return false
 }
 
-// ComponentReplicasEqual compares desired component replicas with an accepted snapshot by name.
-// The second return value reports whether both snapshots are complete and comparable.
-func ComponentReplicasEqual(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) (bool, bool) {
-	if len(accepted) == 0 || len(desired) != len(accepted) {
-		return false, false
+// ClassifyComponentScale compares desired component replicas with the scheduled result by name.
+func ClassifyComponentScale(desired []workv1alpha2.Component, scheduled []workv1alpha2.TargetComponent) ComponentScale {
+	if len(desired) == 0 || len(desired) != len(scheduled) {
+		return ComponentScaleUnknown
 	}
 
-	acceptedReplicas := make(map[string]int32, len(accepted))
-	for i := range accepted {
-		if accepted[i].Name == "" {
-			return false, false
-		}
-		if _, exists := acceptedReplicas[accepted[i].Name]; exists {
-			return false, false
-		}
-		acceptedReplicas[accepted[i].Name] = accepted[i].Replicas
+	scheduledReplicas, valid := scheduledComponentReplicas(scheduled)
+	if !valid {
+		return ComponentScaleUnknown
 	}
 
 	seen := make(map[string]struct{}, len(desired))
-	changed := false
+	var scaleUp, scaleDown bool
 	for i := range desired {
 		if desired[i].Name == "" {
-			return false, false
+			return ComponentScaleUnknown
 		}
 		if _, exists := seen[desired[i].Name]; exists {
-			return false, false
+			return ComponentScaleUnknown
 		}
 		seen[desired[i].Name] = struct{}{}
 
-		replicas, exists := acceptedReplicas[desired[i].Name]
+		replicas, exists := scheduledReplicas[desired[i].Name]
 		if !exists {
-			return false, false
+			return ComponentScaleUnknown
 		}
-		if desired[i].Replicas != replicas {
-			changed = true
+		switch {
+		case desired[i].Replicas > replicas:
+			scaleUp = true
+		case desired[i].Replicas < replicas:
+			scaleDown = true
 		}
 	}
-	return !changed, true
+
+	switch {
+	case scaleUp && scaleDown:
+		return ComponentScaleMixed
+	case scaleUp:
+		return ComponentScaleUp
+	case scaleDown:
+		return ComponentScaleDown
+	default:
+		return ComponentScaleNone
+	}
+}
+
+func scheduledComponentReplicas(scheduled []workv1alpha2.TargetComponent) (replicasByName map[string]int32, valid bool) {
+	replicasByName = make(map[string]int32, len(scheduled))
+	for i := range scheduled {
+		if scheduled[i].Name == "" {
+			return nil, false
+		}
+		if _, exists := replicasByName[scheduled[i].Name]; exists {
+			return nil, false
+		}
+		replicasByName[scheduled[i].Name] = scheduled[i].Replicas
+	}
+	return replicasByName, true
 }
 
 // GetSumOfReplicas will get the sum of replicas in target clusters

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -34,21 +34,20 @@ func GetBindingClusterNames(spec *workv1alpha2.ResourceBindingSpec) []string {
 	return clusterNames
 }
 
-// IsBindingReplicasChanged will check if the sum of replicas is different from the replicas of object
+// IsBindingReplicasChanged reports whether the desired scalar or per-component replicas differ from the accepted result.
 func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, strategy *policyv1alpha1.ReplicaSchedulingStrategy) bool {
 	if strategy == nil {
 		return false
 	}
 
-	// For component-based workloads, trigger rescheduling when clusters are empty (e.g., after eviction).
-	// This is a temporary fix to ensure cluster failover works correctly.
-	// Limitation: This only handles the failover scenario where clusters are cleared.
-	// It does not detect component replica changes (e.g., scale up/down) or replica swaps between components.
-	// A complete solution requires changing how scheduling results are stored to support multi-template workloads,
-	// likely by extending TargetCluster to include per-component replica information.
-	// The comprehensive solution is tracked by: https://github.com/karmada-io/karmada/issues/6998
+	// Component-based workloads also need rescheduling after eviction. For multi-component workloads,
+	// compare the desired replicas with the component snapshot accepted by the scheduler.
 	if features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) && len(bindingSpec.Components) > 0 {
 		if len(bindingSpec.Clusters) == 0 {
+			return true
+		}
+		if len(bindingSpec.Components) > 1 && len(bindingSpec.Clusters) == 1 &&
+			isComponentReplicasChanged(bindingSpec.Components, bindingSpec.Clusters[0].Components) {
 			return true
 		}
 	}
@@ -66,6 +65,44 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, str
 		return replicasSum != bindingSpec.Replicas
 	}
 	return false
+}
+
+func isComponentReplicasChanged(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) bool {
+	if len(accepted) == 0 || len(desired) != len(accepted) {
+		return false
+	}
+
+	acceptedReplicas := make(map[string]int32, len(accepted))
+	for i := range accepted {
+		if accepted[i].Name == "" {
+			return false
+		}
+		if _, exists := acceptedReplicas[accepted[i].Name]; exists {
+			return false
+		}
+		acceptedReplicas[accepted[i].Name] = accepted[i].Replicas
+	}
+
+	seen := make(map[string]struct{}, len(desired))
+	changed := false
+	for i := range desired {
+		if desired[i].Name == "" {
+			return false
+		}
+		if _, exists := seen[desired[i].Name]; exists {
+			return false
+		}
+		seen[desired[i].Name] = struct{}{}
+
+		replicas, exists := acceptedReplicas[desired[i].Name]
+		if !exists {
+			return false
+		}
+		if desired[i].Replicas != replicas {
+			changed = true
+		}
+	}
+	return changed
 }
 
 // GetSumOfReplicas will get the sum of replicas in target clusters

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -46,9 +46,11 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, str
 		if len(bindingSpec.Clusters) == 0 {
 			return true
 		}
-		if len(bindingSpec.Components) > 1 && len(bindingSpec.Clusters) == 1 &&
-			isComponentReplicasChanged(bindingSpec.Components, bindingSpec.Clusters[0].Components) {
-			return true
+		if len(bindingSpec.Components) > 1 && len(bindingSpec.Clusters) == 1 {
+			equal, comparable := ComponentReplicasEqual(bindingSpec.Components, bindingSpec.Clusters[0].Components)
+			if comparable && !equal {
+				return true
+			}
 		}
 	}
 
@@ -67,18 +69,20 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, str
 	return false
 }
 
-func isComponentReplicasChanged(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) bool {
+// ComponentReplicasEqual compares desired component replicas with an accepted snapshot by name.
+// The second return value reports whether both snapshots are complete and comparable.
+func ComponentReplicasEqual(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) (bool, bool) {
 	if len(accepted) == 0 || len(desired) != len(accepted) {
-		return false
+		return false, false
 	}
 
 	acceptedReplicas := make(map[string]int32, len(accepted))
 	for i := range accepted {
 		if accepted[i].Name == "" {
-			return false
+			return false, false
 		}
 		if _, exists := acceptedReplicas[accepted[i].Name]; exists {
-			return false
+			return false, false
 		}
 		acceptedReplicas[accepted[i].Name] = accepted[i].Replicas
 	}
@@ -87,22 +91,22 @@ func isComponentReplicasChanged(desired []workv1alpha2.Component, accepted []wor
 	changed := false
 	for i := range desired {
 		if desired[i].Name == "" {
-			return false
+			return false, false
 		}
 		if _, exists := seen[desired[i].Name]; exists {
-			return false
+			return false, false
 		}
 		seen[desired[i].Name] = struct{}{}
 
 		replicas, exists := acceptedReplicas[desired[i].Name]
 		if !exists {
-			return false
+			return false, false
 		}
 		if desired[i].Replicas != replicas {
 			changed = true
 		}
 	}
-	return changed
+	return !changed, true
 }
 
 // GetSumOfReplicas will get the sum of replicas in target clusters

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -86,27 +86,19 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, str
 }
 
 // ClassifyComponentScale compares desired component replicas with the scheduled result by name.
+// Desired component names are expected to be non-empty and unique, as enforced by admission.
 func ClassifyComponentScale(desired []workv1alpha2.Component, scheduled []workv1alpha2.TargetComponent) ComponentScale {
 	if len(desired) == 0 || len(desired) != len(scheduled) {
 		return ComponentScaleUnknown
 	}
 
-	scheduledReplicas, valid := scheduledComponentReplicas(scheduled)
-	if !valid {
-		return ComponentScaleUnknown
+	scheduledReplicas := make(map[string]int32, len(scheduled))
+	for i := range scheduled {
+		scheduledReplicas[scheduled[i].Name] = scheduled[i].Replicas
 	}
 
-	seen := make(map[string]struct{}, len(desired))
 	var scaleUp, scaleDown bool
 	for i := range desired {
-		if desired[i].Name == "" {
-			return ComponentScaleUnknown
-		}
-		if _, exists := seen[desired[i].Name]; exists {
-			return ComponentScaleUnknown
-		}
-		seen[desired[i].Name] = struct{}{}
-
 		replicas, exists := scheduledReplicas[desired[i].Name]
 		if !exists {
 			return ComponentScaleUnknown
@@ -129,20 +121,6 @@ func ClassifyComponentScale(desired []workv1alpha2.Component, scheduled []workv1
 	default:
 		return ComponentScaleNone
 	}
-}
-
-func scheduledComponentReplicas(scheduled []workv1alpha2.TargetComponent) (replicasByName map[string]int32, valid bool) {
-	replicasByName = make(map[string]int32, len(scheduled))
-	for i := range scheduled {
-		if scheduled[i].Name == "" {
-			return nil, false
-		}
-		if _, exists := replicasByName[scheduled[i].Name]; exists {
-			return nil, false
-		}
-		replicasByName[scheduled[i].Name] = scheduled[i].Replicas
-	}
-	return replicasByName, true
 }
 
 // GetSumOfReplicas will get the sum of replicas in target clusters

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -278,6 +278,24 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "mixed multi-component scale should trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 2},
+					{Name: "taskmanager", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 6},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: true,
+		},
+		{
 			name: "equal multi-component replicas should not trigger rescheduling",
 			bindingSpec: &workv1alpha2.ResourceBindingSpec{
 				Components: []workv1alpha2.Component{
@@ -296,7 +314,7 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "missing accepted component snapshot should not trigger scale rescheduling",
+			name: "missing scheduled component snapshot should not trigger scale rescheduling",
 			bindingSpec: &workv1alpha2.ResourceBindingSpec{
 				Components: []workv1alpha2.Component{
 					{Name: "jobmanager", Replicas: 1},
@@ -313,6 +331,25 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 				Components: []workv1alpha2.Component{
 					{Name: "jobmanager", Replicas: 2},
 					{Name: "worker", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 4},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: false,
+		},
+		{
+			name: "component count change should not trigger replica scale rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+					{Name: "sidecar", Replicas: 1},
 				},
 				Clusters: []workv1alpha2.TargetCluster{{
 					Name: ClusterMember1,
@@ -357,48 +394,94 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 	}
 }
 
-func TestComponentReplicasEqual(t *testing.T) {
+func TestClassifyComponentScale(t *testing.T) {
 	tests := []struct {
-		name       string
-		desired    []workv1alpha2.Component
-		accepted   []workv1alpha2.TargetComponent
-		equal      bool
-		comparable bool
+		name      string
+		desired   []workv1alpha2.Component
+		scheduled []workv1alpha2.TargetComponent
+		want      ComponentScale
 	}{
 		{
-			name:       "equal snapshots ignore order",
-			desired:    []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
-			accepted:   []workv1alpha2.TargetComponent{{Name: "taskmanager", Replicas: 4}, {Name: "jobmanager", Replicas: 1}},
-			equal:      true,
-			comparable: true,
+			name:      "equal snapshots ignore order",
+			desired:   []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			scheduled: []workv1alpha2.TargetComponent{{Name: "taskmanager", Replicas: 4}, {Name: "jobmanager", Replicas: 1}},
+			want:      ComponentScaleNone,
 		},
 		{
-			name:       "replicas changed",
-			desired:    []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
-			accepted:   []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
-			comparable: true,
+			name:      "pure scale up",
+			desired:   []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			scheduled: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			want:      ComponentScaleUp,
 		},
 		{
-			name:    "accepted snapshot missing",
+			name:      "all components scale up",
+			desired:   []workv1alpha2.Component{{Name: "jobmanager", Replicas: 2}, {Name: "taskmanager", Replicas: 6}},
+			scheduled: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			want:      ComponentScaleUp,
+		},
+		{
+			name:      "pure scale down",
+			desired:   []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 2}},
+			scheduled: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			want:      ComponentScaleDown,
+		},
+		{
+			name:      "mixed scale",
+			desired:   []workv1alpha2.Component{{Name: "jobmanager", Replicas: 2}, {Name: "taskmanager", Replicas: 2}},
+			scheduled: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			want:      ComponentScaleMixed,
+		},
+		{
+			name:    "scheduled snapshot missing",
 			desired: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}},
+			want:    ComponentScaleUnknown,
 		},
 		{
-			name:     "component names differ",
-			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
-			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "worker", Replicas: 4}},
+			name:      "component counts differ",
+			desired:   []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			scheduled: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}},
+			want:      ComponentScaleUnknown,
 		},
 		{
-			name:     "accepted names duplicated",
-			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
-			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "jobmanager", Replicas: 4}},
+			name:      "component names differ",
+			desired:   []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			scheduled: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "worker", Replicas: 4}},
+			want:      ComponentScaleUnknown,
+		},
+		{
+			name:      "scheduled names duplicated",
+			desired:   []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			scheduled: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "jobmanager", Replicas: 4}},
+			want:      ComponentScaleUnknown,
+		},
+		{
+			name:      "desired names duplicated",
+			desired:   []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "jobmanager", Replicas: 4}},
+			scheduled: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			want:      ComponentScaleUnknown,
+		},
+		{
+			name:      "desired name empty",
+			desired:   []workv1alpha2.Component{{Name: "", Replicas: 1}},
+			scheduled: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}},
+			want:      ComponentScaleUnknown,
+		},
+		{
+			name:      "scheduled name empty",
+			desired:   []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}},
+			scheduled: []workv1alpha2.TargetComponent{{Name: "", Replicas: 1}},
+			want:      ComponentScaleUnknown,
+		},
+		{
+			name: "empty snapshots",
+			want: ComponentScaleUnknown,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			equal, comparable := ComponentReplicasEqual(tt.desired, tt.accepted)
-			if equal != tt.equal || comparable != tt.comparable {
-				t.Fatalf("ComponentReplicasEqual() = (%t, %t), want (%t, %t)", equal, comparable, tt.equal, tt.comparable)
+			if got := ClassifyComponentScale(tt.desired, tt.scheduled); got != tt.want {
+				t.Fatalf("ClassifyComponentScale() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -178,6 +178,24 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
 			expected: true,
 		},
+		{
+			name: "component replicas changed with feature gate disabled",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 4},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: false,
+		},
 	}
 
 	// Component-based workload failover tests require the MultiplePodTemplatesScheduling feature gate.
@@ -221,6 +239,90 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 				},
 			},
 			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDuplicated},
+			expected: false,
+		},
+		{
+			name: "multi-component scale up should trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 4},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: true,
+		},
+		{
+			name: "multi-component scale down should trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 6},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: true,
+		},
+		{
+			name: "equal multi-component replicas should not trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "taskmanager", Replicas: 4},
+						{Name: "jobmanager", Replicas: 1},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: false,
+		},
+		{
+			name: "missing accepted component snapshot should not trigger scale rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{Name: ClusterMember1}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: false,
+		},
+		{
+			name: "component name change should not trigger replica scale rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 2},
+					{Name: "worker", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 4},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
 			expected: false,
 		},
 	}

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -357,6 +357,53 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 	}
 }
 
+func TestComponentReplicasEqual(t *testing.T) {
+	tests := []struct {
+		name       string
+		desired    []workv1alpha2.Component
+		accepted   []workv1alpha2.TargetComponent
+		equal      bool
+		comparable bool
+	}{
+		{
+			name:       "equal snapshots ignore order",
+			desired:    []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted:   []workv1alpha2.TargetComponent{{Name: "taskmanager", Replicas: 4}, {Name: "jobmanager", Replicas: 1}},
+			equal:      true,
+			comparable: true,
+		},
+		{
+			name:       "replicas changed",
+			desired:    []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			accepted:   []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			comparable: true,
+		},
+		{
+			name:    "accepted snapshot missing",
+			desired: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}},
+		},
+		{
+			name:     "component names differ",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "worker", Replicas: 4}},
+		},
+		{
+			name:     "accepted names duplicated",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "jobmanager", Replicas: 4}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			equal, comparable := ComponentReplicasEqual(tt.desired, tt.accepted)
+			if equal != tt.equal || comparable != tt.comparable {
+				t.Fatalf("ComponentReplicasEqual() = (%t, %t), want (%t, %t)", equal, comparable, tt.equal, tt.comparable)
+			}
+		})
+	}
+}
+
 func TestGetSumOfReplicas(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -455,18 +455,6 @@ func TestClassifyComponentScale(t *testing.T) {
 			want:      ComponentScaleUnknown,
 		},
 		{
-			name:      "desired names duplicated",
-			desired:   []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "jobmanager", Replicas: 4}},
-			scheduled: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
-			want:      ComponentScaleUnknown,
-		},
-		{
-			name:      "desired name empty",
-			desired:   []workv1alpha2.Component{{Name: "", Replicas: 1}},
-			scheduled: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}},
-			want:      ComponentScaleUnknown,
-		},
-		{
 			name:      "scheduled name empty",
 			desired:   []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}},
 			scheduled: []workv1alpha2.TargetComponent{{Name: "", Replicas: 1}},


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind feature

**What this PR does / why we need it**:

For multi-template workloads, the scalar replica fields remain zero, so `IsBindingReplicasChanged` cannot detect component scale-up or scale-down. As a result, an existing Binding does not re-enter the scheduler when component replicas change.

With `MultiplePodTemplatesScheduling` enabled, this change compares the desired `spec.components` replicas with the scheduler-accepted `spec.clusters[0].components` snapshot by component name. Scale-up and scale-down enter the existing `ScaleSchedule` path, while equal snapshots, including reordered entries, keep the existing behavior.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

Part of #7895

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

- Scope: this PR only triggers rescheduling. Incremental estimation and failure-safe Work propagation remain in #7835 and #7841.
- Missing or incomparable accepted component snapshots do not select a fallback policy in this PR; the existing behavior is preserved.
- Tests: `go test -race -count=1 ./pkg/util -run '^TestIsBindingReplicasChanged$'`, `go test -race -count=1 ./pkg/scheduler -run '^(TestDoScheduleBinding|TestDoScheduleClusterBinding)$'`, and `go test -count=1 ./pkg/util ./pkg/scheduler` passed. Full `make test` and live E2E were not run.
- AI assistance: Codex helped inspect the scheduling path and draft the implementation and tests; I reviewed the final diff and validation results.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->

```release-note
`karmada-scheduler`: Multi-template workloads are rescheduled when component replicas change.
```
