### PR TITLE
feat: preserve accepted component state on rescheduling failure

### DIFF
--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -134,6 +134,14 @@ func (c *ResourceBindingController) syncBinding(ctx context.Context, binding *wo
 		klog.ErrorS(err, "Failed to fetch workload for ResourceBinding", "namespace", binding.GetNamespace(), "binding", binding.GetName())
 		return controllerruntime.Result{}, err
 	}
+	wait, err := shouldWaitForComponentScheduleResult(c.ResourceInterpreter, workload, &binding.Spec)
+	if err != nil {
+		return controllerruntime.Result{}, err
+	}
+	if wait {
+		klog.V(4).InfoS("Skip syncing Work until component replicas are accepted", "namespace", binding.GetNamespace(), "binding", binding.GetName())
+		return controllerruntime.Result{}, nil
+	}
 	start := time.Now()
 	err = ensureWork(ctx, c.Client, c.ResourceInterpreter, workload, c.OverrideManager, binding, apiextensionsv1.NamespaceScoped)
 	metrics.ObserveSyncWorkLatency(err, start)

--- a/pkg/controllers/binding/binding_controller_test.go
+++ b/pkg/controllers/binding/binding_controller_test.go
@@ -39,6 +39,7 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/features"
 	testing2 "github.com/karmada-io/karmada/pkg/search/proxy/testing"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
@@ -216,6 +217,69 @@ func TestResourceBindingController_syncBinding(t *testing.T) {
 				t.Errorf("syncBinding() got = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResourceBindingControllerPreservesWorkWhileComponentResultPending(t *testing.T) {
+	originalFeatureGates := features.FeatureGate.DeepCopy()
+	if err := features.FeatureGate.Set(fmt.Sprintf("%s=true", features.MultiplePodTemplatesScheduling)); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { features.FeatureGate = originalFeatureGates })
+
+	resource := workv1alpha2.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "default", Name: "pod"}
+	controller, err := makeFakeRBCByResource(&resource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller.ResourceInterpreter = &componentTestInterpreter{components: []workv1alpha2.Component{
+		{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6},
+	}}
+	controller.OverrideManager = &componentTestOverrideManager{}
+
+	const bindingID = "binding-id"
+	binding := &workv1alpha2.ResourceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rb",
+			Namespace: "default",
+			Labels:    map[string]string{workv1alpha2.ResourceBindingPermanentIDLabel: bindingID},
+		},
+		Spec: workv1alpha2.ResourceBindingSpec{
+			Resource:   resource,
+			Components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			Clusters: []workv1alpha2.TargetCluster{{Name: "member1", Components: []workv1alpha2.TargetComponent{
+				{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4},
+			}}},
+		},
+	}
+	work := newComponentTestWork(workv1alpha2.ResourceBindingPermanentIDLabel, bindingID, resource.Kind, resource.Name, resource.Namespace)
+	if err := controller.Client.Create(context.Background(), work); err != nil {
+		t.Fatal(err)
+	}
+	want := work.Spec.DeepCopy()
+
+	if _, err := controller.syncBinding(context.Background(), binding); err != nil {
+		t.Fatal(err)
+	}
+	got := &workv1alpha1.Work{}
+	if err := controller.Client.Get(context.Background(), client.ObjectKeyFromObject(work), got); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(want, &got.Spec) {
+		t.Fatalf("Work spec changed while component result was pending: got %#v, want %#v", got.Spec, *want)
+	}
+
+	binding.Spec.Clusters[0].Components = []workv1alpha2.TargetComponent{
+		{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6},
+	}
+	if _, err := controller.syncBinding(context.Background(), binding); err != nil {
+		t.Fatal(err)
+	}
+	if err := controller.Client.Get(context.Background(), client.ObjectKeyFromObject(work), got); err != nil {
+		t.Fatal(err)
+	}
+	if reflect.DeepEqual(want, &got.Spec) {
+		t.Fatal("Work spec was not updated after component replicas were accepted")
 	}
 }
 

--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -132,6 +132,14 @@ func (c *ClusterResourceBindingController) syncBinding(ctx context.Context, bind
 		klog.ErrorS(err, "Failed to fetch workload for ClusterResourceBinding.", "ClusterResourceBinding", binding.Name)
 		return controllerruntime.Result{}, err
 	}
+	wait, err := shouldWaitForComponentScheduleResult(c.ResourceInterpreter, workload, &binding.Spec)
+	if err != nil {
+		return controllerruntime.Result{}, err
+	}
+	if wait {
+		klog.V(4).InfoS("Skip syncing Work until component replicas are accepted", "binding", binding.GetName())
+		return controllerruntime.Result{}, nil
+	}
 
 	start := time.Now()
 	err = ensureWork(ctx, c.Client, c.ResourceInterpreter, workload, c.OverrideManager, binding, apiextensionsv1.ClusterScoped)

--- a/pkg/controllers/binding/cluster_resource_binding_controller_test.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller_test.go
@@ -42,6 +42,7 @@ import (
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/events"
+	"github.com/karmada-io/karmada/pkg/features"
 	testing2 "github.com/karmada-io/karmada/pkg/search/proxy/testing"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
@@ -324,6 +325,68 @@ func TestClusterResourceBindingController_syncBinding(t *testing.T) {
 				t.Fatalf("expected at least %d %q events, got %d (%v)", expectedSyncSucceedEventCount, events.EventReasonSyncWorkSucceed, succeedEvents, eventsFound)
 			}
 		})
+	}
+}
+
+func TestClusterResourceBindingControllerPreservesWorkWhileComponentResultPending(t *testing.T) {
+	originalFeatureGates := features.FeatureGate.DeepCopy()
+	if err := features.FeatureGate.Set(fmt.Sprintf("%s=true", features.MultiplePodTemplatesScheduling)); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { features.FeatureGate = originalFeatureGates })
+
+	resource := workv1alpha2.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "test"}
+	controller, err := makeFakeCRBCByResource(&resource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller.ResourceInterpreter = &componentTestInterpreter{components: []workv1alpha2.Component{
+		{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6},
+	}}
+	controller.OverrideManager = &componentTestOverrideManager{}
+
+	const bindingID = "cluster-binding-id"
+	binding := &workv1alpha2.ClusterResourceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-crb",
+			Labels: map[string]string{workv1alpha2.ClusterResourceBindingPermanentIDLabel: bindingID},
+		},
+		Spec: workv1alpha2.ResourceBindingSpec{
+			Resource:   resource,
+			Components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			Clusters: []workv1alpha2.TargetCluster{{Name: "member1", Components: []workv1alpha2.TargetComponent{
+				{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4},
+			}}},
+		},
+	}
+	work := newComponentTestWork(workv1alpha2.ClusterResourceBindingPermanentIDLabel, bindingID, resource.Kind, resource.Name, resource.Namespace)
+	if err := controller.Client.Create(context.Background(), work); err != nil {
+		t.Fatal(err)
+	}
+	want := work.Spec.DeepCopy()
+
+	if _, err := controller.syncBinding(context.Background(), binding); err != nil {
+		t.Fatal(err)
+	}
+	got := &workv1alpha1.Work{}
+	if err := controller.Client.Get(context.Background(), client.ObjectKeyFromObject(work), got); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(want, &got.Spec) {
+		t.Fatalf("Work spec changed while component result was pending: got %#v, want %#v", got.Spec, *want)
+	}
+
+	binding.Spec.Clusters[0].Components = []workv1alpha2.TargetComponent{
+		{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6},
+	}
+	if _, err := controller.syncBinding(context.Background(), binding); err != nil {
+		t.Fatal(err)
+	}
+	if err := controller.Client.Get(context.Background(), client.ObjectKeyFromObject(work), got); err != nil {
+		t.Fatal(err)
+	}
+	if reflect.DeepEqual(want, &got.Spec) {
+		t.Fatal("Work spec was not updated after component replicas were accepted")
 	}
 }
 

--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -47,7 +47,23 @@ import (
 const (
 	// requeueIntervalForDirectlyPurge is the requeue interval for binding when there are works in clusters with PurgeMode 'Directly'.
 	requeueIntervalForDirectlyPurge = 5 * time.Second
+	defaultSchedulerName            = "default-scheduler"
 )
+
+func shouldWaitForComponentScheduleResult(resourceInterpreter resourceinterpreter.ResourceInterpreter, workload *unstructured.Unstructured, bindingSpec *workv1alpha2.ResourceBindingSpec) (bool, error) {
+	if !features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) || len(bindingSpec.Components) <= 1 ||
+		(bindingSpec.SchedulerName != "" && bindingSpec.SchedulerName != defaultSchedulerName) ||
+		len(bindingSpec.Clusters) != 1 || len(bindingSpec.Clusters[0].Components) == 0 {
+		return false, nil
+	}
+
+	components, err := resourceInterpreter.GetComponents(workload)
+	if err != nil {
+		return false, fmt.Errorf("failed to get components from source workload: %w", err)
+	}
+	equal, comparable := util.ComponentReplicasEqual(components, bindingSpec.Clusters[0].Components)
+	return !comparable || !equal, nil
+}
 
 // ensureWork ensure Work to be created or updated.
 func ensureWork(

--- a/pkg/controllers/binding/common_test.go
+++ b/pkg/controllers/binding/common_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package binding
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -24,10 +26,162 @@ import (
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/features"
+	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
+	"github.com/karmada-io/karmada/pkg/util/names"
+	"github.com/karmada-io/karmada/pkg/util/overridemanager"
 )
+
+type componentTestInterpreter struct {
+	resourceinterpreter.ResourceInterpreter
+	components []workv1alpha2.Component
+	err        error
+}
+
+func (i *componentTestInterpreter) GetComponents(*unstructured.Unstructured) ([]workv1alpha2.Component, error) {
+	return i.components, i.err
+}
+
+func (i *componentTestInterpreter) HookEnabled(schema.GroupVersionKind, configv1alpha1.InterpreterOperation) bool {
+	return false
+}
+
+type componentTestOverrideManager struct {
+	overridemanager.OverrideManager
+}
+
+func (*componentTestOverrideManager) ApplyOverridePolicies(*unstructured.Unstructured, string) (*overridemanager.AppliedOverrides, *overridemanager.AppliedOverrides, error) {
+	return nil, nil, nil
+}
+
+func newComponentTestWork(bindingLabel, bindingID, kind, name, namespace string) *workv1alpha1.Work {
+	return &workv1alpha1.Work{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      names.GenerateWorkName(kind, name, namespace),
+			Namespace: names.GenerateExecutionSpaceName("member1"),
+			Labels:    map[string]string{bindingLabel: bindingID},
+		},
+		Spec: workv1alpha1.WorkSpec{Workload: workv1alpha1.WorkloadTemplate{Manifests: []workv1alpha1.Manifest{{
+			RawExtension: runtime.RawExtension{Raw: []byte(`{"accepted":"tm4"}`)},
+		}}}},
+	}
+}
+
+func TestShouldWaitForComponentScheduleResult(t *testing.T) {
+	accepted := []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}}
+	baseSpec := func() *workv1alpha2.ResourceBindingSpec {
+		return &workv1alpha2.ResourceBindingSpec{
+			Components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			Clusters:   []workv1alpha2.TargetCluster{{Name: "member1", Components: accepted}},
+		}
+	}
+	tests := []struct {
+		name       string
+		feature    bool
+		spec       *workv1alpha2.ResourceBindingSpec
+		components []workv1alpha2.Component
+		getErr     error
+		wantWait   bool
+		wantErr    bool
+	}{
+		{
+			name:       "equal source is accepted regardless of order",
+			feature:    true,
+			spec:       baseSpec(),
+			components: []workv1alpha2.Component{{Name: "taskmanager", Replicas: 4}, {Name: "jobmanager", Replicas: 1}},
+		},
+		{
+			name:       "source scale up waits",
+			feature:    true,
+			spec:       baseSpec(),
+			components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			wantWait:   true,
+		},
+		{
+			name:       "source scale down waits",
+			feature:    true,
+			spec:       baseSpec(),
+			components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 2}},
+			wantWait:   true,
+		},
+		{
+			name:       "incomparable source waits",
+			feature:    true,
+			spec:       baseSpec(),
+			components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "worker", Replicas: 4}},
+			wantWait:   true,
+		},
+		{
+			name:       "feature disabled keeps old behavior",
+			spec:       baseSpec(),
+			components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+		},
+		{
+			name:    "single template keeps old behavior",
+			feature: true,
+			spec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{{Name: "workload", Replicas: 2}},
+				Clusters: []workv1alpha2.TargetCluster{{Name: "member1", Components: []workv1alpha2.TargetComponent{
+					{Name: "workload", Replicas: 1},
+				}}},
+			},
+			components: []workv1alpha2.Component{{Name: "workload", Replicas: 2}},
+		},
+		{
+			name:    "custom scheduler keeps old behavior",
+			feature: true,
+			spec: func() *workv1alpha2.ResourceBindingSpec {
+				spec := baseSpec()
+				spec.SchedulerName = "custom-scheduler"
+				return spec
+			}(),
+			components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+		},
+		{
+			name:    "missing accepted snapshot keeps old behavior",
+			feature: true,
+			spec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+				Clusters:   []workv1alpha2.TargetCluster{{Name: "member1"}},
+			},
+			components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+		},
+		{
+			name:       "interpreter error stops synchronization",
+			feature:    true,
+			spec:       baseSpec(),
+			getErr:     errors.New("interpretation failed"),
+			wantErr:    true,
+			components: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalFeatureGates := features.FeatureGate.DeepCopy()
+			if err := features.FeatureGate.Set(fmt.Sprintf("%s=%t", features.MultiplePodTemplatesScheduling, tt.feature)); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { features.FeatureGate = originalFeatureGates })
+
+			wait, err := shouldWaitForComponentScheduleResult(
+				&componentTestInterpreter{components: tt.components, err: tt.getErr},
+				&unstructured.Unstructured{},
+				tt.spec,
+			)
+			if (err != nil) != tt.wantErr || wait != tt.wantWait {
+				t.Fatalf("shouldWaitForComponentScheduleResult() = (%t, %v), want (%t, error=%t)", wait, err, tt.wantWait, tt.wantErr)
+			}
+		})
+	}
+}
 
 func Test_mergeTargetClusters(t *testing.T) {
 	tests := []struct {

--- a/pkg/scheduler/core/common.go
+++ b/pkg/scheduler/core/common.go
@@ -31,14 +31,20 @@ import (
 )
 
 // SelectClusters selects clusters based on the placement and resource binding spec.
-func SelectClusters(clustersScore framework.ClusterScoreList, placement *policyv1alpha1.Placement, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus, assigningCache *schedulercache.AssigningResourceBindingCache) ([]spreadconstraint.ClusterDetailInfo, error) {
+func SelectClusters(clustersScore framework.ClusterScoreList, placement *policyv1alpha1.Placement, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus, assigningCache *schedulercache.AssigningResourceBindingCache, componentScale bool) ([]spreadconstraint.ClusterDetailInfo, error) {
 	startTime := time.Now()
 	defer metrics.ScheduleStep(metrics.ScheduleStepSelect, startTime)
 
 	calAvailableReplicasFunc := func(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha2.ResourceBindingSpec) []workv1alpha2.TargetCluster {
-		return calAvailableReplicas(clusters, spec, assigningCache)
+		return calAvailableReplicas(clusters, spec, assigningCache, componentScale)
 	}
 	groupClustersInfo := spreadconstraint.GroupClustersWithScore(clustersScore, placement, spec, status, calAvailableReplicasFunc)
+	if componentScale {
+		if len(groupClustersInfo.Clusters) != 1 || groupClustersInfo.Clusters[0].AvailableReplicas < int64(minimumAvailableComponentSets) {
+			return nil, &framework.UnschedulableError{Message: "the current target cluster has insufficient resources for component scale"}
+		}
+		return groupClustersInfo.Clusters, nil
+	}
 	if features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) && isMultiTemplateSchedulingApplicable(spec) {
 		// For multi-component workloads, they are scheduled as a whole and do not support replica division.
 		// The scheduling unit is 1 (i.e., 1 instance of the multi-component template), so we require 1 available replica.

--- a/pkg/scheduler/core/common_test.go
+++ b/pkg/scheduler/core/common_test.go
@@ -153,7 +153,7 @@ func TestSelectClusters(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.spec.Placement = tt.placement
-			result, err := SelectClusters(tt.clustersScore, tt.placement, tt.spec, tt.status, nil)
+			result, err := SelectClusters(tt.clustersScore, tt.placement, tt.spec, tt.status, nil, false)
 
 			if tt.expectedError {
 				assert.Error(t, err)
@@ -175,6 +175,77 @@ func TestSelectClusters(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSelectClustersForComponentScale(t *testing.T) {
+	originalFeatureGates := features.FeatureGate.DeepCopy()
+	if err := features.FeatureGate.Set(fmt.Sprintf("%s=true", features.MultiplePodTemplatesScheduling)); err != nil {
+		t.Fatalf("failed to enable feature gate %s: %v", features.MultiplePodTemplatesScheduling, err)
+	}
+	t.Cleanup(func() { features.FeatureGate = originalFeatureGates })
+
+	placement := &policyv1alpha1.Placement{
+		SpreadConstraints: []policyv1alpha1.SpreadConstraint{{
+			SpreadByField: policyv1alpha1.SpreadByFieldCluster,
+			MinGroups:     1,
+			MaxGroups:     1,
+		}},
+		ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+			ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided,
+		},
+	}
+	cluster := helper.NewCluster(ClusterMember1)
+	clustersScore := framework.ClusterScoreList{{Cluster: cluster}}
+	accepted := []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}}
+
+	t.Run("scale down skips estimation and does not persist the capacity sentinel", func(t *testing.T) {
+		desired := []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 2}}
+		spec := &workv1alpha2.ResourceBindingSpec{
+			Placement:  placement,
+			Components: desired,
+			Clusters:   []workv1alpha2.TargetCluster{{Name: ClusterMember1, Components: accepted}},
+		}
+
+		selected, err := SelectClusters(clustersScore, placement, spec, &workv1alpha2.ResourceBindingStatus{}, nil, true)
+		assert.NoError(t, err)
+		if assert.Len(t, selected, 1) {
+			assert.Equal(t, int64(minimumAvailableComponentSets), selected[0].AvailableReplicas)
+		}
+
+		result, err := AssignReplicas(selected, spec, &workv1alpha2.ResourceBindingStatus{})
+		assert.NoError(t, err)
+		assert.Equal(t, []workv1alpha2.TargetCluster{{
+			Name: ClusterMember1,
+			Components: []workv1alpha2.TargetComponent{
+				{Name: "jobmanager", Replicas: 1},
+				{Name: "taskmanager", Replicas: 2},
+			},
+		}}, result)
+	})
+
+	t.Run("scale up without estimator capacity is unschedulable", func(t *testing.T) {
+		spec := &workv1alpha2.ResourceBindingSpec{
+			Placement:  placement,
+			Components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			Clusters:   []workv1alpha2.TargetCluster{{Name: ClusterMember1, Components: accepted}},
+		}
+
+		selected, err := SelectClusters(clustersScore, placement, spec, &workv1alpha2.ResourceBindingStatus{}, nil, true)
+		assert.Error(t, err)
+		assert.Nil(t, selected)
+	})
+
+	t.Run("mixed component scaling is unschedulable", func(t *testing.T) {
+		spec := &workv1alpha2.ResourceBindingSpec{
+			Placement:  placement,
+			Components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 0}, {Name: "taskmanager", Replicas: 6}},
+			Clusters:   []workv1alpha2.TargetCluster{{Name: ClusterMember1, Components: accepted}},
+		}
+
+		selected, err := SelectClusters(clustersScore, placement, spec, &workv1alpha2.ResourceBindingStatus{}, nil, true)
+		assert.Error(t, err)
+		assert.Nil(t, selected)
+	})
 }
 
 func TestAssignComponentSchedulingResults(t *testing.T) {

--- a/pkg/scheduler/core/estimation.go
+++ b/pkg/scheduler/core/estimation.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/klog/v2"
 
@@ -75,9 +76,97 @@ type multiTemplateEstimationContext struct {
 // calculateMultiTemplateAvailableSets calculates available sets for multi-template scheduling.
 // It uses MaxAvailableComponentSets to estimate capacity for workloads with multiple pod templates.
 func calculateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTemplateEstimationContext) ([]workv1alpha2.TargetCluster, error) {
+	return estimateMultiTemplateAvailableSets(ctx, estCtx, estCtx.clusters, estCtx.spec.Components)
+}
+
+// calculateMultiTemplateAvailableSetsForScale plans capacity for a component replica scale.
+// Callers must ensure that only replica counts changed: component requirements and placement
+// must be unchanged, and failure-safe result retention must already be in place.
+func calculateMultiTemplateAvailableSetsForScale(ctx context.Context, estCtx multiTemplateEstimationContext) ([]workv1alpha2.TargetCluster, error) {
+	plans, err := buildComponentScalePlans(estCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]workv1alpha2.TargetCluster, 0, len(estCtx.clusters))
+	fullDesiredClusters := make([]*clusterv1alpha1.Cluster, 0, len(estCtx.clusters))
+	for i := range plans {
+		switch plans[i].direction {
+		case componentScaleNewCandidate:
+			fullDesiredClusters = append(fullDesiredClusters, plans[i].cluster)
+		case componentScaleDown:
+			result = append(result, workv1alpha2.TargetCluster{
+				Name:     plans[i].cluster.Name,
+				Replicas: scaleDownAvailableComponentSets,
+			})
+		case componentScaleUp:
+			delta := positiveComponentDelta(estCtx.spec.Components, plans[i].accepted)
+			estimated, err := estimateMultiTemplateAvailableSets(ctx, estCtx, []*clusterv1alpha1.Cluster{plans[i].cluster}, delta)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, estimated...)
+		}
+	}
+
+	if len(fullDesiredClusters) > 0 {
+		estimated, err := estimateMultiTemplateAvailableSets(ctx, estCtx, fullDesiredClusters, estCtx.spec.Components)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, estimated...)
+	}
+
+	resultByCluster := make(map[string]workv1alpha2.TargetCluster, len(result))
+	for i := range result {
+		resultByCluster[result[i].Name] = result[i]
+	}
+	ordered := make([]workv1alpha2.TargetCluster, 0, len(result))
+	for _, cluster := range estCtx.clusters {
+		if clusterResult, exists := resultByCluster[cluster.Name]; exists {
+			ordered = append(ordered, clusterResult)
+		}
+	}
+	return ordered, nil
+}
+
+type componentScalePlan struct {
+	cluster   *clusterv1alpha1.Cluster
+	direction componentScaleDirection
+	accepted  []workv1alpha2.TargetComponent
+}
+
+func buildComponentScalePlans(estCtx multiTemplateEstimationContext) ([]componentScalePlan, error) {
+	if !componentNamesAreValidAndUnique(estCtx.spec.Components) {
+		return nil, fmt.Errorf("component scale planning requires desired components to have unique, non-empty names")
+	}
+
+	plans := make([]componentScalePlan, 0, len(estCtx.clusters))
+	for _, cluster := range estCtx.clusters {
+		accepted, found := acceptedComponentsForCluster(estCtx.spec.Clusters, cluster.Name)
+		if !found {
+			plans = append(plans, componentScalePlan{cluster: cluster, direction: componentScaleNewCandidate})
+			continue
+		}
+
+		direction := componentReplicaScaleDirection(estCtx.spec.Components, accepted)
+		switch direction {
+		case componentScaleUnknown:
+			return nil, fmt.Errorf("component scale planning for cluster %q requires a comparable accepted component snapshot", cluster.Name)
+		case componentScaleEqual:
+			return nil, fmt.Errorf("component scale planning for cluster %q requires a replica change", cluster.Name)
+		case componentScaleMixed:
+			return nil, fmt.Errorf("mixed component scaling is not supported for cluster %q", cluster.Name)
+		}
+		plans = append(plans, componentScalePlan{cluster: cluster, direction: direction, accepted: accepted})
+	}
+	return plans, nil
+}
+
+func estimateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTemplateEstimationContext, clusters []*clusterv1alpha1.Cluster, components []workv1alpha2.Component) ([]workv1alpha2.TargetCluster, error) {
 	req := estimatorclient.ComponentSetEstimationRequest{
-		Clusters:         estCtx.clusters,
-		Components:       estCtx.spec.Components,
+		Clusters:         clusters,
+		Components:       components,
 		Namespace:        estCtx.spec.Resource.Namespace,
 		AssumedWorkloads: estCtx.assumedWorkloads,
 	}
@@ -99,8 +188,8 @@ func calculateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTempla
 		resMap[resp[i].Name] = resp[i].Sets
 	}
 
-	result := make([]workv1alpha2.TargetCluster, 0, len(estCtx.clusters))
-	for _, cluster := range estCtx.clusters {
+	result := make([]workv1alpha2.TargetCluster, 0, len(clusters))
+	for _, cluster := range clusters {
 		sets, ok := resMap[cluster.Name]
 		if !ok {
 			klog.Warningf("The estimator(%s) missed estimation from cluster(%s) when estimating for workload(%s, kind=%s, %s).",
@@ -110,6 +199,104 @@ func calculateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTempla
 		result = append(result, workv1alpha2.TargetCluster{Name: cluster.Name, Replicas: sets})
 	}
 	return result, nil
+}
+
+func acceptedComponentsForCluster(clusters []workv1alpha2.TargetCluster, name string) ([]workv1alpha2.TargetComponent, bool) {
+	for i := range clusters {
+		if clusters[i].Name == name {
+			return clusters[i].Components, true
+		}
+	}
+	return nil, false
+}
+
+func positiveComponentDelta(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) []workv1alpha2.Component {
+	acceptedReplicas := make(map[string]int32, len(accepted))
+	for i := range accepted {
+		acceptedReplicas[accepted[i].Name] = accepted[i].Replicas
+	}
+
+	delta := make([]workv1alpha2.Component, 0, len(desired))
+	for i := range desired {
+		replicas := desired[i].Replicas - acceptedReplicas[desired[i].Name]
+		if replicas <= 0 {
+			continue
+		}
+		component := desired[i]
+		component.Replicas = replicas
+		delta = append(delta, component)
+	}
+	return delta
+}
+
+type componentScaleDirection int
+
+const (
+	componentScaleUnknown componentScaleDirection = iota
+	componentScaleNewCandidate
+	componentScaleEqual
+	componentScaleUp
+	componentScaleDown
+	componentScaleMixed
+)
+
+// A scale-down requires no additional capacity. One available set keeps the
+// current target eligible; AssignReplicas constructs the final assignment.
+const scaleDownAvailableComponentSets int32 = 1
+
+func componentReplicaScaleDirection(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) componentScaleDirection {
+	if len(desired) != len(accepted) || !componentNamesAreValidAndUnique(desired) {
+		return componentScaleUnknown
+	}
+
+	acceptedReplicas := make(map[string]int32, len(accepted))
+	for i := range accepted {
+		if _, exists := acceptedReplicas[accepted[i].Name]; exists {
+			return componentScaleUnknown
+		}
+		acceptedReplicas[accepted[i].Name] = accepted[i].Replicas
+	}
+	var scaleUp, scaleDown bool
+	for i := range desired {
+		replicas, exists := acceptedReplicas[desired[i].Name]
+		if !exists {
+			return componentScaleUnknown
+		}
+		switch {
+		case desired[i].Replicas > replicas:
+			scaleUp = true
+		case desired[i].Replicas < replicas:
+			scaleDown = true
+		}
+	}
+	switch {
+	case scaleUp && scaleDown:
+		return componentScaleMixed
+	case scaleUp:
+		return componentScaleUp
+	case scaleDown:
+		return componentScaleDown
+	default:
+		return componentScaleEqual
+	}
+}
+
+func componentNamesAreValidAndUnique(components []workv1alpha2.Component) bool {
+	if len(components) == 0 {
+		return false
+	}
+
+	names := make(map[string]struct{}, len(components))
+	for i := range components {
+		if components[i].Name == "" {
+			return false
+		}
+		if _, exists := names[components[i].Name]; exists {
+			return false
+		}
+		names[components[i].Name] = struct{}{}
+	}
+	return true
 }
 
 // buildAssumedWorkloadsByCluster builds a map of assumed workloads for each cluster based on the assigning cache.

--- a/pkg/scheduler/core/estimation.go
+++ b/pkg/scheduler/core/estimation.go
@@ -79,88 +79,35 @@ func calculateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTempla
 	return estimateMultiTemplateAvailableSets(ctx, estCtx, estCtx.clusters, estCtx.spec.Components)
 }
 
-// calculateMultiTemplateAvailableSetsForScale plans capacity for a component replica scale.
-// Callers must ensure that only replica counts changed: component requirements and placement
-// must be unchanged, and failure-safe result retention must already be in place.
+// calculateMultiTemplateAvailableSetsForScale calculates capacity for a component replica
+// scale on the current accepted target. It does not define result retention on failure.
 func calculateMultiTemplateAvailableSetsForScale(ctx context.Context, estCtx multiTemplateEstimationContext) ([]workv1alpha2.TargetCluster, error) {
-	plans, err := buildComponentScalePlans(estCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	result := make([]workv1alpha2.TargetCluster, 0, len(estCtx.clusters))
-	fullDesiredClusters := make([]*clusterv1alpha1.Cluster, 0, len(estCtx.clusters))
-	for i := range plans {
-		switch plans[i].direction {
-		case componentScaleNewCandidate:
-			fullDesiredClusters = append(fullDesiredClusters, plans[i].cluster)
-		case componentScaleDown:
-			result = append(result, workv1alpha2.TargetCluster{
-				Name:     plans[i].cluster.Name,
-				Replicas: scaleDownAvailableComponentSets,
-			})
-		case componentScaleUp:
-			delta := positiveComponentDelta(estCtx.spec.Components, plans[i].accepted)
-			estimated, err := estimateMultiTemplateAvailableSets(ctx, estCtx, []*clusterv1alpha1.Cluster{plans[i].cluster}, delta)
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, estimated...)
-		}
-	}
-
-	if len(fullDesiredClusters) > 0 {
-		estimated, err := estimateMultiTemplateAvailableSets(ctx, estCtx, fullDesiredClusters, estCtx.spec.Components)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, estimated...)
-	}
-
-	resultByCluster := make(map[string]workv1alpha2.TargetCluster, len(result))
-	for i := range result {
-		resultByCluster[result[i].Name] = result[i]
-	}
-	ordered := make([]workv1alpha2.TargetCluster, 0, len(result))
-	for _, cluster := range estCtx.clusters {
-		if clusterResult, exists := resultByCluster[cluster.Name]; exists {
-			ordered = append(ordered, clusterResult)
-		}
-	}
-	return ordered, nil
-}
-
-type componentScalePlan struct {
-	cluster   *clusterv1alpha1.Cluster
-	direction componentScaleDirection
-	accepted  []workv1alpha2.TargetComponent
-}
-
-func buildComponentScalePlans(estCtx multiTemplateEstimationContext) ([]componentScalePlan, error) {
 	if !componentNamesAreValidAndUnique(estCtx.spec.Components) {
 		return nil, fmt.Errorf("component scale planning requires desired components to have unique, non-empty names")
 	}
-
-	plans := make([]componentScalePlan, 0, len(estCtx.clusters))
-	for _, cluster := range estCtx.clusters {
-		accepted, found := acceptedComponentsForCluster(estCtx.spec.Clusters, cluster.Name)
-		if !found {
-			plans = append(plans, componentScalePlan{cluster: cluster, direction: componentScaleNewCandidate})
-			continue
-		}
-
-		direction := componentReplicaScaleDirection(estCtx.spec.Components, accepted)
-		switch direction {
-		case componentScaleUnknown:
-			return nil, fmt.Errorf("component scale planning for cluster %q requires a comparable accepted component snapshot", cluster.Name)
-		case componentScaleEqual:
-			return nil, fmt.Errorf("component scale planning for cluster %q requires a replica change", cluster.Name)
-		case componentScaleMixed:
-			return nil, fmt.Errorf("mixed component scaling is not supported for cluster %q", cluster.Name)
-		}
-		plans = append(plans, componentScalePlan{cluster: cluster, direction: direction, accepted: accepted})
+	if len(estCtx.clusters) != 1 || len(estCtx.spec.Clusters) != 1 ||
+		estCtx.clusters[0].Name != estCtx.spec.Clusters[0].Name {
+		return nil, fmt.Errorf("component scale planning requires exactly one accepted target cluster")
 	}
-	return plans, nil
+
+	cluster := estCtx.clusters[0]
+	accepted := estCtx.spec.Clusters[0].Components
+	direction := componentReplicaScaleDirection(estCtx.spec.Components, accepted)
+	switch direction {
+	case componentScaleUnknown:
+		return nil, fmt.Errorf("component scale planning for cluster %q requires a comparable accepted component snapshot", cluster.Name)
+	case componentScaleEqual:
+		return nil, fmt.Errorf("component scale planning for cluster %q requires a replica change", cluster.Name)
+	case componentScaleMixed:
+		return nil, fmt.Errorf("mixed component scaling is not supported for cluster %q", cluster.Name)
+	case componentScaleDown:
+		return []workv1alpha2.TargetCluster{{Name: cluster.Name, Replicas: minimumAvailableComponentSets}}, nil
+	case componentScaleUp:
+		delta := positiveComponentDelta(estCtx.spec.Components, accepted)
+		return estimateMultiTemplateAvailableSets(ctx, estCtx, estCtx.clusters, delta)
+	default:
+		return nil, fmt.Errorf("component scale planning for cluster %q has an unsupported transition", cluster.Name)
+	}
 }
 
 func estimateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTemplateEstimationContext, clusters []*clusterv1alpha1.Cluster, components []workv1alpha2.Component) ([]workv1alpha2.TargetCluster, error) {
@@ -201,15 +148,6 @@ func estimateMultiTemplateAvailableSets(ctx context.Context, estCtx multiTemplat
 	return result, nil
 }
 
-func acceptedComponentsForCluster(clusters []workv1alpha2.TargetCluster, name string) ([]workv1alpha2.TargetComponent, bool) {
-	for i := range clusters {
-		if clusters[i].Name == name {
-			return clusters[i].Components, true
-		}
-	}
-	return nil, false
-}
-
 func positiveComponentDelta(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) []workv1alpha2.Component {
 	acceptedReplicas := make(map[string]int32, len(accepted))
 	for i := range accepted {
@@ -233,16 +171,15 @@ type componentScaleDirection int
 
 const (
 	componentScaleUnknown componentScaleDirection = iota
-	componentScaleNewCandidate
 	componentScaleEqual
 	componentScaleUp
 	componentScaleDown
 	componentScaleMixed
 )
 
-// A scale-down requires no additional capacity. One available set keeps the
-// current target eligible; AssignReplicas constructs the final assignment.
-const scaleDownAvailableComponentSets int32 = 1
+// minimumAvailableComponentSets is capacity evidence that one atomic component
+// set can use the current target. AssignReplicas constructs the final assignment.
+const minimumAvailableComponentSets int32 = 1
 
 func componentReplicaScaleDirection(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) componentScaleDirection {
 	if len(desired) != len(accepted) || !componentNamesAreValidAndUnique(desired) {

--- a/pkg/scheduler/core/estimation_test.go
+++ b/pkg/scheduler/core/estimation_test.go
@@ -423,6 +423,7 @@ func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
 		wantResult     []workv1alpha2.TargetCluster
 		wantError      string
 		wantCalls      int
+		estimatorError error
 	}{
 		{
 			name: "scale up estimates only the positive delta",
@@ -431,7 +432,7 @@ func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
 					{Name: "jobmanager", Replicas: 1},
 					{Name: "taskmanager", Replicas: 6, ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{PriorityClassName: "high-priority"}},
 				},
-				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+				[]workv1alpha2.TargetComponent{{Name: "taskmanager", Replicas: 4}, {Name: "jobmanager", Replicas: 1}},
 			),
 			wantComponents: []workv1alpha2.Component{{
 				Name:                "taskmanager",
@@ -447,7 +448,28 @@ func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
 				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 2}},
 				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
 			),
-			wantResult: []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: scaleDownAvailableComponentSets}},
+			wantResult: []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: minimumAvailableComponentSets}},
+		},
+		{
+			name: "all components scale up by their positive delta",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 2}, {Name: "taskmanager", Replicas: 6}},
+				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			),
+			wantComponents: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 2}},
+			wantResult:     []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: 1}},
+			wantCalls:      1,
+		},
+		{
+			name: "scale up returns estimator error",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			),
+			wantComponents: []workv1alpha2.Component{{Name: "taskmanager", Replicas: 2}},
+			wantError:      "estimator failed",
+			wantCalls:      1,
+			estimatorError: errors.New("estimator failed"),
 		},
 		{
 			name: "existing target without accepted snapshot is unknown",
@@ -502,6 +524,17 @@ func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
 			spec:      newSpec(nil, nil),
 			wantError: "unique, non-empty names",
 		},
+		{
+			name: "candidate without accepted result is rejected",
+			spec: &workv1alpha2.ResourceBindingSpec{
+				Resource:   workv1alpha2.ObjectReference{Namespace: "default", Name: "flink"},
+				Components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+				Clusters: []workv1alpha2.TargetCluster{{Name: "cluster2", Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4},
+				}}},
+			},
+			wantError: "requires exactly one accepted target cluster",
+		},
 	}
 
 	for _, tt := range tests {
@@ -510,6 +543,9 @@ func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
 			estimator.maxAvailableComponentSetsFunc = func(req estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
 				assert.Equal(t, clusters, req.Clusters)
 				assert.Equal(t, tt.wantComponents, req.Components)
+				if tt.estimatorError != nil {
+					return nil, tt.estimatorError
+				}
 				return []estimatorclient.ComponentSetEstimationResponse{{Name: "cluster1", Sets: 1}}, nil
 			}
 
@@ -532,47 +568,8 @@ func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
 	}
 }
 
-func Test_calculateMultiTemplateAvailableSetsForScaleUsesFullDesiredOnlyForNewCandidates(t *testing.T) {
-	desired := []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 5}}
-	clusters := []*clusterv1alpha1.Cluster{helper.NewCluster("cluster1"), helper.NewCluster("cluster2")}
-	estimator := &mockReplicaEstimator{}
-	estimator.maxAvailableComponentSetsFunc = func(req estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
-		switch req.Clusters[0].Name {
-		case "cluster2":
-			assert.Equal(t, []*clusterv1alpha1.Cluster{clusters[1]}, req.Clusters)
-			assert.Equal(t, []workv1alpha2.Component{{Name: "taskmanager", Replicas: 2}}, req.Components)
-		case "cluster1":
-			assert.Equal(t, []*clusterv1alpha1.Cluster{clusters[0]}, req.Clusters)
-			assert.Equal(t, desired, req.Components)
-		default:
-			t.Fatalf("unexpected cluster request: %s", req.Clusters[0].Name)
-		}
-		return []estimatorclient.ComponentSetEstimationResponse{{Name: req.Clusters[0].Name, Sets: 1}}, nil
-	}
-	spec := &workv1alpha2.ResourceBindingSpec{
-		Resource:   workv1alpha2.ObjectReference{Namespace: "default", Name: "flink"},
-		Components: desired,
-		Clusters: []workv1alpha2.TargetCluster{{
-			Name: "cluster2",
-			Components: []workv1alpha2.TargetComponent{
-				{Name: "jobmanager", Replicas: 1},
-				{Name: "taskmanager", Replicas: 3},
-			},
-		}},
-	}
-
-	got, err := calculateMultiTemplateAvailableSetsForScale(context.Background(), multiTemplateEstimationContext{
-		estimator: estimator,
-		clusters:  clusters,
-		spec:      spec,
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: 1}, {Name: "cluster2", Replicas: 1}}, got)
-	assert.Len(t, estimator.componentSetRequests, 2)
-}
-
 func Test_calculateMultiTemplateAvailableSetsForScaleRejectsBeforeCallingEstimator(t *testing.T) {
-	clusters := []*clusterv1alpha1.Cluster{helper.NewCluster("cluster1"), helper.NewCluster("cluster2")}
+	clusters := []*clusterv1alpha1.Cluster{helper.NewCluster("cluster1")}
 	estimator := &mockReplicaEstimator{}
 	estimator.maxAvailableComponentSetsFunc = func(estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
 		t.Fatal("estimator must not be called before every transition is classified")
@@ -584,22 +581,13 @@ func Test_calculateMultiTemplateAvailableSetsForScaleRejectsBeforeCallingEstimat
 			{Name: "jobmanager", Replicas: 1},
 			{Name: "taskmanager", Replicas: 6},
 		},
-		Clusters: []workv1alpha2.TargetCluster{
-			{
-				Name: "cluster1",
-				Components: []workv1alpha2.TargetComponent{
-					{Name: "jobmanager", Replicas: 1},
-					{Name: "taskmanager", Replicas: 4},
-				},
+		Clusters: []workv1alpha2.TargetCluster{{
+			Name: "cluster1",
+			Components: []workv1alpha2.TargetComponent{
+				{Name: "jobmanager", Replicas: 2},
+				{Name: "taskmanager", Replicas: 4},
 			},
-			{
-				Name: "cluster2",
-				Components: []workv1alpha2.TargetComponent{
-					{Name: "jobmanager", Replicas: 2},
-					{Name: "taskmanager", Replicas: 4},
-				},
-			},
-		},
+		}},
 	}
 
 	got, err := calculateMultiTemplateAvailableSetsForScale(context.Background(), multiTemplateEstimationContext{

--- a/pkg/scheduler/core/estimation_test.go
+++ b/pkg/scheduler/core/estimation_test.go
@@ -35,7 +35,8 @@ import (
 type mockReplicaEstimator struct {
 	maxAvailableComponentSetsResponse []estimatorclient.ComponentSetEstimationResponse
 	maxAvailableComponentSetsError    error
-	lastComponentSetRequest           estimatorclient.ComponentSetEstimationRequest
+	componentSetRequests              []estimatorclient.ComponentSetEstimationRequest
+	maxAvailableComponentSetsFunc     func(estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error)
 }
 
 func (m *mockReplicaEstimator) MaxAvailableReplicas(_ context.Context, _ estimatorclient.ReplicaEstimationRequest) ([]workv1alpha2.TargetCluster, error) {
@@ -43,7 +44,10 @@ func (m *mockReplicaEstimator) MaxAvailableReplicas(_ context.Context, _ estimat
 }
 
 func (m *mockReplicaEstimator) MaxAvailableComponentSets(_ context.Context, req estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
-	m.lastComponentSetRequest = req
+	m.componentSetRequests = append(m.componentSetRequests, req)
+	if m.maxAvailableComponentSetsFunc != nil {
+		return m.maxAvailableComponentSetsFunc(req)
+	}
 	return m.maxAvailableComponentSetsResponse, m.maxAvailableComponentSetsError
 }
 
@@ -327,6 +331,287 @@ func Test_calculateMultiTemplateAvailableSets(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+func Test_componentReplicaScaleDirection(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  []workv1alpha2.Component
+		accepted []workv1alpha2.TargetComponent
+		want     componentScaleDirection
+	}{
+		{
+			name:     "equal snapshots ignore order",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "taskmanager", Replicas: 4}, {Name: "jobmanager", Replicas: 1}},
+			want:     componentScaleEqual,
+		},
+		{
+			name:     "pure scale up",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			want:     componentScaleUp,
+		},
+		{
+			name:     "pure scale down",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 2}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			want:     componentScaleDown,
+		},
+		{
+			name:     "mixed scale",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 2}, {Name: "taskmanager", Replicas: 4}},
+			want:     componentScaleMixed,
+		},
+		{
+			name:    "missing accepted snapshot",
+			desired: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}},
+			want:    componentScaleUnknown,
+		},
+		{
+			name:     "component names differ",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "historyserver", Replicas: 4}},
+			want:     componentScaleUnknown,
+		},
+		{
+			name:     "accepted names are duplicated",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "jobmanager", Replicas: 4}},
+			want:     componentScaleUnknown,
+		},
+		{
+			name:     "desired names are duplicated",
+			desired:  []workv1alpha2.Component{{Name: "worker", Replicas: 2}, {Name: "worker", Replicas: 3}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "worker", Replicas: 2}, {Name: "server", Replicas: 1}},
+			want:     componentScaleUnknown,
+		},
+		{
+			name:     "desired name is empty",
+			desired:  []workv1alpha2.Component{{Name: "", Replicas: 1}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "", Replicas: 1}},
+			want:     componentScaleUnknown,
+		},
+		{
+			name: "empty snapshots",
+			want: componentScaleUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, componentReplicaScaleDirection(tt.desired, tt.accepted))
+		})
+	}
+}
+
+func Test_calculateMultiTemplateAvailableSetsForScale(t *testing.T) {
+	clusters := []*clusterv1alpha1.Cluster{helper.NewCluster("cluster1")}
+	newSpec := func(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) *workv1alpha2.ResourceBindingSpec {
+		return &workv1alpha2.ResourceBindingSpec{
+			Resource:   workv1alpha2.ObjectReference{Namespace: "default", Name: "flink"},
+			Components: desired,
+			Clusters:   []workv1alpha2.TargetCluster{{Name: "cluster1", Components: accepted}},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		spec           *workv1alpha2.ResourceBindingSpec
+		wantComponents []workv1alpha2.Component
+		wantResult     []workv1alpha2.TargetCluster
+		wantError      string
+		wantCalls      int
+	}{
+		{
+			name: "scale up estimates only the positive delta",
+			spec: newSpec(
+				[]workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6, ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{PriorityClassName: "high-priority"}},
+				},
+				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			),
+			wantComponents: []workv1alpha2.Component{{
+				Name:                "taskmanager",
+				Replicas:            2,
+				ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{PriorityClassName: "high-priority"},
+			}},
+			wantResult: []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: 1}},
+			wantCalls:  1,
+		},
+		{
+			name: "pure scale down skips estimation",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 2}},
+				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			),
+			wantResult: []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: scaleDownAvailableComponentSets}},
+		},
+		{
+			name: "existing target without accepted snapshot is unknown",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+				nil,
+			),
+			wantError: "requires a comparable accepted component snapshot",
+		},
+		{
+			name: "equal state is not a scale operation",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+				[]workv1alpha2.TargetComponent{{Name: "taskmanager", Replicas: 4}, {Name: "jobmanager", Replicas: 1}},
+			),
+			wantError: "requires a replica change",
+		},
+		{
+			name: "mixed scale is unsupported",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 2}, {Name: "taskmanager", Replicas: 4}},
+			),
+			wantError: "mixed component scaling is not supported",
+		},
+		{
+			name: "duplicate desired names are rejected",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "worker", Replicas: 2}, {Name: "worker", Replicas: 3}},
+				[]workv1alpha2.TargetComponent{{Name: "worker", Replicas: 2}, {Name: "server", Replicas: 1}},
+			),
+			wantError: "unique, non-empty names",
+		},
+		{
+			name: "empty desired name is rejected",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "", Replicas: 2}},
+				[]workv1alpha2.TargetComponent{{Name: "", Replicas: 1}},
+			),
+			wantError: "unique, non-empty names",
+		},
+		{
+			name: "partial accepted snapshot is unknown",
+			spec: newSpec(
+				[]workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+				[]workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}},
+			),
+			wantError: "requires a comparable accepted component snapshot",
+		},
+		{
+			name:      "empty desired snapshot is rejected",
+			spec:      newSpec(nil, nil),
+			wantError: "unique, non-empty names",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			estimator := &mockReplicaEstimator{}
+			estimator.maxAvailableComponentSetsFunc = func(req estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
+				assert.Equal(t, clusters, req.Clusters)
+				assert.Equal(t, tt.wantComponents, req.Components)
+				return []estimatorclient.ComponentSetEstimationResponse{{Name: "cluster1", Sets: 1}}, nil
+			}
+
+			got, err := calculateMultiTemplateAvailableSetsForScale(context.Background(), multiTemplateEstimationContext{
+				estimator: estimator,
+				clusters:  clusters,
+				spec:      tt.spec,
+			})
+			if tt.wantError != "" {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.wantError)
+				}
+				assert.Nil(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantResult, got)
+			}
+			assert.Len(t, estimator.componentSetRequests, tt.wantCalls)
+		})
+	}
+}
+
+func Test_calculateMultiTemplateAvailableSetsForScaleUsesFullDesiredOnlyForNewCandidates(t *testing.T) {
+	desired := []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 5}}
+	clusters := []*clusterv1alpha1.Cluster{helper.NewCluster("cluster1"), helper.NewCluster("cluster2")}
+	estimator := &mockReplicaEstimator{}
+	estimator.maxAvailableComponentSetsFunc = func(req estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
+		switch req.Clusters[0].Name {
+		case "cluster2":
+			assert.Equal(t, []*clusterv1alpha1.Cluster{clusters[1]}, req.Clusters)
+			assert.Equal(t, []workv1alpha2.Component{{Name: "taskmanager", Replicas: 2}}, req.Components)
+		case "cluster1":
+			assert.Equal(t, []*clusterv1alpha1.Cluster{clusters[0]}, req.Clusters)
+			assert.Equal(t, desired, req.Components)
+		default:
+			t.Fatalf("unexpected cluster request: %s", req.Clusters[0].Name)
+		}
+		return []estimatorclient.ComponentSetEstimationResponse{{Name: req.Clusters[0].Name, Sets: 1}}, nil
+	}
+	spec := &workv1alpha2.ResourceBindingSpec{
+		Resource:   workv1alpha2.ObjectReference{Namespace: "default", Name: "flink"},
+		Components: desired,
+		Clusters: []workv1alpha2.TargetCluster{{
+			Name: "cluster2",
+			Components: []workv1alpha2.TargetComponent{
+				{Name: "jobmanager", Replicas: 1},
+				{Name: "taskmanager", Replicas: 3},
+			},
+		}},
+	}
+
+	got, err := calculateMultiTemplateAvailableSetsForScale(context.Background(), multiTemplateEstimationContext{
+		estimator: estimator,
+		clusters:  clusters,
+		spec:      spec,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []workv1alpha2.TargetCluster{{Name: "cluster1", Replicas: 1}, {Name: "cluster2", Replicas: 1}}, got)
+	assert.Len(t, estimator.componentSetRequests, 2)
+}
+
+func Test_calculateMultiTemplateAvailableSetsForScaleRejectsBeforeCallingEstimator(t *testing.T) {
+	clusters := []*clusterv1alpha1.Cluster{helper.NewCluster("cluster1"), helper.NewCluster("cluster2")}
+	estimator := &mockReplicaEstimator{}
+	estimator.maxAvailableComponentSetsFunc = func(estimatorclient.ComponentSetEstimationRequest) ([]estimatorclient.ComponentSetEstimationResponse, error) {
+		t.Fatal("estimator must not be called before every transition is classified")
+		return nil, nil
+	}
+	spec := &workv1alpha2.ResourceBindingSpec{
+		Resource: workv1alpha2.ObjectReference{Namespace: "default", Name: "flink"},
+		Components: []workv1alpha2.Component{
+			{Name: "jobmanager", Replicas: 1},
+			{Name: "taskmanager", Replicas: 6},
+		},
+		Clusters: []workv1alpha2.TargetCluster{
+			{
+				Name: "cluster1",
+				Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+				},
+			},
+			{
+				Name: "cluster2",
+				Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 2},
+					{Name: "taskmanager", Replicas: 4},
+				},
+			},
+		},
+	}
+
+	got, err := calculateMultiTemplateAvailableSetsForScale(context.Background(), multiTemplateEstimationContext{
+		estimator: estimator,
+		clusters:  clusters,
+		spec:      spec,
+	})
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "mixed component scaling is not supported")
+	}
+	assert.Nil(t, got)
+	assert.Empty(t, estimator.componentSetRequests)
 }
 
 func Test_buildAssumedWorkloadsByCluster(t *testing.T) {

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -41,6 +41,7 @@ type ScheduleAlgorithm interface {
 // ScheduleAlgorithmOption represents the option for ScheduleAlgorithm.
 type ScheduleAlgorithmOption struct {
 	EnableEmptyWorkloadPropagation bool
+	IsMultiComponentScale          bool
 }
 
 // ScheduleResult includes the clusters selected.
@@ -79,6 +80,10 @@ func (g *genericScheduler) Schedule(
 	if err != nil {
 		return result, fmt.Errorf("failed to find fit clusters: %w", err)
 	}
+	componentScale := scheduleAlgorithmOption != nil && scheduleAlgorithmOption.IsMultiComponentScale
+	if componentScale {
+		feasibleClusters = retainScheduledClusters(feasibleClusters, spec.Clusters)
+	}
 
 	// Short path for case no cluster fit.
 	if len(feasibleClusters) == 0 {
@@ -95,7 +100,7 @@ func (g *genericScheduler) Schedule(
 	}
 	klog.V(4).Infof("Feasible clusters scores: %v", clustersScore)
 
-	selectedClusters, err := g.selectClusters(clustersScore, spec.Placement, spec, status)
+	selectedClusters, err := g.selectClusters(clustersScore, spec.Placement, spec, status, componentScale)
 	if err != nil {
 		return result, fmt.Errorf("failed to select clusters: %w", err)
 	}
@@ -194,8 +199,24 @@ func (g *genericScheduler) prioritizeClusters(
 }
 
 func (g *genericScheduler) selectClusters(clustersScore framework.ClusterScoreList,
-	placement *policyv1alpha1.Placement, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus) ([]spreadconstraint.ClusterDetailInfo, error) {
-	return SelectClusters(clustersScore, placement, spec, status, g.schedulerCache.AssigningResourceBindings())
+	placement *policyv1alpha1.Placement, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus,
+	componentScale bool) ([]spreadconstraint.ClusterDetailInfo, error) {
+	return SelectClusters(clustersScore, placement, spec, status, g.schedulerCache.AssigningResourceBindings(), componentScale)
+}
+
+func retainScheduledClusters(feasibleClusters []*clusterv1alpha1.Cluster, scheduledClusters []workv1alpha2.TargetCluster) []*clusterv1alpha1.Cluster {
+	targets := make(map[string]struct{}, len(scheduledClusters))
+	for i := range scheduledClusters {
+		targets[scheduledClusters[i].Name] = struct{}{}
+	}
+
+	retained := make([]*clusterv1alpha1.Cluster, 0, len(feasibleClusters))
+	for _, cluster := range feasibleClusters {
+		if _, exists := targets[cluster.Name]; exists {
+			retained = append(retained, cluster)
+		}
+	}
+	return retained
 }
 
 func (g *genericScheduler) assignReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec,

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -20,11 +20,26 @@ import (
 	"reflect"
 	"testing"
 
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/scheduler/core/spreadconstraint"
 	"github.com/karmada-io/karmada/test/helper"
 )
+
+func TestRetainScheduledClusters(t *testing.T) {
+	cluster1 := helper.NewCluster(ClusterMember1)
+	cluster2 := helper.NewCluster(ClusterMember2)
+
+	got := retainScheduledClusters(
+		[]*clusterv1alpha1.Cluster{cluster1, cluster2},
+		[]workv1alpha2.TargetCluster{{Name: ClusterMember2}},
+	)
+
+	if !reflect.DeepEqual(got, []*clusterv1alpha1.Cluster{cluster2}) {
+		t.Fatalf("retainScheduledClusters() = %v, want only %s", got, ClusterMember2)
+	}
+}
 
 type testcase struct {
 	name     string

--- a/pkg/scheduler/core/util.go
+++ b/pkg/scheduler/core/util.go
@@ -55,13 +55,7 @@ func getDefaultWeightPreference(clusters []spreadconstraint.ClusterDetailInfo) *
 }
 
 func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha2.ResourceBindingSpec, assigningCache *schedulercache.AssigningResourceBindingCache, componentScale bool) []workv1alpha2.TargetCluster {
-	availableTargetClusters := make([]workv1alpha2.TargetCluster, len(clusters))
-
-	// Set the boundary.
-	for i := range availableTargetClusters {
-		availableTargetClusters[i].Name = clusters[i].Name
-		availableTargetClusters[i].Replicas = math.MaxInt32
-	}
+	availableTargetClusters := targetClustersWithReplicas(clusters, math.MaxInt32)
 
 	// For non-workload, like ServiceAccount, ConfigMap, Secret and etc, it's unnecessary to calculate available replicas in member clusters.
 	// See issue: https://github.com/karmada-io/karmada/issues/3743.
@@ -72,20 +66,8 @@ func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha
 		return availableTargetClusters
 	}
 	if componentScale {
-		if len(clusters) != 1 || len(spec.Clusters) != 1 || clusters[0].Name != spec.Clusters[0].Name {
-			for i := range availableTargetClusters {
-				availableTargetClusters[i].Replicas = 0
-			}
-			return availableTargetClusters
-		}
-		switch componentReplicaScaleDirection(spec.Components, spec.Clusters[0].Components) {
-		case componentScaleDown:
-			return []workv1alpha2.TargetCluster{{Name: clusters[0].Name, Replicas: minimumAvailableComponentSets}}
-		case componentScaleUp:
-			// Scale-up capacity is calculated by the component-scale planner below.
-		default:
-			availableTargetClusters[0].Replicas = 0
-			return availableTargetClusters
+		if result, resolved := resolveComponentScaleWithoutEstimator(clusters, spec); resolved {
+			return result
 		}
 	}
 
@@ -117,18 +99,41 @@ func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha
 
 	// In most cases, the target cluster max available replicas should not be MaxInt32 unless the workload is best-effort
 	// and the scheduler-estimator has not been enabled. So we set the replicas to spec.Replicas for avoiding overflow.
+	fallbackReplicas := spec.Replicas
+	if componentScale {
+		fallbackReplicas = 0
+	}
 	for i := range availableTargetClusters {
 		if availableTargetClusters[i].Replicas == math.MaxInt32 {
-			if componentScale {
-				availableTargetClusters[i].Replicas = 0
-			} else {
-				availableTargetClusters[i].Replicas = spec.Replicas
-			}
+			availableTargetClusters[i].Replicas = fallbackReplicas
 		}
 	}
 
 	klog.V(4).Infof("Target cluster calculated by estimators (available cluster && maxAvailableReplicas): %v", availableTargetClusters)
 	return availableTargetClusters
+}
+
+func resolveComponentScaleWithoutEstimator(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha2.ResourceBindingSpec) ([]workv1alpha2.TargetCluster, bool) {
+	if len(clusters) != 1 || len(spec.Clusters) != 1 || clusters[0].Name != spec.Clusters[0].Name {
+		return targetClustersWithReplicas(clusters, 0), true
+	}
+
+	switch componentReplicaScaleDirection(spec.Components, spec.Clusters[0].Components) {
+	case componentScaleDown:
+		return targetClustersWithReplicas(clusters, minimumAvailableComponentSets), true
+	case componentScaleUp:
+		return nil, false
+	default:
+		return targetClustersWithReplicas(clusters, 0), true
+	}
+}
+
+func targetClustersWithReplicas(clusters []*clusterv1alpha1.Cluster, replicas int32) []workv1alpha2.TargetCluster {
+	result := make([]workv1alpha2.TargetCluster, len(clusters))
+	for i := range clusters {
+		result[i] = workv1alpha2.TargetCluster{Name: clusters[i].Name, Replicas: replicas}
+	}
+	return result
 }
 
 // runReplicaEstimator dispatches to the multi-template or single-template estimation path.

--- a/pkg/scheduler/core/util.go
+++ b/pkg/scheduler/core/util.go
@@ -54,7 +54,7 @@ func getDefaultWeightPreference(clusters []spreadconstraint.ClusterDetailInfo) *
 	}
 }
 
-func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha2.ResourceBindingSpec, assigningCache *schedulercache.AssigningResourceBindingCache) []workv1alpha2.TargetCluster {
+func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha2.ResourceBindingSpec, assigningCache *schedulercache.AssigningResourceBindingCache, componentScale bool) []workv1alpha2.TargetCluster {
 	availableTargetClusters := make([]workv1alpha2.TargetCluster, len(clusters))
 
 	// Set the boundary.
@@ -70,6 +70,23 @@ func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha
 		klog.V(4).Infof("Do not calculate available replicas for non-workload(%s, kind=%s, %s).", spec.Resource.APIVersion,
 			spec.Resource.Kind, namespacedKey)
 		return availableTargetClusters
+	}
+	if componentScale {
+		if len(clusters) != 1 || len(spec.Clusters) != 1 || clusters[0].Name != spec.Clusters[0].Name {
+			for i := range availableTargetClusters {
+				availableTargetClusters[i].Replicas = 0
+			}
+			return availableTargetClusters
+		}
+		switch componentReplicaScaleDirection(spec.Components, spec.Clusters[0].Components) {
+		case componentScaleDown:
+			return []workv1alpha2.TargetCluster{{Name: clusters[0].Name, Replicas: minimumAvailableComponentSets}}
+		case componentScaleUp:
+			// Scale-up capacity is calculated by the component-scale planner below.
+		default:
+			availableTargetClusters[0].Replicas = 0
+			return availableTargetClusters
+		}
 	}
 
 	// Get the minimum value of MaxAvailableReplicas in terms of all estimators.
@@ -90,6 +107,7 @@ func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha
 			clusters:         clusters,
 			spec:             spec,
 			assumedWorkloads: assumedWorkloads,
+			componentScale:   componentScale,
 		})
 		if err != nil {
 			continue
@@ -101,7 +119,11 @@ func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha
 	// and the scheduler-estimator has not been enabled. So we set the replicas to spec.Replicas for avoiding overflow.
 	for i := range availableTargetClusters {
 		if availableTargetClusters[i].Replicas == math.MaxInt32 {
-			availableTargetClusters[i].Replicas = spec.Replicas
+			if componentScale {
+				availableTargetClusters[i].Replicas = 0
+			} else {
+				availableTargetClusters[i].Replicas = spec.Replicas
+			}
 		}
 	}
 
@@ -124,17 +146,22 @@ type replicaEstimationContext struct {
 	clusters         []*clusterv1alpha1.Cluster
 	spec             *workv1alpha2.ResourceBindingSpec
 	assumedWorkloads map[string][]estimatorclient.AssumedWorkload
+	componentScale   bool
 }
 
 // runMultiTemplateEstimator handles estimation for workloads with multiple pod templates.
 func runMultiTemplateEstimator(ctx context.Context, in replicaEstimationContext) ([]workv1alpha2.TargetCluster, error) {
-	return calculateMultiTemplateAvailableSets(ctx, multiTemplateEstimationContext{
+	estCtx := multiTemplateEstimationContext{
 		estimator:        in.estimator,
 		estimatorName:    in.estimatorName,
 		clusters:         in.clusters,
 		spec:             in.spec,
 		assumedWorkloads: in.assumedWorkloads,
-	})
+	}
+	if in.componentScale {
+		return calculateMultiTemplateAvailableSetsForScale(ctx, estCtx)
+	}
+	return calculateMultiTemplateAvailableSets(ctx, estCtx)
 }
 
 // runSingleTemplateEstimator handles estimation for workloads with a single pod template.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -428,7 +428,11 @@ func (s *Scheduler) doScheduleBinding(namespace, name string) (err error) {
 	if util.IsBindingReplicasChanged(&rb.Spec, rb.Spec.Placement.ReplicaScheduling) {
 		// binding replicas changed, need reschedule
 		klog.Infof("Reschedule ResourceBinding(%s/%s) as replicas scaled down or scaled up", namespace, name)
-		err = s.scheduleResourceBinding(rb)
+		if isMultiComponentScale(&rb.Spec) {
+			err = s.scheduleResourceBindingForComponentScale(rb)
+		} else {
+			err = s.scheduleResourceBinding(rb)
+		}
 		metrics.BindingSchedule(string(ScaleSchedule), utilmetrics.DurationInSeconds(start), err)
 		return err
 	}
@@ -504,7 +508,11 @@ func (s *Scheduler) doScheduleClusterBinding(name string) (err error) {
 	if util.IsBindingReplicasChanged(&crb.Spec, crb.Spec.Placement.ReplicaScheduling) {
 		// binding replicas changed, need reschedule
 		klog.Infof("Reschedule ClusterResourceBinding(%s) as replicas scaled down or scaled up", name)
-		err = s.scheduleClusterResourceBinding(crb)
+		if isMultiComponentScale(&crb.Spec) {
+			err = s.scheduleClusterResourceBindingForComponentScale(crb)
+		} else {
+			err = s.scheduleClusterResourceBinding(crb)
+		}
 		metrics.BindingSchedule(string(ScaleSchedule), utilmetrics.DurationInSeconds(start), err)
 		return err
 	}
@@ -568,7 +576,21 @@ func (s *Scheduler) HasTerminatingTargetClusters(bindingSpec *workv1alpha2.Resou
 	return false
 }
 
-func (s *Scheduler) scheduleResourceBinding(rb *workv1alpha2.ResourceBinding) (err error) {
+func isMultiComponentScale(spec *workv1alpha2.ResourceBindingSpec) bool {
+	return features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) && len(spec.Components) > 1 &&
+		(spec.SchedulerName == "" || spec.SchedulerName == DefaultScheduler) &&
+		len(spec.Clusters) == 1 && len(spec.Clusters[0].Components) > 0
+}
+
+func (s *Scheduler) scheduleResourceBinding(rb *workv1alpha2.ResourceBinding) error {
+	return s.scheduleResourceBindingWithOptions(rb, false)
+}
+
+func (s *Scheduler) scheduleResourceBindingForComponentScale(rb *workv1alpha2.ResourceBinding) error {
+	return s.scheduleResourceBindingWithOptions(rb, true)
+}
+
+func (s *Scheduler) scheduleResourceBindingWithOptions(rb *workv1alpha2.ResourceBinding, componentScale bool) (err error) {
 	defer func() {
 		condition, ignoreErr := getConditionByError(err)
 		if updateErr := patchBindingStatusCondition(s.KarmadaClient, rb, condition); updateErr != nil {
@@ -580,14 +602,20 @@ func (s *Scheduler) scheduleResourceBinding(rb *workv1alpha2.ResourceBinding) (e
 			err = nil
 		}
 	}()
-
 	if rb.Spec.Placement.ClusterAffinities != nil {
+		if componentScale {
+			return s.scheduleResourceBindingWithClusterAffinityAndOptions(rb, true)
+		}
 		return s.scheduleResourceBindingWithClusterAffinities(rb)
 	}
-	return s.scheduleResourceBindingWithClusterAffinity(rb)
+	return s.scheduleResourceBindingWithClusterAffinityAndOptions(rb, componentScale)
 }
 
 func (s *Scheduler) scheduleResourceBindingWithClusterAffinity(rb *workv1alpha2.ResourceBinding) error {
+	return s.scheduleResourceBindingWithClusterAffinityAndOptions(rb, false)
+}
+
+func (s *Scheduler) scheduleResourceBindingWithClusterAffinityAndOptions(rb *workv1alpha2.ResourceBinding, componentScale bool) error {
 	klog.V(4).InfoS("Begin scheduling ResourceBinding with ClusterAffinity", "ResourceBinding", klog.KObj(rb))
 	defer klog.V(4).InfoS("End scheduling ResourceBinding with ClusterAffinity", "ResourceBinding", klog.KObj(rb))
 
@@ -597,7 +625,14 @@ func (s *Scheduler) scheduleResourceBindingWithClusterAffinity(rb *workv1alpha2.
 		return fmt.Errorf("failed to marshal placement of ResourceBinding %s: %w", rb.GetName(), err)
 	}
 
-	scheduleResult, err := s.Algorithm.Schedule(context.TODO(), &rb.Spec, &rb.Status, &core.ScheduleAlgorithmOption{EnableEmptyWorkloadPropagation: s.enableEmptyWorkloadPropagation})
+	scheduleResult, err := s.Algorithm.Schedule(context.TODO(), &rb.Spec, &rb.Status, &core.ScheduleAlgorithmOption{
+		EnableEmptyWorkloadPropagation: s.enableEmptyWorkloadPropagation,
+		IsMultiComponentScale:          componentScale,
+	})
+	if componentScale && err != nil {
+		s.recordScheduleResultEventForResourceBinding(rb, nil, err)
+		return err
+	}
 	var fitErr *framework.FitError
 	// in case of no cluster error, can not return but continue to patch(cleanup) the result.
 	if err != nil && !errors.As(err, &fitErr) {
@@ -795,7 +830,15 @@ func singleTemplateAsComponents(name string, replicas int32, reqs *workv1alpha2.
 	return []workv1alpha2.Component{c}
 }
 
-func (s *Scheduler) scheduleClusterResourceBinding(crb *workv1alpha2.ClusterResourceBinding) (err error) {
+func (s *Scheduler) scheduleClusterResourceBinding(crb *workv1alpha2.ClusterResourceBinding) error {
+	return s.scheduleClusterResourceBindingWithOptions(crb, false)
+}
+
+func (s *Scheduler) scheduleClusterResourceBindingForComponentScale(crb *workv1alpha2.ClusterResourceBinding) error {
+	return s.scheduleClusterResourceBindingWithOptions(crb, true)
+}
+
+func (s *Scheduler) scheduleClusterResourceBindingWithOptions(crb *workv1alpha2.ClusterResourceBinding, componentScale bool) (err error) {
 	defer func() {
 		condition, ignoreErr := getConditionByError(err)
 		if updateErr := patchClusterBindingStatusCondition(s.KarmadaClient, crb, condition); updateErr != nil {
@@ -807,14 +850,20 @@ func (s *Scheduler) scheduleClusterResourceBinding(crb *workv1alpha2.ClusterReso
 			err = nil
 		}
 	}()
-
 	if crb.Spec.Placement.ClusterAffinities != nil {
+		if componentScale {
+			return s.scheduleClusterResourceBindingWithClusterAffinityAndOptions(crb, true)
+		}
 		return s.scheduleClusterResourceBindingWithClusterAffinities(crb)
 	}
-	return s.scheduleClusterResourceBindingWithClusterAffinity(crb)
+	return s.scheduleClusterResourceBindingWithClusterAffinityAndOptions(crb, componentScale)
 }
 
 func (s *Scheduler) scheduleClusterResourceBindingWithClusterAffinity(crb *workv1alpha2.ClusterResourceBinding) error {
+	return s.scheduleClusterResourceBindingWithClusterAffinityAndOptions(crb, false)
+}
+
+func (s *Scheduler) scheduleClusterResourceBindingWithClusterAffinityAndOptions(crb *workv1alpha2.ClusterResourceBinding, componentScale bool) error {
 	klog.V(4).InfoS("Begin scheduling ClusterResourceBinding with ClusterAffinity", "ClusterResourceBinding", klog.KObj(crb))
 	defer klog.V(4).InfoS("End scheduling ClusterResourceBinding with ClusterAffinity", "ClusterResourceBinding", klog.KObj(crb))
 
@@ -824,7 +873,14 @@ func (s *Scheduler) scheduleClusterResourceBindingWithClusterAffinity(crb *workv
 		return fmt.Errorf("failed to marshal placement of ClusterResourceBinding %s: %w", crb.GetName(), err)
 	}
 
-	scheduleResult, err := s.Algorithm.Schedule(context.TODO(), &crb.Spec, &crb.Status, &core.ScheduleAlgorithmOption{EnableEmptyWorkloadPropagation: s.enableEmptyWorkloadPropagation})
+	scheduleResult, err := s.Algorithm.Schedule(context.TODO(), &crb.Spec, &crb.Status, &core.ScheduleAlgorithmOption{
+		EnableEmptyWorkloadPropagation: s.enableEmptyWorkloadPropagation,
+		IsMultiComponentScale:          componentScale,
+	})
+	if componentScale && err != nil {
+		s.recordScheduleResultEventForClusterResourceBinding(crb, nil, err)
+		return err
+	}
 	var fitErr *framework.FitError
 	// in case of no cluster error, can not return but continue to patch(cleanup) the result.
 	if err != nil && !errors.As(err, &fitErr) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -263,7 +263,13 @@ func TestDoScheduleBinding(t *testing.T) {
 		{
 			name: "binding with component replicas changed",
 			binding: &workv1alpha2.ResourceBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-binding-components", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-binding-components",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.PolicyPlacementAnnotation: `{"replicaScheduling":{"replicaSchedulingType":"Divided"}}`,
+					},
+				},
 				Spec: workv1alpha2.ResourceBindingSpec{
 					Components: []workv1alpha2.Component{
 						{Name: "jobmanager", Replicas: 1},
@@ -423,7 +429,12 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 		{
 			name: "cluster binding with component replicas changed",
 			binding: &workv1alpha2.ClusterResourceBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-binding-components"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-binding-components",
+					Annotations: map[string]string{
+						util.PolicyPlacementAnnotation: `{"replicaScheduling":{"replicaSchedulingType":"Divided"}}`,
+					},
+				},
 				Spec: workv1alpha2.ResourceBindingSpec{
 					Components: []workv1alpha2.Component{
 						{Name: "jobmanager", Replicas: 1},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -186,6 +186,7 @@ func TestDoScheduleBinding(t *testing.T) {
 		expectError      bool
 		expectedClusters []workv1alpha2.TargetCluster
 		expectedEvent    string
+		enableComponents bool
 	}{
 		{
 			name: "binding with changed placement",
@@ -259,10 +260,43 @@ func TestDoScheduleBinding(t *testing.T) {
 			},
 			expectedEvent: "Normal ScheduleBindingSucceed",
 		},
+		{
+			name: "binding with component replicas changed",
+			binding: &workv1alpha2.ResourceBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-binding-components", Namespace: "default"},
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Components: []workv1alpha2.Component{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 6},
+					},
+					Clusters: []workv1alpha2.TargetCluster{{
+						Name: "cluster1",
+						Components: []workv1alpha2.TargetComponent{
+							{Name: "jobmanager", Replicas: 1},
+							{Name: "taskmanager", Replicas: 4},
+						},
+					}},
+					Placement: &policyv1alpha1.Placement{ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+						ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided,
+					}},
+				},
+			},
+			expectSchedule: true,
+			expectedClusters: []workv1alpha2.TargetCluster{{
+				Name: "cluster1",
+				Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6},
+				},
+			}},
+			expectedEvent:    "Normal ScheduleBindingSucceed",
+			enableComponents: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer setFeatureGateDuringTest(t, features.FeatureGate, features.MultiplePodTemplatesScheduling, tt.enableComponents)()
 			fakeClient := karmadafake.NewClientset(tt.binding)
 			fakeRecorder := record.NewFakeRecorder(10)
 			mockAlgorithm := &mockAlgorithm{
@@ -315,6 +349,7 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 		expectError      bool
 		expectedClusters []workv1alpha2.TargetCluster
 		expectedEvent    string
+		enableComponents bool
 	}{
 		{
 			name: "cluster binding with changed placement",
@@ -385,10 +420,43 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 			},
 			expectedEvent: "Normal ScheduleBindingSucceed",
 		},
+		{
+			name: "cluster binding with component replicas changed",
+			binding: &workv1alpha2.ClusterResourceBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-binding-components"},
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Components: []workv1alpha2.Component{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 6},
+					},
+					Clusters: []workv1alpha2.TargetCluster{{
+						Name: "cluster1",
+						Components: []workv1alpha2.TargetComponent{
+							{Name: "jobmanager", Replicas: 1},
+							{Name: "taskmanager", Replicas: 4},
+						},
+					}},
+					Placement: &policyv1alpha1.Placement{ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+						ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided,
+					}},
+				},
+			},
+			expectSchedule: true,
+			expectedClusters: []workv1alpha2.TargetCluster{{
+				Name: "cluster1",
+				Components: []workv1alpha2.TargetComponent{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6},
+				},
+			}},
+			expectedEvent:    "Normal ScheduleBindingSucceed",
+			enableComponents: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer setFeatureGateDuringTest(t, features.FeatureGate, features.MultiplePodTemplatesScheduling, tt.enableComponents)()
 			fakeClient := karmadafake.NewClientset(tt.binding)
 			fakeRecorder := record.NewFakeRecorder(10)
 			mockAlgorithm := &mockAlgorithm{

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -187,6 +187,7 @@ func TestDoScheduleBinding(t *testing.T) {
 		expectedClusters []workv1alpha2.TargetCluster
 		expectedEvent    string
 		enableComponents bool
+		componentScale   bool
 	}{
 		{
 			name: "binding with changed placement",
@@ -297,6 +298,7 @@ func TestDoScheduleBinding(t *testing.T) {
 			}},
 			expectedEvent:    "Normal ScheduleBindingSucceed",
 			enableComponents: true,
+			componentScale:   true,
 		},
 	}
 
@@ -306,7 +308,8 @@ func TestDoScheduleBinding(t *testing.T) {
 			fakeClient := karmadafake.NewClientset(tt.binding)
 			fakeRecorder := record.NewFakeRecorder(10)
 			mockAlgorithm := &mockAlgorithm{
-				scheduleFunc: func(context.Context, *workv1alpha2.ResourceBindingSpec, *workv1alpha2.ResourceBindingStatus, *core.ScheduleAlgorithmOption) (core.ScheduleResult, error) {
+				scheduleFunc: func(_ context.Context, _ *workv1alpha2.ResourceBindingSpec, _ *workv1alpha2.ResourceBindingStatus, option *core.ScheduleAlgorithmOption) (core.ScheduleResult, error) {
+					assert.Equal(t, tt.componentScale, option.IsMultiComponentScale)
 					return core.ScheduleResult{SuggestedClusters: tt.expectedClusters}, nil
 				},
 			}
@@ -356,6 +359,7 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 		expectedClusters []workv1alpha2.TargetCluster
 		expectedEvent    string
 		enableComponents bool
+		componentScale   bool
 	}{
 		{
 			name: "cluster binding with changed placement",
@@ -462,6 +466,7 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 			}},
 			expectedEvent:    "Normal ScheduleBindingSucceed",
 			enableComponents: true,
+			componentScale:   true,
 		},
 	}
 
@@ -471,7 +476,8 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 			fakeClient := karmadafake.NewClientset(tt.binding)
 			fakeRecorder := record.NewFakeRecorder(10)
 			mockAlgorithm := &mockAlgorithm{
-				scheduleFunc: func(context.Context, *workv1alpha2.ResourceBindingSpec, *workv1alpha2.ResourceBindingStatus, *core.ScheduleAlgorithmOption) (core.ScheduleResult, error) {
+				scheduleFunc: func(_ context.Context, _ *workv1alpha2.ResourceBindingSpec, _ *workv1alpha2.ResourceBindingStatus, option *core.ScheduleAlgorithmOption) (core.ScheduleResult, error) {
+					assert.Equal(t, tt.componentScale, option.IsMultiComponentScale)
 					return core.ScheduleResult{SuggestedClusters: tt.expectedClusters}, nil
 				},
 			}
@@ -508,6 +514,40 @@ func TestDoScheduleClusterBinding(t *testing.T) {
 			default:
 				t.Errorf("Expected an event to be recorded")
 			}
+		})
+	}
+}
+
+func TestIsMultiComponentScale(t *testing.T) {
+	newSpec := func() *workv1alpha2.ResourceBindingSpec {
+		return &workv1alpha2.ResourceBindingSpec{
+			Components: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			Clusters: []workv1alpha2.TargetCluster{{Name: "cluster1", Components: []workv1alpha2.TargetComponent{
+				{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4},
+			}}},
+		}
+	}
+	tests := []struct {
+		name     string
+		feature  bool
+		mutate   func(*workv1alpha2.ResourceBindingSpec)
+		expected bool
+	}{
+		{name: "default scheduler", feature: true, expected: true},
+		{name: "explicit default scheduler", feature: true, mutate: func(spec *workv1alpha2.ResourceBindingSpec) { spec.SchedulerName = DefaultScheduler }, expected: true},
+		{name: "custom scheduler keeps old routing", feature: true, mutate: func(spec *workv1alpha2.ResourceBindingSpec) { spec.SchedulerName = "custom-scheduler" }},
+		{name: "feature disabled", expected: false},
+		{name: "missing accepted snapshot", feature: true, mutate: func(spec *workv1alpha2.ResourceBindingSpec) { spec.Clusters[0].Components = nil }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer setFeatureGateDuringTest(t, features.FeatureGate, features.MultiplePodTemplatesScheduling, tt.feature)()
+			spec := newSpec()
+			if tt.mutate != nil {
+				tt.mutate(spec)
+			}
+			assert.Equal(t, tt.expected, isMultiComponentScale(spec))
 		})
 	}
 }
@@ -611,6 +651,104 @@ func TestScheduleResourceBindingWithClusterAffinity(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestComponentScaleSchedulingCommitsOnlySuccessfulResult(t *testing.T) {
+	accepted := []workv1alpha2.TargetCluster{{Name: "cluster1", Components: []workv1alpha2.TargetComponent{
+		{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4},
+	}}}
+	desired := []workv1alpha2.TargetCluster{{Name: "cluster1", Components: []workv1alpha2.TargetComponent{
+		{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6},
+	}}}
+
+	t.Run("ResourceBinding", func(t *testing.T) {
+		tests := []struct {
+			name           string
+			componentScale bool
+			placement      *policyv1alpha1.Placement
+			result         core.ScheduleResult
+			err            error
+			want           []workv1alpha2.TargetCluster
+		}{
+			{name: "success commits desired snapshot", componentScale: true, result: core.ScheduleResult{SuggestedClusters: desired}, want: desired},
+			{
+				name:           "ordered affinities use pinned component scale without fallback",
+				componentScale: true,
+				placement: &policyv1alpha1.Placement{ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{{
+					AffinityName: "primary",
+				}}},
+				result: core.ScheduleResult{SuggestedClusters: desired},
+				want:   desired,
+			},
+			{name: "FitError preserves accepted snapshot", componentScale: true, err: &framework.FitError{}, want: accepted},
+			{name: "ordinary FitError keeps legacy cleanup", err: &framework.FitError{}, want: nil},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				placement := tt.placement
+				if placement == nil {
+					placement = &policyv1alpha1.Placement{}
+				}
+				binding := &workv1alpha2.ResourceBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-binding", Namespace: "default"},
+					Spec: workv1alpha2.ResourceBindingSpec{
+						Placement: placement,
+						Clusters:  accepted,
+					},
+				}
+				client := karmadafake.NewClientset(binding)
+				scheduler := &Scheduler{
+					KarmadaClient: client,
+					eventRecorder: record.NewFakeRecorder(10),
+					Algorithm: &mockAlgorithm{scheduleFunc: func(_ context.Context, _ *workv1alpha2.ResourceBindingSpec, _ *workv1alpha2.ResourceBindingStatus, option *core.ScheduleAlgorithmOption) (core.ScheduleResult, error) {
+						assert.Equal(t, tt.componentScale, option.IsMultiComponentScale)
+						return tt.result, tt.err
+					}},
+				}
+
+				_ = scheduler.scheduleResourceBindingWithOptions(binding, tt.componentScale)
+				got, err := client.WorkV1alpha2().ResourceBindings(binding.Namespace).Get(context.Background(), binding.Name, metav1.GetOptions{})
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got.Spec.Clusters)
+			})
+		}
+	})
+
+	t.Run("ClusterResourceBinding", func(t *testing.T) {
+		for _, tt := range []struct {
+			name   string
+			result core.ScheduleResult
+			err    error
+			want   []workv1alpha2.TargetCluster
+		}{
+			{name: "success commits desired snapshot", result: core.ScheduleResult{SuggestedClusters: desired}, want: desired},
+			{name: "FitError preserves accepted snapshot", err: &framework.FitError{}, want: accepted},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				binding := &workv1alpha2.ClusterResourceBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-binding"},
+					Spec: workv1alpha2.ResourceBindingSpec{
+						Placement: &policyv1alpha1.Placement{},
+						Clusters:  accepted,
+					},
+				}
+				client := karmadafake.NewClientset(binding)
+				scheduler := &Scheduler{
+					KarmadaClient: client,
+					eventRecorder: record.NewFakeRecorder(10),
+					Algorithm: &mockAlgorithm{scheduleFunc: func(_ context.Context, _ *workv1alpha2.ResourceBindingSpec, _ *workv1alpha2.ResourceBindingStatus, option *core.ScheduleAlgorithmOption) (core.ScheduleResult, error) {
+						assert.True(t, option.IsMultiComponentScale)
+						return tt.result, tt.err
+					}},
+				}
+
+				_ = scheduler.scheduleClusterResourceBindingWithOptions(binding, true)
+				got, err := client.WorkV1alpha2().ClusterResourceBindings().Get(context.Background(), binding.Name, metav1.GetOptions{})
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got.Spec.Clusters)
+			})
+		}
+	})
 }
 
 func TestScheduleResourceBindingWithClusterAffinities(t *testing.T) {

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -34,21 +34,20 @@ func GetBindingClusterNames(spec *workv1alpha2.ResourceBindingSpec) []string {
 	return clusterNames
 }
 
-// IsBindingReplicasChanged will check if the sum of replicas is different from the replicas of object
+// IsBindingReplicasChanged reports whether the desired scalar or per-component replicas differ from the accepted result.
 func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, strategy *policyv1alpha1.ReplicaSchedulingStrategy) bool {
 	if strategy == nil {
 		return false
 	}
 
-	// For component-based workloads, trigger rescheduling when clusters are empty (e.g., after eviction).
-	// This is a temporary fix to ensure cluster failover works correctly.
-	// Limitation: This only handles the failover scenario where clusters are cleared.
-	// It does not detect component replica changes (e.g., scale up/down) or replica swaps between components.
-	// A complete solution requires changing how scheduling results are stored to support multi-template workloads,
-	// likely by extending TargetCluster to include per-component replica information.
-	// The comprehensive solution is tracked by: https://github.com/karmada-io/karmada/issues/6998
+	// Component-based workloads also need rescheduling after eviction. For multi-component workloads,
+	// compare the desired replicas with the component snapshot accepted by the scheduler.
 	if features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) && len(bindingSpec.Components) > 0 {
 		if len(bindingSpec.Clusters) == 0 {
+			return true
+		}
+		if len(bindingSpec.Components) > 1 && len(bindingSpec.Clusters) == 1 &&
+			isComponentReplicasChanged(bindingSpec.Components, bindingSpec.Clusters[0].Components) {
 			return true
 		}
 	}
@@ -66,6 +65,44 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, str
 		return replicasSum != bindingSpec.Replicas
 	}
 	return false
+}
+
+func isComponentReplicasChanged(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) bool {
+	if len(accepted) == 0 || len(desired) != len(accepted) {
+		return false
+	}
+
+	acceptedReplicas := make(map[string]int32, len(accepted))
+	for i := range accepted {
+		if accepted[i].Name == "" {
+			return false
+		}
+		if _, exists := acceptedReplicas[accepted[i].Name]; exists {
+			return false
+		}
+		acceptedReplicas[accepted[i].Name] = accepted[i].Replicas
+	}
+
+	seen := make(map[string]struct{}, len(desired))
+	changed := false
+	for i := range desired {
+		if desired[i].Name == "" {
+			return false
+		}
+		if _, exists := seen[desired[i].Name]; exists {
+			return false
+		}
+		seen[desired[i].Name] = struct{}{}
+
+		replicas, exists := acceptedReplicas[desired[i].Name]
+		if !exists {
+			return false
+		}
+		if desired[i].Replicas != replicas {
+			changed = true
+		}
+	}
+	return changed
 }
 
 // GetSumOfReplicas will get the sum of replicas in target clusters

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -46,9 +46,11 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, str
 		if len(bindingSpec.Clusters) == 0 {
 			return true
 		}
-		if len(bindingSpec.Components) > 1 && len(bindingSpec.Clusters) == 1 &&
-			isComponentReplicasChanged(bindingSpec.Components, bindingSpec.Clusters[0].Components) {
-			return true
+		if len(bindingSpec.Components) > 1 && len(bindingSpec.Clusters) == 1 {
+			equal, comparable := ComponentReplicasEqual(bindingSpec.Components, bindingSpec.Clusters[0].Components)
+			if comparable && !equal {
+				return true
+			}
 		}
 	}
 
@@ -67,18 +69,20 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, str
 	return false
 }
 
-func isComponentReplicasChanged(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) bool {
+// ComponentReplicasEqual compares desired component replicas with an accepted snapshot by name.
+// The second return value reports whether both snapshots are complete and comparable.
+func ComponentReplicasEqual(desired []workv1alpha2.Component, accepted []workv1alpha2.TargetComponent) (bool, bool) {
 	if len(accepted) == 0 || len(desired) != len(accepted) {
-		return false
+		return false, false
 	}
 
 	acceptedReplicas := make(map[string]int32, len(accepted))
 	for i := range accepted {
 		if accepted[i].Name == "" {
-			return false
+			return false, false
 		}
 		if _, exists := acceptedReplicas[accepted[i].Name]; exists {
-			return false
+			return false, false
 		}
 		acceptedReplicas[accepted[i].Name] = accepted[i].Replicas
 	}
@@ -87,22 +91,22 @@ func isComponentReplicasChanged(desired []workv1alpha2.Component, accepted []wor
 	changed := false
 	for i := range desired {
 		if desired[i].Name == "" {
-			return false
+			return false, false
 		}
 		if _, exists := seen[desired[i].Name]; exists {
-			return false
+			return false, false
 		}
 		seen[desired[i].Name] = struct{}{}
 
 		replicas, exists := acceptedReplicas[desired[i].Name]
 		if !exists {
-			return false
+			return false, false
 		}
 		if desired[i].Replicas != replicas {
 			changed = true
 		}
 	}
-	return changed
+	return !changed, true
 }
 
 // GetSumOfReplicas will get the sum of replicas in target clusters

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -178,6 +178,24 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
 			expected: true,
 		},
+		{
+			name: "component replicas changed with feature gate disabled",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 4},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: false,
+		},
 	}
 
 	// Component-based workload failover tests require the MultiplePodTemplatesScheduling feature gate.
@@ -221,6 +239,90 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 				},
 			},
 			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDuplicated},
+			expected: false,
+		},
+		{
+			name: "multi-component scale up should trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 6},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 4},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: true,
+		},
+		{
+			name: "multi-component scale down should trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 6},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: true,
+		},
+		{
+			name: "equal multi-component replicas should not trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "taskmanager", Replicas: 4},
+						{Name: "jobmanager", Replicas: 1},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: false,
+		},
+		{
+			name: "missing accepted component snapshot should not trigger scale rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 1},
+					{Name: "taskmanager", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{Name: ClusterMember1}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
+			expected: false,
+		},
+		{
+			name: "component name change should not trigger replica scale rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "jobmanager", Replicas: 2},
+					{Name: "worker", Replicas: 4},
+				},
+				Clusters: []workv1alpha2.TargetCluster{{
+					Name: ClusterMember1,
+					Components: []workv1alpha2.TargetComponent{
+						{Name: "jobmanager", Replicas: 1},
+						{Name: "taskmanager", Replicas: 4},
+					},
+				}},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided},
 			expected: false,
 		},
 	}

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -357,6 +357,53 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 	}
 }
 
+func TestComponentReplicasEqual(t *testing.T) {
+	tests := []struct {
+		name       string
+		desired    []workv1alpha2.Component
+		accepted   []workv1alpha2.TargetComponent
+		equal      bool
+		comparable bool
+	}{
+		{
+			name:       "equal snapshots ignore order",
+			desired:    []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted:   []workv1alpha2.TargetComponent{{Name: "taskmanager", Replicas: 4}, {Name: "jobmanager", Replicas: 1}},
+			equal:      true,
+			comparable: true,
+		},
+		{
+			name:       "replicas changed",
+			desired:    []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 6}},
+			accepted:   []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			comparable: true,
+		},
+		{
+			name:    "accepted snapshot missing",
+			desired: []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}},
+		},
+		{
+			name:     "component names differ",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "worker", Replicas: 4}},
+		},
+		{
+			name:     "accepted names duplicated",
+			desired:  []workv1alpha2.Component{{Name: "jobmanager", Replicas: 1}, {Name: "taskmanager", Replicas: 4}},
+			accepted: []workv1alpha2.TargetComponent{{Name: "jobmanager", Replicas: 1}, {Name: "jobmanager", Replicas: 4}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			equal, comparable := ComponentReplicasEqual(tt.desired, tt.accepted)
+			if equal != tt.equal || comparable != tt.comparable {
+				t.Fatalf("ComponentReplicasEqual() = (%t, %t), want (%t, %t)", equal, comparable, tt.equal, tt.comparable)
+			}
+		})
+	}
+}
+
 func TestGetSumOfReplicas(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/test/e2e/suites/base/schedule_multi_template_test.go
+++ b/test/e2e/suites/base/schedule_multi_template_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/yaml"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -57,6 +58,14 @@ var (
 var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resource", func() {
 	// Helper function to find component by name
 	findComponent := func(components []workv1alpha2.Component, name string) *workv1alpha2.Component {
+		for i := range components {
+			if components[i].Name == name {
+				return &components[i]
+			}
+		}
+		return nil
+	}
+	findTargetComponent := func(components []workv1alpha2.TargetComponent, name string) *workv1alpha2.TargetComponent {
 		for i := range components {
 			if components[i].Name == name {
 				return &components[i]
@@ -125,9 +134,40 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 			})
 		})
 
-		ginkgo.It("base case: propagate FlinkDeployment to one cluster", func() {
-			flinkDeploymentNamespace = testNamespace
+		ginkgo.It("reschedule FlinkDeployment component replicas on one cluster", func() {
+			ctx := context.Background()
+			flinkDeploymentNamespace = "karmadatest-flink-scale-" + rand.String(RandomStrLength)
 			flinkDeploymentName = fmt.Sprintf("flinkdeployment-%s", rand.String(RandomStrLength))
+
+			ginkgo.By("create an isolated namespace and component-scale CPU quota", func() {
+				gomega.Expect(setupTestNamespace(flinkDeploymentNamespace, kubeClient)).Should(gomega.Succeed())
+				ginkgo.DeferCleanup(func() {
+					gomega.Expect(cleanupTestNamespace(flinkDeploymentNamespace, kubeClient)).Should(gomega.Succeed())
+				})
+				framework.WaitNamespacePresentOnClusters(framework.ClusterNames(), flinkDeploymentNamespace)
+
+				const quotaName = "flink-component-scale"
+				expectedCPU := resource.MustParse("300m")
+				for _, clusterName := range framework.ClusterNames() {
+					clusterClient := framework.GetClusterClient(clusterName)
+					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+					framework.CreateResourceQuota(clusterClient, &corev1.ResourceQuota{
+						ObjectMeta: metav1.ObjectMeta{Name: quotaName, Namespace: flinkDeploymentNamespace},
+						Spec:       corev1.ResourceQuotaSpec{Hard: corev1.ResourceList{corev1.ResourceCPU: expectedCPU}},
+					})
+					currentCluster := clusterName
+					ginkgo.DeferCleanup(func() {
+						framework.RemoveResourceQuota(framework.GetClusterClient(currentCluster), flinkDeploymentNamespace, quotaName)
+					})
+					gomega.Eventually(func(g gomega.Gomega) {
+						quota, err := clusterClient.CoreV1().ResourceQuotas(flinkDeploymentNamespace).Get(ctx, quotaName, metav1.GetOptions{})
+						g.Expect(err).ShouldNot(gomega.HaveOccurred())
+						actual, found := quota.Status.Hard[corev1.ResourceCPU]
+						g.Expect(found).Should(gomega.BeTrue())
+						g.Expect(actual.Cmp(expectedCPU)).Should(gomega.Equal(0))
+					}, framework.PollTimeout, framework.PollInterval).Should(gomega.Succeed())
+				}
+			})
 
 			ginkgo.By("create FlinkDeployment on karmada control plane", func() {
 				flinkDeploymentObj = &unstructured.Unstructured{}
@@ -144,11 +184,11 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 				}
 
 				_, err = dynamicClient.Resource(flinkDeploymentGVR).Namespace(flinkDeploymentNamespace).
-					Create(context.Background(), flinkDeploymentObj, metav1.CreateOptions{})
+					Create(ctx, flinkDeploymentObj, metav1.CreateOptions{})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				ginkgo.DeferCleanup(func() {
 					err := dynamicClient.Resource(flinkDeploymentGVR).Namespace(flinkDeploymentNamespace).
-						Delete(context.Background(), flinkDeploymentName, metav1.DeleteOptions{})
+						Delete(ctx, flinkDeploymentName, metav1.DeleteOptions{})
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				})
 			})
@@ -237,6 +277,97 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 						Get(context.Background(), flinkDeploymentName, metav1.GetOptions{})
 					g.Expect(err).ShouldNot(gomega.HaveOccurred(), "FlinkDeployment should be present on cluster %s", targetClusterName)
 				}, framework.PollTimeout, framework.PollInterval).Should(gomega.Succeed())
+			})
+
+			workName := names.GenerateWorkName(flinkDeploymentObj.GetKind(), flinkDeploymentName, flinkDeploymentNamespace)
+			updateTaskManagerReplicas := func(replicas int64) {
+				gomega.Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					current, err := dynamicClient.Resource(flinkDeploymentGVR).Namespace(flinkDeploymentNamespace).
+						Get(ctx, flinkDeploymentName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					if err := unstructured.SetNestedField(current.Object, replicas, "spec", "taskManager", "replicas"); err != nil {
+						return err
+					}
+					_, err = dynamicClient.Resource(flinkDeploymentGVR).Namespace(flinkDeploymentNamespace).
+						Update(ctx, current, metav1.UpdateOptions{})
+					return err
+				})).Should(gomega.Succeed())
+			}
+			taskManagerReplicas := func(g gomega.Gomega, object *unstructured.Unstructured) int64 {
+				replicas, found, err := unstructured.NestedInt64(object.Object, "spec", "taskManager", "replicas")
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				if !found {
+					return 1
+				}
+				return replicas
+			}
+			type deliveredRevision struct {
+				workGeneration   int64
+				memberGeneration int64
+			}
+			assertScaleState := func(g gomega.Gomega, desiredReplicas, acceptedReplicas, deliveredReplicas int32, scheduled metav1.ConditionStatus) deliveredRevision {
+				binding, err := karmadaClient.WorkV1alpha2().ResourceBindings(flinkDeploymentNamespace).
+					Get(ctx, bindingName, metav1.GetOptions{})
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				desired := findComponent(binding.Spec.Components, "taskmanager")
+				g.Expect(desired).ShouldNot(gomega.BeNil())
+				g.Expect(desired.Replicas).Should(gomega.Equal(desiredReplicas))
+				g.Expect(binding.Spec.Clusters).Should(gomega.HaveLen(1))
+				g.Expect(binding.Spec.Clusters[0].Name).Should(gomega.Equal(targetClusterName))
+				accepted := findTargetComponent(binding.Spec.Clusters[0].Components, "taskmanager")
+				g.Expect(accepted).ShouldNot(gomega.BeNil())
+				g.Expect(accepted.Replicas).Should(gomega.Equal(acceptedReplicas))
+				condition := meta.FindStatusCondition(binding.Status.Conditions, workv1alpha2.Scheduled)
+				g.Expect(condition).ShouldNot(gomega.BeNil())
+				g.Expect(condition.Status).Should(gomega.Equal(scheduled))
+				if scheduled == metav1.ConditionFalse {
+					g.Expect(condition.Reason).Should(gomega.Equal(workv1alpha2.BindingReasonUnschedulable))
+					g.Expect(condition.Message).Should(gomega.ContainSubstring("insufficient resources for component scale"))
+				}
+
+				work, err := karmadaClient.WorkV1alpha1().Works(names.GenerateExecutionSpaceName(targetClusterName)).
+					Get(ctx, workName, metav1.GetOptions{})
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				g.Expect(work.Spec.Workload.Manifests).Should(gomega.HaveLen(1))
+				workload := &unstructured.Unstructured{}
+				g.Expect(workload.UnmarshalJSON(work.Spec.Workload.Manifests[0].Raw)).Should(gomega.Succeed())
+				g.Expect(taskManagerReplicas(g, workload)).Should(gomega.Equal(int64(deliveredReplicas)))
+
+				member, err := framework.GetClusterDynamicClient(targetClusterName).Resource(flinkDeploymentGVR).
+					Namespace(flinkDeploymentNamespace).Get(ctx, flinkDeploymentName, metav1.GetOptions{})
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				g.Expect(taskManagerReplicas(g, member)).Should(gomega.Equal(int64(deliveredReplicas)))
+				return deliveredRevision{workGeneration: work.Generation, memberGeneration: member.GetGeneration()}
+			}
+			waitForScaleState := func(desiredReplicas, acceptedReplicas, deliveredReplicas int32, scheduled metav1.ConditionStatus) deliveredRevision {
+				var revision deliveredRevision
+				gomega.Eventually(func(g gomega.Gomega) {
+					revision = assertScaleState(g, desiredReplicas, acceptedReplicas, deliveredReplicas, scheduled)
+				}, framework.PollTimeout, framework.PollInterval).Should(gomega.Succeed())
+				return revision
+			}
+
+			ginkgo.By("verify the initial accepted snapshot and delivery", func() {
+				waitForScaleState(1, 1, 1, metav1.ConditionTrue)
+			})
+			ginkgo.By("scale taskmanager up using only incremental capacity", func() {
+				updateTaskManagerReplicas(2)
+				waitForScaleState(2, 2, 2, metav1.ConditionTrue)
+			})
+			ginkgo.By("scale taskmanager down without capacity estimation", func() {
+				updateTaskManagerReplicas(1)
+				waitForScaleState(1, 1, 1, metav1.ConditionTrue)
+			})
+			ginkgo.By("preserve accepted snapshot and Work when scale-up cannot fit", func() {
+				acceptedRevision := waitForScaleState(1, 1, 1, metav1.ConditionTrue)
+				updateTaskManagerReplicas(4)
+				waitForScaleState(4, 1, 1, metav1.ConditionFalse)
+				gomega.Consistently(func(g gomega.Gomega) {
+					current := assertScaleState(g, 4, 1, 1, metav1.ConditionFalse)
+					g.Expect(current).Should(gomega.Equal(acceptedRevision))
+				}, 3*framework.PollInterval, framework.PollInterval).Should(gomega.Succeed())
 			})
 		})
 	})

--- a/test/e2e/suites/base/schedule_multi_template_test.go
+++ b/test/e2e/suites/base/schedule_multi_template_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,6 +139,7 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 			ctx := context.Background()
 			flinkDeploymentNamespace = "karmadatest-flink-scale-" + rand.String(RandomStrLength)
 			flinkDeploymentName = fmt.Sprintf("flinkdeployment-%s", rand.String(RandomStrLength))
+			const quotaName = "flink-component-scale"
 
 			ginkgo.By("create an isolated namespace and component-scale CPU quota", func() {
 				gomega.Expect(setupTestNamespace(flinkDeploymentNamespace, kubeClient)).Should(gomega.Succeed())
@@ -146,7 +148,6 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 				})
 				framework.WaitNamespacePresentOnClusters(framework.ClusterNames(), flinkDeploymentNamespace)
 
-				const quotaName = "flink-component-scale"
 				expectedCPU := resource.MustParse("300m")
 				for _, clusterName := range framework.ClusterNames() {
 					clusterClient := framework.GetClusterClient(clusterName)
@@ -280,6 +281,7 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 			})
 
 			workName := names.GenerateWorkName(flinkDeploymentObj.GetKind(), flinkDeploymentName, flinkDeploymentNamespace)
+			var alternateClusterName string
 			updateTaskManagerReplicas := func(replicas int64) {
 				gomega.Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					current, err := dynamicClient.Resource(flinkDeploymentGVR).Namespace(flinkDeploymentNamespace).
@@ -341,6 +343,17 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 				g.Expect(taskManagerReplicas(g, member)).Should(gomega.Equal(int64(deliveredReplicas)))
 				return deliveredRevision{workGeneration: work.Generation, memberGeneration: member.GetGeneration()}
 			}
+			assertNotMigrated := func(g gomega.Gomega) {
+				_, err := karmadaClient.WorkV1alpha1().Works(names.GenerateExecutionSpaceName(alternateClusterName)).
+					Get(ctx, workName, metav1.GetOptions{})
+				g.Expect(apierrors.IsNotFound(err)).Should(gomega.BeTrue(), "Work should not be created in alternate cluster %s: %v", alternateClusterName, err)
+
+				alternateDynamicClient := framework.GetClusterDynamicClient(alternateClusterName)
+				g.Expect(alternateDynamicClient).ShouldNot(gomega.BeNil())
+				_, err = alternateDynamicClient.Resource(flinkDeploymentGVR).
+					Namespace(flinkDeploymentNamespace).Get(ctx, flinkDeploymentName, metav1.GetOptions{})
+				g.Expect(apierrors.IsNotFound(err)).Should(gomega.BeTrue(), "FlinkDeployment should not migrate to alternate cluster %s: %v", alternateClusterName, err)
+			}
 			waitForScaleState := func(desiredReplicas, acceptedReplicas, deliveredReplicas int32, scheduled metav1.ConditionStatus) deliveredRevision {
 				var revision deliveredRevision
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -360,13 +373,48 @@ var _ = ginkgo.Describe("[ScheduleMultiTemplate] schedule multi template resourc
 				updateTaskManagerReplicas(1)
 				waitForScaleState(1, 1, 1, metav1.ConditionTrue)
 			})
-			ginkgo.By("preserve accepted snapshot and Work when scale-up cannot fit", func() {
+			ginkgo.By("make a non-target cluster able to fit the complete scaled workload", func() {
+				for _, clusterName := range framework.ClusterNames() {
+					if clusterName != targetClusterName {
+						alternateClusterName = clusterName
+						break
+					}
+				}
+				gomega.Expect(alternateClusterName).ShouldNot(gomega.BeEmpty())
+				alternateClient := framework.GetClusterClient(alternateClusterName)
+				gomega.Expect(alternateClient).ShouldNot(gomega.BeNil())
+				alternateCPU := resource.MustParse("1")
+				gomega.Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					quota, err := alternateClient.CoreV1().ResourceQuotas(flinkDeploymentNamespace).Get(ctx, quotaName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					quota.Spec.Hard[corev1.ResourceCPU] = alternateCPU
+					_, err = alternateClient.CoreV1().ResourceQuotas(flinkDeploymentNamespace).Update(ctx, quota, metav1.UpdateOptions{})
+					return err
+				})).Should(gomega.Succeed())
+
+				requiredCPU := resource.MustParse("450m") // jobmanager 50m + 4 taskmanagers * 100m
+				gomega.Eventually(func(g gomega.Gomega) {
+					quota, err := alternateClient.CoreV1().ResourceQuotas(flinkDeploymentNamespace).Get(ctx, quotaName, metav1.GetOptions{})
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
+					hardCPU, found := quota.Status.Hard[corev1.ResourceCPU]
+					g.Expect(found).Should(gomega.BeTrue())
+					usedCPU := quota.Status.Used[corev1.ResourceCPU]
+					availableCPU := hardCPU.DeepCopy()
+					availableCPU.Sub(usedCPU)
+					g.Expect(availableCPU.Cmp(requiredCPU)).Should(gomega.BeNumerically(">=", 0))
+				}, framework.PollTimeout, framework.PollInterval).Should(gomega.Succeed())
+				assertNotMigrated(gomega.Default)
+			})
+			ginkgo.By("preserve accepted state instead of migrating when the target cannot fit", func() {
 				acceptedRevision := waitForScaleState(1, 1, 1, metav1.ConditionTrue)
 				updateTaskManagerReplicas(4)
 				waitForScaleState(4, 1, 1, metav1.ConditionFalse)
 				gomega.Consistently(func(g gomega.Gomega) {
 					current := assertScaleState(g, 4, 1, 1, metav1.ConditionFalse)
 					g.Expect(current).Should(gomega.Equal(acceptedRevision))
+					assertNotMigrated(g)
 				}, 3*framework.PollInterval, framework.PollInterval).Should(gomega.Succeed())
 			})
 		})


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind feature

**What this PR does / why we need it**:

When component scale rescheduling fails, Karmada must preserve the accepted component result and existing Work.

This change calls the #7835 planner only for component scale on the current accepted target. Success commits the complete desired `TargetCluster.Components` result through the existing scheduler patch; any error returns before that patch. Before updating Work, the binding controllers compare replicas extracted from the current source with the accepted snapshot. Mismatched or incomparable replicas wait, while equal replicas continue through the existing `ensureWork` path without workload rewriting.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

Fixes #7492

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

- Scope: the guard applies to default-scheduler multi-template bindings with an accepted snapshot. Other scheduler, feature-off, single-template, and missing-snapshot paths keep existing behavior; failover and requirements provenance remain out of scope.
- Review the residual diff as `e19a318eb...9a0487307`; the preceding commits are the stacked #7830 and #7835 dependencies.
- Tests: the affected package race tests passed. The base E2E package compiled and passed changed-path lint; live multi-cluster E2E was not run locally.
- AI assistance: Codex helped inspect the scheduler and Work update paths and draft the implementation and tests; I reviewed the final diff and validation results.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->

```release-note
`karmada-scheduler`: Failed multi-template component scale rescheduling now preserves the accepted component result and existing Work until the new replicas are accepted.
```
