### PR TITLE
test(e2e): make the NodeResource estimator assumption e2e test capacity-aware

### DIFF
--- a/test/e2e/suites/base/estimator_test.go
+++ b/test/e2e/suites/base/estimator_test.go
@@ -374,7 +374,7 @@ var _ = framework.SerialDescribe("[EstimatorAssumption] ResourceQuota plugin ass
 		// exceeding the 1000m ResourceQuota. This step verifies that the assumption cache also
 		// protects against over-scheduling of single-template workloads.
 		ginkgo.By("verifying a single-template Deployment requesting 200m CPU is also unschedulable due to assumed workloads", func() {
-			assertSingleTemplateDeploymentUnschedulable(quotaNamespace, targetCluster)
+			assertSingleTemplateDeploymentUnschedulable(quotaNamespace, targetCluster, 200, nil)
 		})
 	})
 })
@@ -423,19 +423,32 @@ var _ = framework.SerialDescribe("[EstimatorAssumption] NodeResource plugin assu
 	})
 
 	ginkgo.It("FlinkDeployment should be unschedulable when assumed workloads exhaust cluster resources", func(ctx context.Context) {
-		// Each FlinkDeployment has jobManager (100m) + taskManager (100m) = 200m total assumed CPU.
-		// We create FlinkDeployments sequentially (each scheduled before the next is created) so the
-		// assumption cache accumulates in-flight CPU on member1. Since no Flink Operator is installed,
-		// no pods are created and no real CPU is consumed, but karmada-scheduler treats these as
-		// assumed workloads. Within maxFlinkCount attempts, at least one must get NoClusterFit,
-		// which proves the assumption feature is working correctly.
+		targetNodeName, targetNodeHostname, availableMilliCPU := mostAvailableSchedulableNodeCPU(ctx, targetCluster)
+		targetNodeSelector := map[string]string{corev1.LabelHostname: targetNodeHostname}
 		const (
-			componentCPU  = 0.1 // 0.1 core (100m) as a number, matching the CRD schema type
-			maxFlinkCount = 50
+			// A FlinkDeployment reserves CPU for one JobManager and one TaskManager.
+			flinkComponentsPerDeployment int64 = 2
+			// Six scheduled deployments are enough to verify that assumed CPU accumulates while keeping the test bounded.
+			targetSchedulableFlinkDeployments int64 = 6
+			// Each component requests at least 50m CPU, even on a small node.
+			minimumComponentMilliCPU int64 = 50
 		)
+		// Divide the node's available CPU across the target deployments and their two components.
+		componentMilliCPU := max(minimumComponentMilliCPU,
+			availableMilliCPU/(flinkComponentsPerDeployment*targetSchedulableFlinkDeployments))
+		flinkDeploymentMilliCPU := flinkComponentsPerDeployment * componentMilliCPU
+		gomega.Expect(availableMilliCPU).Should(gomega.BeNumerically(">", flinkDeploymentMilliCPU),
+			"expected enough available CPU on node %q to schedule one FlinkDeployment", targetNodeName)
+		componentCPU := float64(componentMilliCPU) / 1000
 
-		// createFlinkDeployment creates a FlinkDeployment with fixed 100m per component and its
-		// PropagationPolicy targeting member1, then returns the ResourceBinding name.
+		// Create one more deployment than the node can fit, the final one must be unschedulable.
+		maxFlinkCount := int(availableMilliCPU/flinkDeploymentMilliCPU) + 1
+
+		ginkgo.By(fmt.Sprintf("targeting node %q with %dm available CPU, %dm per Flink component, and up to %d FlinkDeployments",
+			targetNodeName, availableMilliCPU, componentMilliCPU, maxFlinkCount))
+
+		// createFlinkDeployment creates a FlinkDeployment with the calculated CPU request,
+		// pins it to the selected node, and returns its ResourceBinding name.
 		createFlinkDeployment := func() string {
 			flinkName := fmt.Sprintf("flinkdeployment-%s", rand.String(RandomStrLength))
 
@@ -444,9 +457,11 @@ var _ = framework.SerialDescribe("[EstimatorAssumption] NodeResource plugin assu
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			flinkObj.SetNamespace(testNamespace)
 			flinkObj.SetName(flinkName)
-			err = unstructured.SetNestedField(flinkObj.Object, float64(componentCPU), "spec", "jobManager", "resource", "cpu")
+			err = unstructured.SetNestedField(flinkObj.Object, componentCPU, "spec", "jobManager", "resource", "cpu")
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			err = unstructured.SetNestedField(flinkObj.Object, float64(componentCPU), "spec", "taskManager", "resource", "cpu")
+			err = unstructured.SetNestedField(flinkObj.Object, componentCPU, "spec", "taskManager", "resource", "cpu")
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			err = unstructured.SetNestedStringMap(flinkObj.Object, targetNodeSelector, "spec", "podTemplate", "spec", "nodeSelector")
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			_, err = dynamicClient.Resource(flinkDeploymentGVR).Namespace(testNamespace).
 				Create(ctx, flinkObj, metav1.CreateOptions{})
@@ -488,6 +503,7 @@ var _ = framework.SerialDescribe("[EstimatorAssumption] NodeResource plugin assu
 
 		ginkgo.By(fmt.Sprintf("creating FlinkDeployments one by one (up to %d) until assumption exhausts cluster resources", maxFlinkCount), func() {
 			assumptionExhausted := false
+			scheduledCount := 0
 			for range maxFlinkCount {
 				bindingName := createFlinkDeployment()
 				// Wait for a definitive scheduling result before creating the next one,
@@ -501,37 +517,111 @@ var _ = framework.SerialDescribe("[EstimatorAssumption] NodeResource plugin assu
 						if cond.Status == metav1.ConditionFalse && cond.Reason == workv1alpha2.BindingReasonSchedulerError &&
 							strings.Contains(cond.Message, "no enough resource") {
 							assumptionExhausted = true
+							return true
 						}
-						return true
+						if cond.Status == metav1.ConditionTrue {
+							scheduledCount++
+							return true
+						}
+						return false
 					})
 				if assumptionExhausted {
 					break
 				}
 			}
+			gomega.Expect(scheduledCount).Should(gomega.BeNumerically(">", 0),
+				"expected at least one FlinkDeployment to schedule before assumptions exhaust node resources")
 			gomega.Expect(assumptionExhausted).Should(gomega.BeTrue(),
 				"expected assumption to exhaust cluster resources within %d FlinkDeployments", maxFlinkCount)
 		})
 
-		// At this point the assumption cache has consumed all available node CPU on member1.
-		// A single-template Deployment requesting 200m CPU should also fail to schedule,
-		// verifying that the assumption cache protects against over-scheduling of
+		// At this point the assumption cache has less than one FlinkDeployment's total CPU request
+		// remaining on member1. A single-template Deployment with that total request should also fail
+		// to schedule, verifying that the assumption cache protects against over-scheduling of
 		// single-template workloads as well.
-		ginkgo.By("verifying a single-template Deployment requesting 200m CPU is also unschedulable due to assumed workloads", func() {
-			assertSingleTemplateDeploymentUnschedulable(testNamespace, targetCluster)
+		ginkgo.By("verifying a single-template Deployment is also unschedulable due to assumed workloads", func() {
+			assertSingleTemplateDeploymentUnschedulable(testNamespace, targetCluster, flinkDeploymentMilliCPU, targetNodeSelector)
 		})
 	})
 })
 
+// mostAvailableSchedulableNodeCPU finds the Ready, schedulable node with the most
+// CPU remaining after subtracting requests from non-terminal pods. It returns the
+// node's name, hostname, and remaining CPU in millicores.
+func mostAvailableSchedulableNodeCPU(ctx context.Context, cluster string) (string, string, int64) {
+	clusterClient := framework.GetClusterClient(cluster)
+	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+	nodeList, err := clusterClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	podList, err := clusterClient.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	requestedCPUByNode := make(map[string]int64)
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.Spec.NodeName == "" || pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		requestedCPUByNode[pod.Spec.NodeName] += util.EmptyResource().AddPodRequest(&pod.Spec).MilliCPU
+	}
+
+	var selectedNodeName, selectedHostname string
+	var maxAvailableMilliCPU int64
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		if !nodeSchedulableByDefault(node) {
+			continue
+		}
+		hostname := node.Labels[corev1.LabelHostname]
+		if hostname == "" {
+			continue
+		}
+		availableMilliCPU := node.Status.Allocatable.Cpu().MilliValue() - requestedCPUByNode[node.Name]
+		if availableMilliCPU > maxAvailableMilliCPU {
+			selectedNodeName = node.Name
+			selectedHostname = hostname
+			maxAvailableMilliCPU = availableMilliCPU
+		}
+	}
+
+	gomega.Expect(selectedNodeName).ShouldNot(gomega.BeEmpty(), "expected at least one schedulable node in cluster %q", cluster)
+	gomega.Expect(maxAvailableMilliCPU).Should(gomega.BeNumerically(">", 0), "expected positive available CPU on node %q", selectedNodeName)
+	return selectedNodeName, selectedHostname, maxAvailableMilliCPU
+}
+
+func nodeSchedulableByDefault(node *corev1.Node) bool {
+	if node.Spec.Unschedulable {
+		return false
+	}
+	ready := false
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			ready = cond.Status == corev1.ConditionTrue
+			break
+		}
+	}
+	if !ready {
+		return false
+	}
+	for _, taint := range node.Spec.Taints {
+		if taint.Effect == corev1.TaintEffectNoSchedule || taint.Effect == corev1.TaintEffectNoExecute {
+			return false
+		}
+	}
+	return true
+}
+
 // assertSingleTemplateDeploymentUnschedulable creates a single-replica Deployment requesting
-// 200m CPU in the given namespace, propagates it to targetCluster, and asserts that the
+// cpuRequestMilliCPU in the given namespace, propagates it to targetCluster, and asserts that the
 // ResourceBinding transitions to an unschedulable state because the assumption cache has
 // already exhausted the available resources.
-func assertSingleTemplateDeploymentUnschedulable(namespace, targetCluster string) {
-	const cpuRequest = "200m"
-
+func assertSingleTemplateDeploymentUnschedulable(namespace, targetCluster string, cpuRequestMilliCPU int64, nodeSelector map[string]string) {
+	cpuRequest := fmt.Sprintf("%dm", cpuRequestMilliCPU)
 	deployName := fmt.Sprintf("deploy-%s", rand.String(RandomStrLength))
 	deploy := helper.NewDeployment(namespace, deployName)
 	deploy.Spec.Replicas = ptr.To[int32](1)
+	deploy.Spec.Template.Spec.NodeSelector = nodeSelector
 	deploy.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU: resource.MustParse(cpuRequest),


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind flake

**What this PR does / why we need it**:

This PR makes the NodeResource estimator assumption e2e test capacity-aware

Currently, CI tests for the NodeResource estimator created up to 50 FlinkDeployments with a fixed CPU request with 200m each (10 CPU total)

The test expected those workloads to exhaust `member1`, but *I think* that assumption is only valid when the target member node running the CI tests has less than roughly 10 CPU available

This means that for CI executions running on larger nodes, all 50 workloads can schedule but still result in test failure even though the scheduler assumption logic is working correctly

The updated test now does the following
1. Reads the target member cluster’s current node CPU availability
2. Selects a schedulable node
3. Sizes the FlinkDeployment component CPU request from that node’s available CPU
4. Pins the test workload to that node. 

The updated test also verifies that at least one FlinkDeployment schedules before a later one becomes unschedulable due to assumed workload accounting

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This was discovered as part of unrelated CI failures due to ongoing work on https://github.com/karmada-io/karmada/pull/7832 (not ready for review)

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```
