### PR TITLE
fix(hack): use OS-aware endpoint detection in create-cluster.sh

### DIFF
--- a/hack/create-cluster.sh
+++ b/hack/create-cluster.sh
@@ -104,14 +104,12 @@ kind create cluster --name "${CLUSTER_NAME}" --kubeconfig="${KUBECONFIG}" --imag
 )
 rm -rf "${kind_log}"
 
-# Kind cluster's context name contains a "kind-" prefix by default.
-# Change context name to cluster name.
-kubectl config rename-context "kind-${CLUSTER_NAME}" "${CLUSTER_NAME}" --kubeconfig="${KUBECONFIG}"
-
-# Kind cluster uses `127.0.0.1` as kube-apiserver endpoint by default, thus kind clusters can't reach each other.
-# So we need to update endpoint with container IP.
-container_ip=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${CLUSTER_NAME}-control-plane")
-kubectl config set-cluster "kind-${CLUSTER_NAME}" --server="https://${container_ip}:6443" --kubeconfig="${KUBECONFIG}"
+# Kind cluster's context name contains a "kind-" prefix by default. Change context
+# name to cluster name, and update the endpoint address in kubeconfig, since the
+# container's native IP is not routable from the host on macOS/WSL2 (Docker Desktop
+# runs containers inside a VM), while kind's default `127.0.0.1` endpoint is only
+# reachable from the host, not from other containers.
+util::check_clusters_ready "${KUBECONFIG}" "${CLUSTER_NAME}"
 
 echo "cluster \"${CLUSTER_NAME}\" is created successfully!"
 echo "You can now use your cluster with:"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`hack/create-cluster.sh` writes the kind control-plane container's native
Docker IP straight into the generated kubeconfig's server address. On native
Linux this IP is directly routable from the host, but on macOS/WSL2, Docker
Desktop runs containers inside a VM, so the host cannot route to that
container IP at all. Anyone following the "Install Karmada in kind cluster"
doc on macOS and running `kubectl karmada init` (or any other host-side
`kubectl`) against the generated kubeconfig hits
`dial tcp <container_ip>:6443: connect: no route to host`.

This exact OS-aware endpoint detection already exists in this repo as
`util::check_clusters_ready` (`hack/util.sh`), which picks the native
container IP on Linux but the Docker-published host IP:port (via
`docker inspect`'s `NetworkSettings.Ports`) on macOS/WSL2, and only reports
success once `/healthz` is actually reachable. It's already used by
`hack/setup-dev-base.sh` (the script behind `hack/local-up-karmada.sh`, which
is exercised by CI's e2e job) for every cluster it creates. `create-cluster.sh`
is a separate, standalone script — the one the installation doc tells users
to run directly — that was never updated to use it, so it kept the old,
Linux-only logic.

**Approach**: Replace the manual `rename-context` + `docker inspect`
container-IP logic in `hack/create-cluster.sh` with a call to the existing
`util::check_clusters_ready`, matching how `hack/setup-dev-base.sh` already
uses it for the other kind clusters it creates. `util.sh` is already sourced
by `create-cluster.sh`. Behavior for native Linux is unchanged (still uses
the native container IP); macOS/WSL2 now get the host-reachable
address instead of the unroutable container IP.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Validation performed:
- `bash -n hack/create-cluster.sh` — passes.
- Read `hack/util.sh` to confirm `util::check_clusters_ready` and everything
  it calls (`util::wait_file_exist`, `util::wait_for_condition`,
  `util::get_docker_native_ipaddress`, `util::get_docker_host_ip_port`,
  `util::is_wsl2`) exist with matching signatures, and that the call
  arguments (`kubeconfig_path`, `context_name`) match the four existing call
  sites in `hack/setup-dev-base.sh`.
- Confirmed no double context-rename: the old manual `rename-context` call
  was removed, since `util::check_clusters_ready` performs it internally.
- Confirmed `hack/create-cluster.sh` is not invoked by any `.github/workflows`
  CI job (`grep -rn create-cluster .github/workflows/` returns nothing), so
  this change cannot regress existing CI. `setup-dev-base.sh`, which already
  relies on the same `util::check_clusters_ready` function for all of its kind
  clusters, IS exercised by `.github/workflows/ci.yml`'s e2e job.
- I do not have `docker`/`kind` available in this environment, so I could not
  run `hack/create-cluster.sh` end-to-end (on any OS) to reproduce the
  original macOS failure or confirm the fix live. The fix reuses an
  already-shipped, already-CI-exercised OS-detection code path verbatim
  rather than introducing new logic, which is why I'm confident in it despite
  not being able to run it here.

**Does this PR introduce a user-facing change?**:

```release-note
`hack/create-cluster.sh`: Fixed cluster creation writing an unreachable kubeconfig server address on macOS/WSL2 (Docker Desktop), which caused `no route to host` errors for host-side `kubectl`/`karmadactl` commands.
```

Fixes #6346