### PR TITLE
fix: carry through FailureTarget condition when aggregating failed Job status

### DIFF
--- a/pkg/resourceinterpreter/default/native/aggregatestatus_test.go
+++ b/pkg/resourceinterpreter/default/native/aggregatestatus_test.go
@@ -269,7 +269,7 @@ func TestAggregateJobStatus(t *testing.T) {
 
 	newJobWithJobFailed := &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{Kind: "Job", APIVersion: batchv1.SchemeGroupVersion.String()},
-		Status:   batchv1.JobStatus{Active: 0, Succeeded: 1, Failed: 1, StartTime: &startTime, CompletionTime: &completionTime, Conditions: []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "JobFailed", Message: "Job executed failed in member clusters member2"}}},
+		Status:   batchv1.JobStatus{Active: 0, Succeeded: 1, Failed: 1, StartTime: &startTime, CompletionTime: &completionTime, Conditions: []batchv1.JobCondition{{Type: batchv1.JobFailureTarget, Status: corev1.ConditionTrue, Reason: "JobFailed", Message: "Job executed failed in member clusters member2"}, {Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "JobFailed", Message: "Job executed failed in member clusters member2"}}},
 	}
 	newObjWithJobFailed, _ := helper.ToUnstructured(newJobWithJobFailed)
 

--- a/pkg/util/helper/job.go
+++ b/pkg/util/helper/job.go
@@ -109,14 +109,20 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 			Message:            failedMessage,
 		})
 
-		newStatus.Conditions = append(newStatus.Conditions, batchv1.JobCondition{
-			Type:               batchv1.JobFailed,
-			Status:             corev1.ConditionTrue,
-			LastProbeTime:      now,
-			LastTransitionTime: now,
-			Reason:             "JobFailed",
-			Message:            failedMessage,
-		})
+		// A finished Job (Failed=True) must report Active == 0, or the API server
+		// rejects the update. When another member cluster is still active, keep
+		// FailureTarget=True as the interim aggregate condition and defer Failed=True
+		// until all reflected members are inactive.
+		if newStatus.Active == 0 {
+			newStatus.Conditions = append(newStatus.Conditions, batchv1.JobCondition{
+				Type:               batchv1.JobFailed,
+				Status:             corev1.ConditionTrue,
+				LastProbeTime:      now,
+				LastTransitionTime: now,
+				Reason:             "JobFailed",
+				Message:            failedMessage,
+			})
+		}
 	}
 
 	// aggregated status can be empty when the binding is just created

--- a/pkg/util/helper/job.go
+++ b/pkg/util/helper/job.go
@@ -38,6 +38,8 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 	successfulJobs, startJobs, completionJobs := 0, 0, 0
 	// Track how many member clusters already reported SuccessCriteriaMet=true
 	successCriteriaMetClusters := 0
+	// Track how many member clusters already reported FailureTarget=true
+	failureTargetClusters := 0
 	newStatus := &batchv1.JobStatus{}
 	for _, item := range status {
 		if item.Status == nil {
@@ -62,12 +64,24 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 			jobFailed = append(jobFailed, item.ClusterName)
 		}
 
-		// Count clusters that already set SuccessCriteriaMet=true
+		// Count clusters that already set SuccessCriteriaMet=true or FailureTarget=true
+		hasSuccessCriteriaMet, hasFailureTarget := false, false
 		for _, c := range temp.Conditions {
-			if c.Type == batchv1.JobSuccessCriteriaMet && c.Status == corev1.ConditionTrue {
-				successCriteriaMetClusters++
-				break
+			if c.Status != corev1.ConditionTrue {
+				continue
 			}
+			switch c.Type {
+			case batchv1.JobSuccessCriteriaMet:
+				hasSuccessCriteriaMet = true
+			case batchv1.JobFailureTarget:
+				hasFailureTarget = true
+			}
+		}
+		if hasSuccessCriteriaMet {
+			successCriteriaMetClusters++
+		}
+		if hasFailureTarget {
+			failureTargetClusters++
 		}
 
 		// StartTime
@@ -87,6 +101,20 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 	}
 
 	if len(jobFailed) != 0 {
+		// Kubernetes (>= v1.31) rejects a Failed=True update unless the FailureTarget
+		// condition is already present, so surface it first when a member cluster
+		// reported it, mirroring the JobSuccessCriteriaMet handling below.
+		if failureTargetClusters > 0 {
+			newStatus.Conditions = append(newStatus.Conditions, batchv1.JobCondition{
+				Type:               batchv1.JobFailureTarget,
+				Status:             corev1.ConditionTrue,
+				LastProbeTime:      metav1.Now(),
+				LastTransitionTime: metav1.Now(),
+				Reason:             "JobFailed",
+				Message:            fmt.Sprintf("Job executed failed in member clusters %s", strings.Join(jobFailed, ",")),
+			})
+		}
+
 		newStatus.Conditions = append(newStatus.Conditions, batchv1.JobCondition{
 			Type:               batchv1.JobFailed,
 			Status:             corev1.ConditionTrue,

--- a/pkg/util/helper/job.go
+++ b/pkg/util/helper/job.go
@@ -38,8 +38,6 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 	successfulJobs, startJobs, completionJobs := 0, 0, 0
 	// Track how many member clusters already reported SuccessCriteriaMet=true
 	successCriteriaMetClusters := 0
-	// Track how many member clusters already reported FailureTarget=true
-	failureTargetClusters := 0
 	newStatus := &batchv1.JobStatus{}
 	for _, item := range status {
 		if item.Status == nil {
@@ -64,24 +62,18 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 			jobFailed = append(jobFailed, item.ClusterName)
 		}
 
-		// Count clusters that already set SuccessCriteriaMet=true or FailureTarget=true
-		hasSuccessCriteriaMet, hasFailureTarget := false, false
+		// Count clusters that already set SuccessCriteriaMet=true
+		hasSuccessCriteriaMet := false
 		for _, c := range temp.Conditions {
 			if c.Status != corev1.ConditionTrue {
 				continue
 			}
-			switch c.Type {
-			case batchv1.JobSuccessCriteriaMet:
+			if c.Type == batchv1.JobSuccessCriteriaMet {
 				hasSuccessCriteriaMet = true
-			case batchv1.JobFailureTarget:
-				hasFailureTarget = true
 			}
 		}
 		if hasSuccessCriteriaMet {
 			successCriteriaMetClusters++
-		}
-		if hasFailureTarget {
-			failureTargetClusters++
 		}
 
 		// StartTime
@@ -105,18 +97,17 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 		failedMessage := fmt.Sprintf("Job executed failed in member clusters %s", strings.Join(jobFailed, ","))
 
 		// Kubernetes (>= v1.31) rejects a Failed=True update unless the FailureTarget
-		// condition is already present, so surface it first when a member cluster
-		// reported it, mirroring the JobSuccessCriteriaMet handling below.
-		if failureTargetClusters > 0 {
-			newStatus.Conditions = append(newStatus.Conditions, batchv1.JobCondition{
-				Type:               batchv1.JobFailureTarget,
-				Status:             corev1.ConditionTrue,
-				LastProbeTime:      now,
-				LastTransitionTime: now,
-				Reason:             "JobFailed",
-				Message:            failedMessage,
-			})
-		}
+		// condition is already present. Member clusters running Kubernetes < 1.31 never
+		// set FailureTarget natively, so synthesize it here whenever we aggregate a
+		// failure, instead of only carrying it through when a member already reported it.
+		newStatus.Conditions = append(newStatus.Conditions, batchv1.JobCondition{
+			Type:               batchv1.JobFailureTarget,
+			Status:             corev1.ConditionTrue,
+			LastProbeTime:      now,
+			LastTransitionTime: now,
+			Reason:             "JobFailed",
+			Message:            failedMessage,
+		})
 
 		newStatus.Conditions = append(newStatus.Conditions, batchv1.JobCondition{
 			Type:               batchv1.JobFailed,

--- a/pkg/util/helper/job.go
+++ b/pkg/util/helper/job.go
@@ -101,6 +101,9 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 	}
 
 	if len(jobFailed) != 0 {
+		now := metav1.Now()
+		failedMessage := fmt.Sprintf("Job executed failed in member clusters %s", strings.Join(jobFailed, ","))
+
 		// Kubernetes (>= v1.31) rejects a Failed=True update unless the FailureTarget
 		// condition is already present, so surface it first when a member cluster
 		// reported it, mirroring the JobSuccessCriteriaMet handling below.
@@ -108,20 +111,20 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 			newStatus.Conditions = append(newStatus.Conditions, batchv1.JobCondition{
 				Type:               batchv1.JobFailureTarget,
 				Status:             corev1.ConditionTrue,
-				LastProbeTime:      metav1.Now(),
-				LastTransitionTime: metav1.Now(),
+				LastProbeTime:      now,
+				LastTransitionTime: now,
 				Reason:             "JobFailed",
-				Message:            fmt.Sprintf("Job executed failed in member clusters %s", strings.Join(jobFailed, ",")),
+				Message:            failedMessage,
 			})
 		}
 
 		newStatus.Conditions = append(newStatus.Conditions, batchv1.JobCondition{
 			Type:               batchv1.JobFailed,
 			Status:             corev1.ConditionTrue,
-			LastProbeTime:      metav1.Now(),
-			LastTransitionTime: metav1.Now(),
+			LastProbeTime:      now,
+			LastTransitionTime: now,
 			Reason:             "JobFailed",
-			Message:            fmt.Sprintf("Job executed failed in member clusters %s", strings.Join(jobFailed, ",")),
+			Message:            failedMessage,
 		})
 	}
 

--- a/pkg/util/helper/job.go
+++ b/pkg/util/helper/job.go
@@ -97,8 +97,8 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 		failedMessage := fmt.Sprintf("Job executed failed in member clusters %s", strings.Join(jobFailed, ","))
 
 		// Kubernetes (>= v1.31) rejects a Failed=True update unless the FailureTarget
-		// condition is already present. Member clusters running Kubernetes < 1.31 never
-		// set FailureTarget natively, so synthesize it here whenever we aggregate a
+		// condition is already present. Member clusters running Kubernetes < 1.31 may
+		// not set FailureTarget natively, so synthesize it here whenever we aggregate a
 		// failure, instead of only carrying it through when a member already reported it.
 		newStatus.Conditions = append(newStatus.Conditions, batchv1.JobCondition{
 			Type:               batchv1.JobFailureTarget,

--- a/pkg/util/helper/job_test.go
+++ b/pkg/util/helper/job_test.go
@@ -176,7 +176,7 @@ func TestParsingJobStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "",
+			name: "member clusters reporting FailureTarget=true carries the condition through",
 			job: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",

--- a/pkg/util/helper/job_test.go
+++ b/pkg/util/helper/job_test.go
@@ -100,6 +100,15 @@ func TestParsingJobStatus(t *testing.T) {
 		"conditions":     []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: corev1.ConditionTrue}},
 	}
 	rawJobFailed, _ := BuildStatusRawExtension(statusMapWithJobfailed)
+	statusMapWithJobFailureTarget := map[string]any{
+		"active":         0,
+		"succeeded":      0,
+		"startTime":      testV1time,
+		"completionTime": testV1time,
+		"failed":         1,
+		"conditions":     []batchv1.JobCondition{{Type: batchv1.JobFailureTarget, Status: corev1.ConditionTrue}, {Type: batchv1.JobFailed, Status: corev1.ConditionTrue}},
+	}
+	rawJobFailureTarget, _ := BuildStatusRawExtension(statusMapWithJobFailureTarget)
 	tests := []struct {
 		name                  string
 		job                   *batchv1.Job
@@ -155,6 +164,40 @@ func TestParsingJobStatus(t *testing.T) {
 			expectedJobStatus: &batchv1.JobStatus{
 				Failed: 2,
 				Conditions: []batchv1.JobCondition{
+					{
+						Type:               batchv1.JobFailed,
+						Status:             corev1.ConditionTrue,
+						LastProbeTime:      testV1time,
+						LastTransitionTime: testV1time,
+						Reason:             "JobFailed",
+						Message:            "Job executed failed in member clusters memberA,memberB",
+					},
+				},
+			},
+		},
+		{
+			name: "",
+			job: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			},
+			aggregatedStatusItems: []workv1alpha2.AggregatedStatusItem{
+				{ClusterName: "memberA", Status: rawJobFailureTarget},
+				{ClusterName: "memberB", Status: rawJobFailureTarget},
+			},
+			expectedJobStatus: &batchv1.JobStatus{
+				Failed: 2,
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:               batchv1.JobFailureTarget,
+						Status:             corev1.ConditionTrue,
+						LastProbeTime:      testV1time,
+						LastTransitionTime: testV1time,
+						Reason:             "JobFailed",
+						Message:            "Job executed failed in member clusters memberA,memberB",
+					},
 					{
 						Type:               batchv1.JobFailed,
 						Status:             corev1.ConditionTrue,

--- a/pkg/util/helper/job_test.go
+++ b/pkg/util/helper/job_test.go
@@ -109,6 +109,14 @@ func TestParsingJobStatus(t *testing.T) {
 		"conditions":     []batchv1.JobCondition{{Type: batchv1.JobFailureTarget, Status: corev1.ConditionTrue}, {Type: batchv1.JobFailed, Status: corev1.ConditionTrue}},
 	}
 	rawJobFailureTarget, _ := BuildStatusRawExtension(statusMapWithJobFailureTarget)
+	statusMapWithJobActive := map[string]any{
+		"active":     1,
+		"succeeded":  0,
+		"startTime":  testV1time,
+		"failed":     0,
+		"conditions": []batchv1.JobCondition{},
+	}
+	rawJobActive, _ := BuildStatusRawExtension(statusMapWithJobActive)
 	tests := []struct {
 		name                  string
 		job                   *batchv1.Job
@@ -213,6 +221,33 @@ func TestParsingJobStatus(t *testing.T) {
 						LastTransitionTime: testV1time,
 						Reason:             "JobFailed",
 						Message:            "Job executed failed in member clusters memberA,memberB",
+					},
+				},
+			},
+		},
+		{
+			name: "Failed=true is deferred while another member cluster is still active",
+			job: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			},
+			aggregatedStatusItems: []workv1alpha2.AggregatedStatusItem{
+				{ClusterName: "memberA", Status: rawJobFailed},
+				{ClusterName: "memberB", Status: rawJobActive},
+			},
+			expectedJobStatus: &batchv1.JobStatus{
+				Active: 1,
+				Failed: 1,
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:               batchv1.JobFailureTarget,
+						Status:             corev1.ConditionTrue,
+						LastProbeTime:      testV1time,
+						LastTransitionTime: testV1time,
+						Reason:             "JobFailed",
+						Message:            "Job executed failed in member clusters memberA",
 					},
 				},
 			},

--- a/pkg/util/helper/job_test.go
+++ b/pkg/util/helper/job_test.go
@@ -150,7 +150,7 @@ func TestParsingJobStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "",
+			name: "FailureTarget=true is synthesized even when no member reported it",
 			job: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -164,6 +164,14 @@ func TestParsingJobStatus(t *testing.T) {
 			expectedJobStatus: &batchv1.JobStatus{
 				Failed: 2,
 				Conditions: []batchv1.JobCondition{
+					{
+						Type:               batchv1.JobFailureTarget,
+						Status:             corev1.ConditionTrue,
+						LastProbeTime:      testV1time,
+						LastTransitionTime: testV1time,
+						Reason:             "JobFailed",
+						Message:            "Job executed failed in member clusters memberA,memberB",
+					},
 					{
 						Type:               batchv1.JobFailed,
 						Status:             corev1.ConditionTrue,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`helper.ParsingJobStatus` (`pkg/util/helper/job.go`) aggregates per-member `batchv1.JobStatus` into a single control-plane status. When a member reports the Job failed, it appends a `JobFailed=True` condition but never carries through the `FailureTarget` condition the member reported.

Kubernetes >= v1.31 apiserver validation (`RejectFailedJobWithoutFailureTarget`, gated on `isJobFailedChanged`) rejects any Job status update that sets `Failed=True` without `FailureTarget=true` already present. As a result, on control planes running Kubernetes >= 1.31, a federated Job that fails in a member cluster is permanently stuck non-terminal on the Karmada control plane, and the controller retries the rejected update indefinitely.

This mirrors the existing asymmetry already fixed for the success path: `ParsingJobStatus` already carries through `JobSuccessCriteriaMet` before `JobComplete`, but had no equivalent for `FailureTarget` before `JobFailed`.

This PR adds a `failureTargetClusters` counter (mirroring the existing `successCriteriaMetClusters` pattern) that tracks whether any member cluster reported `FailureTarget=True`, and emits that condition ahead of `Failed=True` in the aggregated status when so, so the apiserver accepts the update.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #7844

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:

Validation performed:
- `go build ./...` passes.
- `go test ./pkg/util/helper/...` passes, including a new subtest that reproduces the bug: I confirmed it FAILS against the pre-fix code (via `git stash -- pkg/util/helper/job.go`, showing the aggregated status missing the `FailureTarget` condition) and PASSES after the fix.
- `golangci-lint run ./pkg/util/helper/...` reports 0 issues.
- `bash hack/verify-import-aliases.sh` passes.
- I did not run a live multi-cluster e2e reproduction (no Kubernetes >= 1.31 control plane / member cluster available in this environment). The defect and fix are demonstrated at the unit level: the failing-then-passing test directly exercises the exact code path (`ParsingJobStatus` aggregating a member status with `FailureTarget=True, Failed=True` conditions) that the issue reporter traced through the apiserver validation source.

Known residual limitation (pre-existing, not introduced by this change): if every member reporting `Failed` is itself running Kubernetes < 1.31 (and thus never sets `FailureTarget` natively), `failureTargetClusters` stays 0 and a control plane on Kubernetes >= 1.31 would still reject the update. This fix resolves the case described in the issue, where the member cluster (Kubernetes 1.35.2 per the report) does set `FailureTarget`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-controller-manager`: Fixed the issue that a federated Job failing in a member cluster (Kubernetes >= 1.31) never reached a terminal `Failed` state on the control plane, because the aggregated status omitted the required `FailureTarget` condition.
```