### PR TITLE
feat: persist component scheduling results

### DIFF
--- a/pkg/scheduler/core/common.go
+++ b/pkg/scheduler/core/common.go
@@ -71,10 +71,26 @@ func AssignReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1a
 
 	// For non-workloads (e.g., Service, Config) and multi-component workloads (e.g., FlinkDeployment), propagate to all candidate clusters.
 	targetClusters := make([]workv1alpha2.TargetCluster, len(clusters))
+	recordComponentResult := features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) &&
+		len(spec.Components) > 1 && isMultiTemplateSchedulingApplicable(spec)
 	for i, cluster := range clusters {
 		targetClusters[i] = workv1alpha2.TargetCluster{Name: cluster.Cluster.Name}
+		if recordComponentResult {
+			targetClusters[i].Components = buildTargetComponents(spec.Components)
+		}
 	}
 	return targetClusters, nil
+}
+
+func buildTargetComponents(components []workv1alpha2.Component) []workv1alpha2.TargetComponent {
+	result := make([]workv1alpha2.TargetComponent, len(components))
+	for i := range components {
+		result[i] = workv1alpha2.TargetComponent{
+			Name:     components[i].Name,
+			Replicas: components[i].Replicas,
+		}
+	}
+	return result
 }
 
 // assignWorkloadReplicas assigns replicas to clusters for workloads, supporting overflow if enabled.

--- a/pkg/scheduler/core/common_test.go
+++ b/pkg/scheduler/core/common_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package core
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,7 @@ import (
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/features"
 	"github.com/karmada-io/karmada/pkg/scheduler/core/spreadconstraint"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework"
 	"github.com/karmada-io/karmada/test/helper"
@@ -171,6 +173,90 @@ func TestSelectClusters(t *testing.T) {
 
 				assert.ElementsMatch(t, expectedNames, actualNames)
 			}
+		})
+	}
+}
+
+func TestAssignComponentSchedulingResults(t *testing.T) {
+	applicablePlacement := &policyv1alpha1.Placement{SpreadConstraints: []policyv1alpha1.SpreadConstraint{{
+		SpreadByField: policyv1alpha1.SpreadByFieldCluster,
+		MinGroups:     1,
+		MaxGroups:     1,
+	}}}
+
+	tests := []struct {
+		name        string
+		featureGate bool
+		clusters    []spreadconstraint.ClusterDetailInfo
+		spec        *workv1alpha2.ResourceBindingSpec
+		want        []workv1alpha2.TargetCluster
+	}{
+		{
+			name:        "multi-component workload writes complete result",
+			featureGate: true,
+			clusters:    []spreadconstraint.ClusterDetailInfo{{Name: ClusterMember1, Cluster: helper.NewCluster(ClusterMember1)}},
+			spec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+				Placement:  applicablePlacement,
+			},
+			want: []workv1alpha2.TargetCluster{{
+				Name: ClusterMember1,
+				Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+				},
+			}},
+		},
+		{
+			name:        "feature disabled keeps legacy result",
+			featureGate: false,
+			clusters:    []spreadconstraint.ClusterDetailInfo{{Name: ClusterMember1, Cluster: helper.NewCluster(ClusterMember1)}},
+			spec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+				Placement:  applicablePlacement,
+			},
+			want: []workv1alpha2.TargetCluster{{Name: ClusterMember1}},
+		},
+		{
+			name:        "unsupported placement keeps legacy result",
+			featureGate: true,
+			clusters:    []spreadconstraint.ClusterDetailInfo{{Name: ClusterMember1, Cluster: helper.NewCluster(ClusterMember1)}},
+			spec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+				Placement:  &policyv1alpha1.Placement{},
+			},
+			want: []workv1alpha2.TargetCluster{{Name: ClusterMember1}},
+		},
+		{
+			name:        "ordinary workload keeps scalar result",
+			featureGate: true,
+			clusters:    []spreadconstraint.ClusterDetailInfo{{Name: ClusterMember1, Cluster: helper.NewCluster(ClusterMember1)}},
+			spec: &workv1alpha2.ResourceBindingSpec{
+				Replicas: 3,
+				Placement: &policyv1alpha1.Placement{
+					ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+						ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+						ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
+					},
+				},
+			},
+			want: []workv1alpha2.TargetCluster{{Name: ClusterMember1, Replicas: 3}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalFeatureGates := features.FeatureGate.DeepCopy()
+			if err := features.FeatureGate.Set(fmt.Sprintf("%s=%t", features.MultiplePodTemplatesScheduling, tt.featureGate)); err != nil {
+				t.Fatalf("failed to set feature gate %s: %v", features.MultiplePodTemplatesScheduling, err)
+			}
+			t.Cleanup(func() {
+				features.FeatureGate = originalFeatureGates
+			})
+
+			got, err := AssignReplicas(tt.clusters, tt.spec, &workv1alpha2.ResourceBindingStatus{})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

#7837 introduced `TargetCluster.components`, but the scheduler still stores only the selected cluster names for multi-template workloads.

When `MultiplePodTemplatesScheduling` is enabled and the placement selects exactly one cluster, this change copies the complete component name and replica assignment from `spec.components` into the selected `TargetCluster.components`. The existing ResourceBinding and ClusterResourceBinding schedule-result patch paths then persist the complete `TargetCluster` in `spec.clusters`.

This PR only produces the scheduling result. Applying the result to Work, interpreter changes, and replica-change rescheduling remain follow-up work.

**Which issue(s) this PR fixes**:

Part of #7492

**Special notes for your reviewer**:

- Only workloads with multiple components use the new result field. Ordinary and single-component workloads retain the legacy scalar result. Feature-gate-disabled and unsupported placement paths are unchanged.
- Validation: focused race tests and all scheduler package tests passed. Full repository tests and live E2E were not completed; PR CI will rerun the repository test matrix.

Codex assisted with implementation, tests, and review; I reviewed the final diff and validation results.

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-scheduler`: With the `MultiplePodTemplatesScheduling` feature gate enabled, the scheduler now records per-component replica assignments in the scheduling result (`spec.clusters[*].components`) of ResourceBinding/ClusterResourceBinding for workloads with multiple pod templates.
```
