### PR TITLE
sync OWNERS files with MAINTAINERS.md

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,13 +12,17 @@ reviewers:
 - zach593
 - zhzhuang-zju
 approvers:
+- CharlesQQ
 - chaunceyjiang
 - Garrybest
+- GitHubxsy
 - jabellard
 - kevin-wangzefeng
 - mszacillo
 - RainbowMango
 - seanlaii
+- warjiang
+- wawa0210
 - whitewindmills
 - XiShanYongYe-Chang
 - zach593

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,13 +1,12 @@
 reviewers:
 - chaosi-zju
 - ikaven1024
-- lfbear
 - liangyuanpeng
-- mrlihanbo
 - zhzhuang-zju
 approvers:
 - ikaven1024
 - liangyuanpeng
+- zhzhuang-zju
+emeritus_approvers:
 - lfbear
 - mrlihanbo
-- zhzhuang-zju

--- a/pkg/controllers/OWNERS
+++ b/pkg/controllers/OWNERS
@@ -3,7 +3,6 @@ reviewers:
 - chaunceyjiang
 - Garrybest
 - jwcesign
-- mrlihanbo
 - mszacillo
 - pigletfly
 - Poor12

--- a/pkg/scheduler/OWNERS
+++ b/pkg/scheduler/OWNERS
@@ -2,7 +2,6 @@ reviewers:
 - chaunceyjiang
 - Garrybest
 - jwcesign
-- mrlihanbo
 - Poor12
 - qianjun1993
 - seanlaii


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
- Remove emeritus maintainers from OWNERS files (they still hold approval rights enforced by Prow)
- Add active maintainers missing from the main repo's OWNERS approvers

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Parts of https://github.com/karmada-io/community/issues/217

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

In addition to the changes made here, we also need to modify the `CODEOWNERS` file in `.project`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

