### PR TITLE
feat: plan component replica scale estimation

### DIFF
--- a/pkg/scheduler/core/estimation.go
+++ b/pkg/scheduler/core/estimation.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/klog/v2"
 
@@ -75,9 +76,97 @@ type multiTemplateEstimationContext struct {
 // calculateMultiTemplateAvailableSets calculates available sets for multi-template scheduling.
 // It uses MaxAvailableComponentSets to estimate capacity for workloads with multiple pod templates.
 func calculateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTemplateEstimationContext) ([]workv1alpha2.TargetCluster, error) {
+	return estimateMultiTemplateAvailableSets(ctx, estCtx, estCtx.clusters, estCtx.spec.Components)
+}
+
+// calculateMultiTemplateAvailableSetsForScale plans capacity for a component replica scale.
+// Callers must ensure that only replica counts changed: component requirements and placement
+// must be unchanged, and failure-safe result retention must already be in place.
+func calculateMultiTemplateAvailableSetsForScale(ctx context.Context, estCtx multiTemplateEstimationContext) ([]workv1alpha2.TargetCluster, error) {
+	plans, err := buildComponentScalePlans(estCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]workv1alpha2.TargetCluster, 0, len(estCtx.clusters))
+	fullDesiredClusters := make([]*clusterv1alpha1.Cluster, 0, len(estCtx.clusters))
+	for i := range plans {
+		switch plans[i].direction {
+		case componentScaleNewCandidate:
+			fullDesiredClusters = append(fullDesiredClusters, plans[i].cluster)
+		case componentScaleDown:
+			result = append(result, workv1alpha2.TargetCluster{
+				Name:     plans[i].cluster.Name,
+				Replicas: scaleDownAvailableComponentSets,
+			})
+		case componentScaleUp:
+			delta := positiveComponentDelta(estCtx.spec.Components, plans[i].accepted)
+			estimated, err := estimateMultiTemplateAvailableSets(ctx, estCtx, []*clusterv1alpha1.Cluster{plans[i].cluster}, delta)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, estimated...)
+		}
+	}
+
+	if len(fullDesiredClusters) > 0 {
+		estimated, err := estimateMultiTemplateAvailableSets(ctx, estCtx, fullDesiredClusters, estCtx.spec.Components)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, estimated...)
+	}
+
+	resultByCluster := make(map[string]workv1alpha2.TargetCluster, len(result))
+	for i := range result {
+		resultByCluster[result[i].Name] = result[i]
+	}
+	ordered := make([]workv1alpha2.TargetCluster, 0, len(result))
+	for _, cluster := range estCtx.clusters {
+		if clusterResult, exists := resultByCluster[cluster.Name]; exists {
+			ordered = append(ordered, clusterResult)
+		}
+	}
+	return ordered, nil
+}
+
+type componentScalePlan struct {
+	cluster   *clusterv1alpha1.Cluster
+	direction componentScaleDirection
+	accepted  []workv1alpha2.TargetComponent
+}
+
+func buildComponentScalePlans(estCtx multiTemplateEstimationContext) ([]componentScalePlan, error) {
+	if !componentNamesAreValidAndUnique(estCtx.spec.Components) {
+		return nil, fmt.Errorf("component scale planning requires desired components to have unique, non-empty names")
+	}
+
+	plans := make([]componentScalePlan, 0, len(estCtx.clusters))
+	for _, cluster := range estCtx.clusters {
+		accepted, found := acceptedComponentsForCluster(estCtx.spec.Clusters, cluster.Name)
+		if !found {
+			plans = append(plans, componentScalePlan{cluster: cluster, direction: componentScaleNewCandidate})
+			continue
+		}
+
+		direction := componentReplicaScaleDirection(estCtx.spec.Components, accepted)
+		switch direction {
+		case componentScaleUnknown:
+			return nil, fmt.Errorf("component scale planning for cluster %q requires a comparable accepted component snapshot", cluster.Name)
+		case componentScaleEqual:
+			return nil, fmt.Errorf("component scale planning for cluster %q requires a replica change", cluster.Name)
+		case componentScaleMixed:
+			return nil, fmt.Errorf("mixed component scaling is not supported for cluster %q", cluster.Name)
+		}
+		plans = append(plans, componentScalePlan{cluster: cluster, direction: direction, accepted: accepted})
+	}
+	return plans, nil
+}
+
+func estimateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTemplateEstimationContext, clusters []*clusterv1alpha1.Cluster, components []workv1alpha2.Component) ([]workv1alpha2.TargetCluster, error) {
 	req := estimatorclient.ComponentSetEstimationRequest{
-		Clusters:         estCtx.clusters,
-		Components:       estCtx.spec.Components,
+		Clusters:         clusters,
+		Components:       components,
 		Namespace:        estCtx.spec.Resource.Namespace,
 		AssumedWorkloads: estCtx.assumedWorkloads,
 	}
@@ -99,8 +188,8 @@ func calculateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTempla
 		resMap[resp[i].Name] = resp[i].Sets
 	}
 
-	result := make([]workv1alpha2.TargetCluster, 0, len(estCtx.clusters))
-	for _, cluster := range estCtx.clusters {
+	result := make([]workv1alpha2.TargetCluster, 0, len(clusters))
+	for _, cluster := range clusters {
 		sets, ok := resMap[cluster.Name]
 		if !ok {
 			klog.Warningf("The estimator(%s) missed estimation from cluster(%s) when estimating for workload(%s, kind=%s, %s).",
@@ -110,6 +199,104 @@ func calculateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTempla
 		result = append(result, workv1alpha2.TargetCluster{Name: cluster.Name, Replicas: sets})
 	}
 	return result, nil
+}
+
+func acceptedComponentsForCluster(clusters []workv1alpha2.TargetCluster, name string) ([]workv1alpha2.TargetComponent, bool) {
+	for i := range clusters {
+		if clusters[i].Name == name {
+			return clusters[i].Components, true
+		}
+	}
+	return nil, false
+}
+
+func positiveComponentDelta(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) []workv1alpha2.Component {
+	acceptedReplicas := make(map[string]int32, len(accepted))
+	for i := range accepted {
+		acceptedReplicas[accepted[i].Name] = accepted[i].Replicas
+	}
+
+	delta := make([]workv1alpha2.Component, 0, len(desired))
+	for i := range desired {
+		replicas := desired[i].Replicas - acceptedReplicas[desired[i].Name]
+		if replicas <= 0 {
+			continue
+		}
+		component := desired[i]
+		component.Replicas = replicas
+		delta = append(delta, component)
+	}
+	return delta
+}
+
+type componentScaleDirection int
+
+const (
+	componentScaleUnknown componentScaleDirection = iota
+	componentScaleNewCandidate
+	componentScaleEqual
+	componentScaleUp
+	componentScaleDown
+	componentScaleMixed
+)
+
+// A scale-down requires no additional capacity. One available set keeps the
+// current target eligible; AssignReplicas constructs the final assignment.
+const scaleDownAvailableComponentSets int32 = 1
+
+func componentReplicaScaleDirection(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) componentScaleDirection {
+	if len(desired) != len(accepted) || !componentNamesAreValidAndUnique(desired) {
+		return componentScaleUnknown
+	}
+
+	acceptedReplicas := make(map[string]int32, len(accepted))
+	for i := range accepted {
+		if _, exists := acceptedReplicas[accepted[i].Name]; exists {
+			return componentScaleUnknown
+		}
+		acceptedReplicas[accepted[i].Name] = accepted[i].Replicas
+	}
+	var scaleUp, scaleDown bool
+	for i := range desired {
+		replicas, exists := acceptedReplicas[desired[i].Name]
+		if !exists {
+			return componentScaleUnknown
+		}
+		switch {
+		case desired[i].Replicas > replicas:
+			scaleUp = true
+		case desired[i].Replicas < replicas:
+			scaleDown = true
+		}
+	}
+	switch {
+	case scaleUp && scaleDown:
+		return componentScaleMixed
+	case scaleUp:
+		return componentScaleUp
+	case scaleDown:
+		return componentScaleDown
+	default:
+		return componentScaleEqual
+	}
+}
+
+func componentNamesAreValidAndUnique(components []workv1alpha2.Component) bool {
+	if len(components) == 0 {
+		return false
+	}
+
+	names := make(map[string]struct{}, len(components))
+	for i := range components {
+		if components[i].Name == "" {
+			return false
+		}
+		if _, exists := names[components[i].Name]; exists {
+			return false
+		}
+		names[components[i].Name] = struct{}{}
+	}
+	return true
 }
 
 // buildAssumedWorkloadsByCluster builds a map of assumed workloads for each cluster based on the assigning cache.

--- a/pkg/scheduler/core/estimation.go
+++ b/pkg/scheduler/core/estimation.go
@@ -79,88 +79,35 @@ func calculateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTempla
 	return estimateMultiTemplateAvailableSets(ctx, estCtx, estCtx.clusters, estCtx.spec.Components)
 }
 
-// calculateMultiTemplateAvailableSetsForScale plans capacity for a component replica scale.
-// Callers must ensure that only replica counts changed: component requirements and placement
-// must be unchanged, and failure-safe result retention must already be in place.
+// calculateMultiTemplateAvailableSetsForScale calculates capacity for a component replica
+// scale on the current accepted target. It does not define result retention on failure.
 func calculateMultiTemplateAvailableSetsForScale(ctx context.Context, estCtx multiTemplateEstimationContext) ([]workv1alpha2.TargetCluster, error) {
-	plans, err := buildComponentScalePlans(estCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	result := make([]workv1alpha2.TargetCluster, 0, len(estCtx.clusters))
-	fullDesiredClusters := make([]*clusterv1alpha1.Cluster, 0, len(estCtx.clusters))
-	for i := range plans {
-		switch plans[i].direction {
-		case componentScaleNewCandidate:
-			fullDesiredClusters = append(fullDesiredClusters, plans[i].cluster)
-		case componentScaleDown:
-			result = append(result, workv1alpha2.TargetCluster{
-				Name:     plans[i].cluster.Name,
-				Replicas: scaleDownAvailableComponentSets,
-			})
-		case componentScaleUp:
-			delta := positiveComponentDelta(estCtx.spec.Components, plans[i].accepted)
-			estimated, err := estimateMultiTemplateAvailableSets(ctx, estCtx, []*clusterv1alpha1.Cluster{plans[i].cluster}, delta)
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, estimated...)
-		}
-	}
-
-	if len(fullDesiredClusters) > 0 {
-		estimated, err := estimateMultiTemplateAvailableSets(ctx, estCtx, fullDesiredClusters, estCtx.spec.Components)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, estimated...)
-	}
-
-	resultByCluster := make(map[string]workv1alpha2.TargetCluster, len(result))
-	for i := range result {
-		resultByCluster[result[i].Name] = result[i]
-	}
-	ordered := make([]workv1alpha2.TargetCluster, 0, len(result))
-	for _, cluster := range estCtx.clusters {
-		if clusterResult, exists := resultByCluster[cluster.Name]; exists {
-			ordered = append(ordered, clusterResult)
-		}
-	}
-	return ordered, nil
-}
-
-type componentScalePlan struct {
-	cluster   *clusterv1alpha1.Cluster
-	direction componentScaleDirection
-	accepted  []workv1alpha2.TargetComponent
-}
-
-func buildComponentScalePlans(estCtx multiTemplateEstimationContext) ([]componentScalePlan, error) {
 	if !componentNamesAreValidAndUnique(estCtx.spec.Components) {
 		return nil, fmt.Errorf("component scale planning requires desired components to have unique, non-empty names")
 	}
-
-	plans := make([]componentScalePlan, 0, len(estCtx.clusters))
-	for _, cluster := range estCtx.clusters {
-		accepted, found := acceptedComponentsForCluster(estCtx.spec.Clusters, cluster.Name)
-		if !found {
-			plans = append(plans, componentScalePlan{cluster: cluster, direction: componentScaleNewCandidate})
-			continue
-		}
-
-		direction := componentReplicaScaleDirection(estCtx.spec.Components, accepted)
-		switch direction {
-		case componentScaleUnknown:
-			return nil, fmt.Errorf("component scale planning for cluster %q requires a comparable accepted component snapshot", cluster.Name)
-		case componentScaleEqual:
-			return nil, fmt.Errorf("component scale planning for cluster %q requires a replica change", cluster.Name)
-		case componentScaleMixed:
-			return nil, fmt.Errorf("mixed component scaling is not supported for cluster %q", cluster.Name)
-		}
-		plans = append(plans, componentScalePlan{cluster: cluster, direction: direction, accepted: accepted})
+	if len(estCtx.clusters) != 1 || len(estCtx.spec.Clusters) != 1 ||
+		estCtx.clusters[0].Name != estCtx.spec.Clusters[0].Name {
+		return nil, fmt.Errorf("component scale planning requires exactly one accepted target cluster")
 	}
-	return plans, nil
+
+	cluster := estCtx.clusters[0]
+	accepted := estCtx.spec.Clusters[0].Components
+	direction := componentReplicaScaleDirection(estCtx.spec.Components, accepted)
+	switch direction {
+	case componentScaleUnknown:
+		return nil, fmt.Errorf("component scale planning for cluster %q requires a comparable accepted component snapshot", cluster.Name)
+	case componentScaleEqual:
+		return nil, fmt.Errorf("component scale planning for cluster %q requires a replica change", cluster.Name)
+	case componentScaleMixed:
+		return nil, fmt.Errorf("mixed component scaling is not supported for cluster %q", cluster.Name)
+	case componentScaleDown:
+		return []workv1alpha2.TargetCluster{{Name: cluster.Name, Replicas: minimumAvailableComponentSets}}, nil
+	case componentScaleUp:
+		delta := positiveComponentDelta(estCtx.spec.Components, accepted)
+		return estimateMultiTemplateAvailableSets(ctx, estCtx, estCtx.clusters, delta)
+	default:
+		return nil, fmt.Errorf("component scale planning for cluster %q has an unsupported transition", cluster.Name)
+	}
 }
 
 func estimateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTemplateEstimationContext, clusters []*clusterv1alpha1.Cluster, components []workv1alpha2.Component) ([]workv1alpha2.TargetCluster, error) {
@@ -201,15 +148,6 @@ func estimateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTemplat
 	return result, nil
 }
 
-func acceptedComponentsForCluster(clusters []workv1alpha2.TargetCluster, name string) ([]workv1alpha2.TargetComponent, bool) {
-	for i := range clusters {
-		if clusters[i].Name == name {
-			return clusters[i].Components, true
-		}
-	}
-	return nil, false
-}
-
 func positiveComponentDelta(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) []workv1alpha2.Component {
 	acceptedReplicas := make(map[string]int32, len(accepted))
 	for i := range accepted {
@@ -233,16 +171,15 @@ type componentScaleDirection int
 
 const (
 	componentScaleUnknown componentScaleDirection = iota
-	componentScaleNewCandidate
 	componentScaleEqual
 	componentScaleUp
 	componentScaleDown
 	componentScaleMixed
 )
 
-// A scale-down requires no additional capacity. One available set keeps the
-// current target eligible; AssignReplicas constructs the final assignment.
-const scaleDownAvailableComponentSets int32 = 1
+// minimumAvailableComponentSets is capacity evidence that one atomic component
+// set can use the current target. AssignReplicas constructs the final assignment.
+const minimumAvailableComponentSets int32 = 1
 
 func componentReplicaScaleDirection(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) componentScaleDirection {
 	if len(desired) != len(accepted) || !componentNamesAreValidAndUnique(desired) {

--- a/pkg/scheduler/core/estimation_test.go
+++ b/pkg/scheduler/core/estimation_test.go
@@ -423,6 +423,7 @@ func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
 		wantResult     []workv1alpha2.TargetCluster
 		wantError      string
 		wantCalls      int
+		estimatorError error
 	}{
 		{
 			name: "scale up estimates only the positive delta",
@@ -431,7 +432,7 @@ func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
 					{Name: "jobmanager", Replicas: 1},
 					{Name: "taskmanager", Replicas: 6, ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{PriorityClassName: "high-priority"}},
 				},
-				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+				[]workv1alpha2.TargetComponent{{Name: "taskmanager", Replicas: 4}, {Name: "jobmanager", Replicas: 1}},
 			),
 			wantComponents: []workv1alpha2.Component{{
 				Name:                "taskmanager",
@@ -447,7 +448,28 @@ func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
 				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 2}},
 				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
 			),
-			wantResult: []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: scaleDownAvailableComponentSets}},
+			wantResult: []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: minimumAvailableComponentSets}},
+		},
+		{
+			name: "all components scale up by their positive delta",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 2}, {Name: "taskmanager", Replicas: 6}},
+				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			),
+			wantComponents: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 2}},
+			wantResult:     []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: 1}},
+			wantCalls:      1,
+		},
+		{
+			name: "scale up returns estimator error",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			),
+			wantComponents: []workv1alpha2.Component{{Name: "taskmanager", Replicas: 2}},
+			wantError:      "estimator failed",
+			wantCalls:      1,
+			estimatorError: errors.New("estimator failed"),
 		},
 		{
 			name: "existing target without accepted snapshot is unknown",
@@ -502,6 +524,17 @@ func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
 			spec:      newSpec(nil, nil),
 			wantError: "unique, non-empty names",
 		},
+		{
+			name: "candidate without accepted result is rejected",
+			spec: &workv1alpha2.ResourceBindingSpec{
+				Resource:   workv1alpha2.ObjectReference{Namespace: "default", Name: "flink"},
+				Components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+				Clusters: []workv1alpha2.TargetCluster{{Name: "cluster2", Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4},
+				}}},
+			},
+			wantError: "requires exactly one accepted target cluster",
+		},
 	}
 
 	for _, tt := range tests {
@@ -510,6 +543,9 @@ func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
 			estimator.maxAvailableComponentSetsFunc = func(req estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
 				assert.Equal(t, clusters, req.Clusters)
 				assert.Equal(t, tt.wantComponents, req.Components)
+				if tt.estimatorError != nil {
+					return nil, tt.estimatorError
+				}
 				return []estimatorclient.ComponentSetEstimationResponse{{Name: "cluster1", Sets: 1}}, nil
 			}
 
@@ -532,47 +568,8 @@ func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
 	}
 }
 
-func Test_calculateMultiTemplateAvailableSetsForScaleUsesFullDesiredOnlyForNewCandidates(t *testing.T) {
-	desired := []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 5}}
-	clusters := []*clusterv1alpha1.Cluster{helper.NewCluster("cluster1"), helper.NewCluster("cluster2")}
-	estimator := &mockReplicaEstimator{}
-	estimator.maxAvailableComponentSetsFunc = func(req estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
-		switch req.Clusters[0].Name {
-		case "cluster2":
-			assert.Equal(t, []*clusterv1alpha1.Cluster{clusters[1]}, req.Clusters)
-			assert.Equal(t, []workv1alpha2.Component{{Name: "taskmanager", Replicas: 2}}, req.Components)
-		case "cluster1":
-			assert.Equal(t, []*clusterv1alpha1.Cluster{clusters[0]}, req.Clusters)
-			assert.Equal(t, desired, req.Components)
-		default:
-			t.Fatalf("unexpected cluster request: %s", req.Clusters[0].Name)
-		}
-		return []estimatorclient.ComponentSetEstimationResponse{{Name: req.Clusters[0].Name, Sets: 1}}, nil
-	}
-	spec := &workv1alpha2.ResourceBindingSpec{
-		Resource:   workv1alpha2.ObjectReference{Namespace: "default", Name: "flink"},
-		Components: desired,
-		Clusters: []workv1alpha2.TargetCluster{{
-			Name: "cluster2",
-			Components: []workv1alpha2.TargetComponent{
-				{Name: "jobmanager", Replicas: 1},
-				{Name: "taskmanager", Replicas: 3},
-			},
-		}},
-	}
-
-	got, err := calculateMultiTemplateAvailableSetsForScale(context.Background(), multiTemplateEstimationContext{
-		estimator: estimator,
-		clusters:  clusters,
-		spec:      spec,
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: 1}, {Name: "cluster2", Replicas: 1}}, got)
-	assert.Len(t, estimator.componentSetRequests, 2)
-}
-
 func Test_calculateMultiTemplateAvailableSetsForScaleRejectsBeforeCallingEstimator(t *testing.T) {
-	clusters := []*clusterv1alpha1.Cluster{helper.NewCluster("cluster1"), helper.NewCluster("cluster2")}
+	clusters := []*clusterv1alpha1.Cluster{helper.NewCluster("cluster1")}
 	estimator := &mockReplicaEstimator{}
 	estimator.maxAvailableComponentSetsFunc = func(estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
 		t.Fatal("estimator must not be called before every transition is classified")
@@ -584,22 +581,13 @@ func Test_calculateMultiTemplateAvailableSetsForScaleRejectsBeforeCallingEstimat
 			{Name: "jobmanager", Replicas: 1},
 			{Name: "taskmanager", Replicas: 6},
 		},
-		Clusters: []workv1alpha2.TargetCluster{
-			{
-				Name: "cluster1",
-				Components: []workv1alpha2.TargetComponent{
-					{Name: "jobmanager", Replicas: 1},
-					{Name: "taskmanager", Replicas: 4},
-				},
+		Clusters: []workv1alpha2.TargetCluster{{
+			Name: "cluster1",
+			Components: []workv1alpha2.TargetComponent{
+				{Name: "jobmanager", Replicas: 2},
+				{Name: "taskmanager", Replicas: 4},
 			},
-			{
-				Name: "cluster2",
-				Components: []workv1alpha2.TargetComponent{
-					{Name: "jobmanager", Replicas: 2},
-					{Name: "taskmanager", Replicas: 4},
-				},
-			},
-		},
+		}},
 	}
 
 	got, err := calculateMultiTemplateAvailableSetsForScale(context.Background(), multiTemplateEstimationContext{

--- a/pkg/scheduler/core/estimation_test.go
+++ b/pkg/scheduler/core/estimation_test.go
@@ -35,7 +35,8 @@ import (
 type mockReplicaEstimator struct {
 	maxAvailableComponentSetsResponse []estimatorclient.ComponentSetEstimationResponse
 	maxAvailableComponentSetsError    error
-	lastComponentSetRequest           estimatorclient.ComponentSetEstimationRequest
+	componentSetRequests              []estimatorclient.ComponentSetEstimationRequest
+	maxAvailableComponentSetsFunc     func(estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error)
 }
 
 func (m *mockReplicaEstimator) MaxAvailableReplicas(_ context.Context, _ estimatorclient.ReplicaEstimationRequest) ([]workv1alpha2.TargetCluster, error) {
@@ -43,7 +44,10 @@ func (m *mockReplicaEstimator) MaxAvailableReplicas(_ context.Context, _ estimat
 }
 
 func (m *mockReplicaEstimator) MaxAvailableComponentSets(_ context.Context, req estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
-	m.lastComponentSetRequest = req
+	m.componentSetRequests = append(m.componentSetRequests, req)
+	if m.maxAvailableComponentSetsFunc != nil {
+		return m.maxAvailableComponentSetsFunc(req)
+	}
 	return m.maxAvailableComponentSetsResponse, m.maxAvailableComponentSetsError
 }
 
@@ -327,6 +331,287 @@ func Test_calculateMultiTemplateAvailableSets(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+func Test_componentReplicaScaleDirection(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  []workv1alpha2.Component
+		accepted []workv1alpha2.TargetComponent
+		want     componentScaleDirection
+	}{
+		{
+			name:     "equal snapshots ignore order",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "taskmanager", Replicas: 4}, {Name: "jobmanager", Replicas: 1}},
+			want:     componentScaleEqual,
+		},
+		{
+			name:     "pure scale up",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			want:     componentScaleUp,
+		},
+		{
+			name:     "pure scale down",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 2}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			want:     componentScaleDown,
+		},
+		{
+			name:     "mixed scale",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 2}, {Name: "taskmanager", Replicas: 4}},
+			want:     componentScaleMixed,
+		},
+		{
+			name:    "missing accepted snapshot",
+			desired: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}},
+			want:    componentScaleUnknown,
+		},
+		{
+			name:     "component names differ",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "historyserver", Replicas: 4}},
+			want:     componentScaleUnknown,
+		},
+		{
+			name:     "accepted names are duplicated",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "jobmanager", Replicas: 4}},
+			want:     componentScaleUnknown,
+		},
+		{
+			name:     "desired names are duplicated",
+			desired:  []workv1alpha2.Component{{Name: "worker", Replicas: 2}, {Name: "worker", Replicas: 3}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "worker", Replicas: 2}, {Name: "server", Replicas: 1}},
+			want:     componentScaleUnknown,
+		},
+		{
+			name:     "desired name is empty",
+			desired:  []workv1alpha2.Component{{Name: "", Replicas: 1}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "", Replicas: 1}},
+			want:     componentScaleUnknown,
+		},
+		{
+			name: "empty snapshots",
+			want: componentScaleUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, componentReplicaScaleDirection(tt.desired, tt.accepted))
+		})
+	}
+}
+
+func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
+	clusters := []*clusterv1alpha1.Cluster{helper.NewCluster("cluster1")}
+	newSpec := func(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) *workv1alpha2.ResourceBindingSpec {
+		return &workv1alpha2.ResourceBindingSpec{
+			Resource:   workv1alpha2.ObjectReference{Namespace: "default", Name: "flink"},
+			Components: desired,
+			Clusters:   []workv1alpha2.TargetCluster{{Name: "cluster1", Components: accepted}},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		spec           *workv1alpha2.ResourceBindingSpec
+		wantComponents []workv1alpha2.Component
+		wantResult     []workv1alpha2.TargetCluster
+		wantError      string
+		wantCalls      int
+	}{
+		{
+			name: "scale up estimates only the positive delta",
+			spec: newSpec(
+				[]workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6, ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{PriorityClassName: "high-priority"}},
+				},
+				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			),
+			wantComponents: []workv1alpha2.Component{{
+				Name:                "taskmanager",
+				Replicas:            2,
+				ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{PriorityClassName: "high-priority"},
+			}},
+			wantResult: []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: 1}},
+			wantCalls:  1,
+		},
+		{
+			name: "pure scale down skips estimation",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 2}},
+				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			),
+			wantResult: []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: scaleDownAvailableComponentSets}},
+		},
+		{
+			name: "existing target without accepted snapshot is unknown",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+				nil,
+			),
+			wantError: "requires a comparable accepted component snapshot",
+		},
+		{
+			name: "equal state is not a scale operation",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+				[]workv1alpha2.TargetComponent{{Name: "taskmanager", Replicas: 4}, {Name: "jobmanager", Replicas: 1}},
+			),
+			wantError: "requires a replica change",
+		},
+		{
+			name: "mixed scale is unsupported",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 2}, {Name: "taskmanager", Replicas: 4}},
+			),
+			wantError: "mixed component scaling is not supported",
+		},
+		{
+			name: "duplicate desired names are rejected",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "worker", Replicas: 2}, {Name: "worker", Replicas: 3}},
+				[]workv1alpha2.TargetComponent{{Name: "worker", Replicas: 2}, {Name: "server", Replicas: 1}},
+			),
+			wantError: "unique, non-empty names",
+		},
+		{
+			name: "empty desired name is rejected",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "", Replicas: 2}},
+				[]workv1alpha2.TargetComponent{{Name: "", Replicas: 1}},
+			),
+			wantError: "unique, non-empty names",
+		},
+		{
+			name: "partial accepted snapshot is unknown",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}},
+			),
+			wantError: "requires a comparable accepted component snapshot",
+		},
+		{
+			name:      "empty desired snapshot is rejected",
+			spec:      newSpec(nil, nil),
+			wantError: "unique, non-empty names",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			estimator := &mockReplicaEstimator{}
+			estimator.maxAvailableComponentSetsFunc = func(req estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
+				assert.Equal(t, clusters, req.Clusters)
+				assert.Equal(t, tt.wantComponents, req.Components)
+				return []estimatorclient.ComponentSetEstimationResponse{{Name: "cluster1", Sets: 1}}, nil
+			}
+
+			got, err := calculateMultiTemplateAvailableSetsForScale(context.Background(), multiTemplateEstimationContext{
+				estimator: estimator,
+				clusters:  clusters,
+				spec:      tt.spec,
+			})
+			if tt.wantError != "" {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.wantError)
+				}
+				assert.Nil(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantResult, got)
+			}
+			assert.Len(t, estimator.componentSetRequests, tt.wantCalls)
+		})
+	}
+}
+
+func Test_calculateMultiTemplateAvailableSetsForScaleUsesFullDesiredOnlyForNewCandidates(t *testing.T) {
+	desired := []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 5}}
+	clusters := []*clusterv1alpha1.Cluster{helper.NewCluster("cluster1"), helper.NewCluster("cluster2")}
+	estimator := &mockReplicaEstimator{}
+	estimator.maxAvailableComponentSetsFunc = func(req estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
+		switch req.Clusters[0].Name {
+		case "cluster2":
+			assert.Equal(t, []*clusterv1alpha1.Cluster{clusters[1]}, req.Clusters)
+			assert.Equal(t, []workv1alpha2.Component{{Name: "taskmanager", Replicas: 2}}, req.Components)
+		case "cluster1":
+			assert.Equal(t, []*clusterv1alpha1.Cluster{clusters[0]}, req.Clusters)
+			assert.Equal(t, desired, req.Components)
+		default:
+			t.Fatalf("unexpected cluster request: %s", req.Clusters[0].Name)
+		}
+		return []estimatorclient.ComponentSetEstimationResponse{{Name: req.Clusters[0].Name, Sets: 1}}, nil
+	}
+	spec := &workv1alpha2.ResourceBindingSpec{
+		Resource:   workv1alpha2.ObjectReference{Namespace: "default", Name: "flink"},
+		Components: desired,
+		Clusters: []workv1alpha2.TargetCluster{{
+			Name: "cluster2",
+			Components: []workv1alpha2.TargetComponent{
+				{Name: "jobmanager", Replicas: 1},
+				{Name: "taskmanager", Replicas: 3},
+			},
+		}},
+	}
+
+	got, err := calculateMultiTemplateAvailableSetsForScale(context.Background(), multiTemplateEstimationContext{
+		estimator: estimator,
+		clusters:  clusters,
+		spec:      spec,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: 1}, {Name: "cluster2", Replicas: 1}}, got)
+	assert.Len(t, estimator.componentSetRequests, 2)
+}
+
+func Test_calculateMultiTemplateAvailableSetsForScaleRejectsBeforeCallingEstimator(t *testing.T) {
+	clusters := []*clusterv1alpha1.Cluster{helper.NewCluster("cluster1"), helper.NewCluster("cluster2")}
+	estimator := &mockReplicaEstimator{}
+	estimator.maxAvailableComponentSetsFunc = func(estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
+		t.Fatal("estimator must not be called before every transition is classified")
+		return nil, nil
+	}
+	spec := &workv1alpha2.ResourceBindingSpec{
+		Resource: workv1alpha2.ObjectReference{Namespace: "default", Name: "flink"},
+		Components: []workv1alpha2.Component{
+			{Name: "jobmanager", Replicas: 1},
+			{Name: "taskmanager", Replicas: 6},
+		},
+		Clusters: []workv1alpha2.TargetCluster{
+			{
+				Name: "cluster1",
+				Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+				},
+			},
+			{
+				Name: "cluster2",
+				Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 2},
+					{Name: "taskmanager", Replicas: 4},
+				},
+			},
+		},
+	}
+
+	got, err := calculateMultiTemplateAvailableSetsForScale(context.Background(), multiTemplateEstimationContext{
+		estimator: estimator,
+		clusters:  clusters,
+		spec:      spec,
+	})
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "mixed component scaling is not supported")
+	}
+	assert.Nil(t, got)
+	assert.Empty(t, estimator.componentSetRequests)
 }
 
 func Test_buildAssumedWorkloadsByCluster(t *testing.T) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -263,7 +263,13 @@ func TestDoScheduleBinding(t *testing.T) {
 		{
 			name: "binding with component replicas changed",
 			binding: &workv1alpha2.ResourceBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-binding-components", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-binding-components",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.PolicyPlacementAnnotation: `{"replicaScheduling":{"replicaSchedulingType":"Divided"}}`,
+					},
+				},
 				Spec: workv1alpha2.ResourceBindingSpec{
 					Components: []workv1alpha2.Component{
 						{Name: "jobmanager", Replicas: 1},
@@ -423,7 +429,12 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 		{
 			name: "cluster binding with component replicas changed",
 			binding: &workv1alpha2.ClusterResourceBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-binding-components"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-binding-components",
+					Annotations: map[string]string{
+						util.PolicyPlacementAnnotation: `{"replicaScheduling":{"replicaSchedulingType":"Divided"}}`,
+					},
+				},
 				Spec: workv1alpha2.ResourceBindingSpec{
 					Components: []workv1alpha2.Component{
 						{Name: "jobmanager", Replicas: 1},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -186,6 +186,7 @@ func TestDoScheduleBinding(t *testing.T) {
 		expectError      bool
 		expectedClusters []workv1alpha2.TargetCluster
 		expectedEvent    string
+		enableComponents bool
 	}{
 		{
 			name: "binding with changed placement",
@@ -259,10 +260,43 @@ func TestDoScheduleBinding(t *testing.T) {
 			},
 			expectedEvent: "Normal ScheduleBindingSucceed",
 		},
+		{
+			name: "binding with component replicas changed",
+			binding: &workv1alpha2.ResourceBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-binding-components", Namespace: "default"},
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Components: []workv1alpha2.Component{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 6},
+					},
+					Clusters: []workv1alpha2.TargetCluster{{
+						Name: "cluster1",
+						Components: []workv1alpha2.TargetComponent{
+							{Name: "jobmanager", Replicas: 1},
+							{Name: "taskmanager", Replicas: 4},
+						},
+					}},
+					Placement: &policyv1alpha1.Placement{ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+						ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided,
+					}},
+				},
+			},
+			expectSchedule: true,
+			expectedClusters: []workv1alpha2.TargetCluster{{
+				Name: "cluster1",
+				Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6},
+				},
+			}},
+			expectedEvent:    "Normal ScheduleBindingSucceed",
+			enableComponents: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer setFeatureGateDuringTest(t, features.FeatureGate, features.MultiplePodTemplatesScheduling, tt.enableComponents)()
 			fakeClient := karmadafake.NewClientset(tt.binding)
 			fakeRecorder := record.NewFakeRecorder(10)
 			mockAlgorithm := &mockAlgorithm{
@@ -315,6 +349,7 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 		expectError      bool
 		expectedClusters []workv1alpha2.TargetCluster
 		expectedEvent    string
+		enableComponents bool
 	}{
 		{
 			name: "cluster binding with changed placement",
@@ -385,10 +420,43 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 			},
 			expectedEvent: "Normal ScheduleBindingSucceed",
 		},
+		{
+			name: "cluster binding with component replicas changed",
+			binding: &workv1alpha2.ClusterResourceBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-binding-components"},
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Components: []workv1alpha2.Component{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 6},
+					},
+					Clusters: []workv1alpha2.TargetCluster{{
+						Name: "cluster1",
+						Components: []workv1alpha2.TargetComponent{
+							{Name: "jobmanager", Replicas: 1},
+							{Name: "taskmanager", Replicas: 4},
+						},
+					}},
+					Placement: &policyv1alpha1.Placement{ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+						ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided,
+					}},
+				},
+			},
+			expectSchedule: true,
+			expectedClusters: []workv1alpha2.TargetCluster{{
+				Name: "cluster1",
+				Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6},
+				},
+			}},
+			expectedEvent:    "Normal ScheduleBindingSucceed",
+			enableComponents: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer setFeatureGateDuringTest(t, features.FeatureGate, features.MultiplePodTemplatesScheduling, tt.enableComponents)()
 			fakeClient := karmadafake.NewClientset(tt.binding)
 			fakeRecorder := record.NewFakeRecorder(10)
 			mockAlgorithm := &mockAlgorithm{

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -34,21 +34,20 @@ func GetBindingClusterNames(spec *workv1alpha2.ResourceBindingSpec) []string {
 	return clusterNames
 }
 
-// IsBindingReplicasChanged will check if the sum of replicas is different from the replicas of object
+// IsBindingReplicasChanged reports whether the desired scalar or per-component replicas differ from the accepted result.
 func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, strategy *policyv1alpha1.ReplicaSchedulingStrategy) bool {
 	if strategy == nil {
 		return false
 	}
 
-	// For component-based workloads, trigger rescheduling when clusters are empty (e.g., after eviction).
-	// This is a temporary fix to ensure cluster failover works correctly.
-	// Limitation: This only handles the failover scenario where clusters are cleared.
-	// It does not detect component replica changes (e.g., scale up/down) or replica swaps between components.
-	// A complete solution requires changing how scheduling results are stored to support multi-template workloads,
-	// likely by extending TargetCluster to include per-component replica information.
-	// The comprehensive solution is tracked by: https://github.com/karmada-io/karmada/issues/6998
+	// Component-based workloads also need rescheduling after eviction. For multi-component workloads,
+	// compare the desired replicas with the component snapshot accepted by the scheduler.
 	if features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) && len(bindingSpec.Components) > 0 {
 		if len(bindingSpec.Clusters) == 0 {
+			return true
+		}
+		if len(bindingSpec.Components) > 1 && len(bindingSpec.Clusters) == 1 &&
+			isComponentReplicasChanged(bindingSpec.Components, bindingSpec.Clusters[0].Components) {
 			return true
 		}
 	}
@@ -66,6 +65,44 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, str
 		return replicasSum != bindingSpec.Replicas
 	}
 	return false
+}
+
+func isComponentReplicasChanged(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) bool {
+	if len(accepted) == 0 || len(desired) != len(accepted) {
+		return false
+	}
+
+	acceptedReplicas := make(map[string]int32, len(accepted))
+	for i := range accepted {
+		if accepted[i].Name == "" {
+			return false
+		}
+		if _, exists := acceptedReplicas[accepted[i].Name]; exists {
+			return false
+		}
+		acceptedReplicas[accepted[i].Name] = accepted[i].Replicas
+	}
+
+	seen := make(map[string]struct{}, len(desired))
+	changed := false
+	for i := range desired {
+		if desired[i].Name == "" {
+			return false
+		}
+		if _, exists := seen[desired[i].Name]; exists {
+			return false
+		}
+		seen[desired[i].Name] = struct{}{}
+
+		replicas, exists := acceptedReplicas[desired[i].Name]
+		if !exists {
+			return false
+		}
+		if desired[i].Replicas != replicas {
+			changed = true
+		}
+	}
+	return changed
 }
 
 // GetSumOfReplicas will get the sum of replicas in target clusters

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -46,9 +46,11 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, str
 		if len(bindingSpec.Clusters) == 0 {
 			return true
 		}
-		if len(bindingSpec.Components) > 1 && len(bindingSpec.Clusters) == 1 &&
-			isComponentReplicasChanged(bindingSpec.Components, bindingSpec.Clusters[0].Components) {
-			return true
+		if len(bindingSpec.Components) > 1 && len(bindingSpec.Clusters) == 1 {
+			equal, comparable := ComponentReplicasEqual(bindingSpec.Components, bindingSpec.Clusters[0].Components)
+			if comparable && !equal {
+				return true
+			}
 		}
 	}
 
@@ -67,18 +69,20 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, str
 	return false
 }
 
-func isComponentReplicasChanged(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) bool {
+// ComponentReplicasEqual compares desired component replicas with an accepted snapshot by name.
+// The second return value reports whether both snapshots are complete and comparable.
+func ComponentReplicasEqual(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) (bool, bool) {
 	if len(accepted) == 0 || len(desired) != len(accepted) {
-		return false
+		return false, false
 	}
 
 	acceptedReplicas := make(map[string]int32, len(accepted))
 	for i := range accepted {
 		if accepted[i].Name == "" {
-			return false
+			return false, false
 		}
 		if _, exists := acceptedReplicas[accepted[i].Name]; exists {
-			return false
+			return false, false
 		}
 		acceptedReplicas[accepted[i].Name] = accepted[i].Replicas
 	}
@@ -87,22 +91,22 @@ func isComponentReplicasChanged(desired []workv1alpha2.Component, accepted []wor
 	changed := false
 	for i := range desired {
 		if desired[i].Name == "" {
-			return false
+			return false, false
 		}
 		if _, exists := seen[desired[i].Name]; exists {
-			return false
+			return false, false
 		}
 		seen[desired[i].Name] = struct{}{}
 
 		replicas, exists := acceptedReplicas[desired[i].Name]
 		if !exists {
-			return false
+			return false, false
 		}
 		if desired[i].Replicas != replicas {
 			changed = true
 		}
 	}
-	return changed
+	return !changed, true
 }
 
 // GetSumOfReplicas will get the sum of replicas in target clusters

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -178,6 +178,24 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
 			expected: true,
 		},
+		{
+			name: "component replicas changed with feature gate disabled",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 4},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: false,
+		},
 	}
 
 	// Component-based workload failover tests require the MultiplePodTemplatesScheduling feature gate.
@@ -221,6 +239,90 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 				},
 			},
 			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDuplicated},
+			expected: false,
+		},
+		{
+			name: "multi-component scale up should trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 4},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: true,
+		},
+		{
+			name: "multi-component scale down should trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 6},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: true,
+		},
+		{
+			name: "equal multi-component replicas should not trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "taskmanager", Replicas: 4},
+						{Name: "jobmanager", Replicas: 1},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: false,
+		},
+		{
+			name: "missing accepted component snapshot should not trigger scale rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{Name: ClusterMember1}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: false,
+		},
+		{
+			name: "component name change should not trigger replica scale rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 2},
+					{Name: "worker", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 4},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
 			expected: false,
 		},
 	}

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -357,6 +357,53 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 	}
 }
 
+func TestComponentReplicasEqual(t *testing.T) {
+	tests := []struct {
+		name       string
+		desired    []workv1alpha2.Component
+		accepted   []workv1alpha2.TargetComponent
+		equal      bool
+		comparable bool
+	}{
+		{
+			name:       "equal snapshots ignore order",
+			desired:    []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted:   []workv1alpha2.TargetComponent{{Name: "taskmanager", Replicas: 4}, {Name: "jobmanager", Replicas: 1}},
+			equal:      true,
+			comparable: true,
+		},
+		{
+			name:       "replicas changed",
+			desired:    []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			accepted:   []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			comparable: true,
+		},
+		{
+			name:    "accepted snapshot missing",
+			desired: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}},
+		},
+		{
+			name:     "component names differ",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "worker", Replicas: 4}},
+		},
+		{
+			name:     "accepted names duplicated",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "jobmanager", Replicas: 4}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			equal, comparable := ComponentReplicasEqual(tt.desired, tt.accepted)
+			if equal != tt.equal || comparable != tt.comparable {
+				t.Fatalf("ComponentReplicasEqual() = (%t, %t), want (%t, %t)", equal, comparable, tt.equal, tt.comparable)
+			}
+		})
+	}
+}
+
 func TestGetSumOfReplicas(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind feature

**What this PR does / why we need it**:

Estimating the complete desired component set during multi-template workload rescheduling can double-count replicas already running on the accepted target. This change adds a calculation-only planner based on the accepted `TargetCluster.Components` snapshot.

Pure scale-up sends only each component's positive replica delta to the estimator. Pure scale-down returns internal evidence that the accepted target remains usable without calling the estimator. Mixed directions, equal or incomparable snapshots, missing or partial results, and candidates other than the single accepted target are rejected without falling back to full desired estimation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

Part of #7492

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

- Scope: this PR only defines component-scale estimation. Production routing and failure-safe result retention are added by #7841.
- Review the residual diff as `e3e9d4e9f...e19a318eb`; the preceding commits are the stacked #7830 dependency.
- Tests: `go test -race -count=1 ./pkg/scheduler/core` passed. Full `make test` and live E2E were not run for this calculation-only slice.
- AI assistance: Codex helped inspect the estimation path and draft the implementation and tests; I reviewed the final diff and validation results.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->

```release-note
NONE
```
