### PR TITLE
cherry pick of #7663: fix: push-mode informers pick up rotated bearer token without restart

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64
 	go.uber.org/mock v0.4.0
 	golang.org/x/net v0.43.0
+	golang.org/x/oauth2 v0.30.0
 	golang.org/x/term v0.34.0
 	golang.org/x/text v0.28.0
 	golang.org/x/time v0.11.0
@@ -178,7 +179,6 @@ require (
 	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/mod v0.27.0 // indirect
-	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect

--- a/pkg/util/membercluster_client.go
+++ b/pkg/util/membercluster_client.go
@@ -23,12 +23,14 @@ import (
 	"net/url"
 	"time"
 
+	"golang.org/x/oauth2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/scale"
+	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -41,6 +43,9 @@ import (
 const (
 	defaultTimeout = 32 * time.Second
 )
+
+// tokenRefreshPeriod is how often the cached bearer token is re-read from the Secret.
+var tokenRefreshPeriod = 5 * time.Minute
 
 // ClusterClient stands for a cluster Clientset for the given member cluster
 type ClusterClient struct {
@@ -211,16 +216,15 @@ func BuildClusterConfig(clusterName string,
 		return nil, err
 	}
 
-	token, ok := secret.Data[clusterv1alpha1.SecretTokenKey]
-	if !ok || len(token) == 0 {
-		return nil, fmt.Errorf("the secret for cluster %s is missing a non-empty value for %q", clusterName, clusterv1alpha1.SecretTokenKey)
+	// Validate the token is present; the token source below reads it lazily.
+	if _, err := tokenFromSecret(secret, clusterName); err != nil {
+		return nil, err
 	}
 
 	// Initialize cluster configuration.
 	clusterConfig := &rest.Config{
-		BearerToken: string(token),
-		Host:        apiEndpoint,
-		Timeout:     defaultTimeout,
+		Host:    apiEndpoint,
+		Timeout: defaultTimeout,
 	}
 
 	// Handle TLS configuration.
@@ -248,7 +252,49 @@ func BuildClusterConfig(clusterName string,
 		}
 	}
 
+	// Uses a token source that re-reads the Secret instead of a static token; a 401
+	// clears the cache so a revoked token refreshes immediately.
+	// Wrap after the proxy so the proxy round tripper stays innermost.
+	tokenSource := newSecretTokenSource(clusterName, cluster.Spec.SecretRef.Namespace, cluster.Spec.SecretRef.Name, secretGetter)
+	cachedTokenSource := transport.NewCachedTokenSource(tokenSource)
+	clusterConfig.Wrap(transport.ResettableTokenSourceWrapTransport(cachedTokenSource))
+
 	return clusterConfig, nil
+}
+
+// secretTokenSource reads the bearer token from the cluster's Secret, with a
+// tokenRefreshPeriod expiry so the caching wrapper re-reads it periodically.
+type secretTokenSource struct {
+	clusterName     string
+	secretNamespace string
+	secretName      string
+	secretGetter    func(namespace, name string) (*corev1.Secret, error)
+}
+
+func newSecretTokenSource(clusterName, secretNamespace, secretName string,
+	secretGetter func(string, string) (*corev1.Secret, error)) *secretTokenSource {
+	return &secretTokenSource{
+		clusterName:     clusterName,
+		secretNamespace: secretNamespace,
+		secretName:      secretName,
+		secretGetter:    secretGetter,
+	}
+}
+
+// Token implements oauth2.TokenSource.
+func (s *secretTokenSource) Token() (*oauth2.Token, error) {
+	secret, err := s.secretGetter(s.secretNamespace, s.secretName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret for cluster %s: %v", s.clusterName, err)
+	}
+	token, err := tokenFromSecret(secret, s.clusterName)
+	if err != nil {
+		return nil, err
+	}
+	return &oauth2.Token{
+		AccessToken: string(token),
+		Expiry:      time.Now().Add(tokenRefreshPeriod),
+	}, nil
 }
 
 func clusterGetter(client client.Client) func(string) (*clusterv1alpha1.Cluster, error) {
@@ -263,4 +309,12 @@ func secretGetter(client client.Client) func(string, string) (*corev1.Secret, er
 		err := client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, secret)
 		return secret, err
 	}
+}
+
+func tokenFromSecret(secret *corev1.Secret, clusterName string) ([]byte, error) {
+	token, ok := secret.Data[clusterv1alpha1.SecretTokenKey]
+	if !ok || len(token) == 0 {
+		return nil, fmt.Errorf("the secret for cluster %s is missing a non-empty value for %q", clusterName, clusterv1alpha1.SecretTokenKey)
+	}
+	return token, nil
 }

--- a/pkg/util/membercluster_client_rotation_test.go
+++ b/pkg/util/membercluster_client_rotation_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util/gclient"
+)
+
+// rotatableTokenServer is a fake member API server that accepts a mutable set of
+// bearer tokens. A request whose token is not currently accepted gets a 401,
+// which lets tests exercise both the periodic-refresh and 401-reset code paths.
+type rotatableTokenServer struct {
+	*httptest.Server
+
+	mu           sync.Mutex
+	accepted     map[string]bool
+	unauthorized atomic.Int32
+	lastAuth     atomic.Value // string
+}
+
+func newRotatableTokenServer(acceptedTokens ...string) *rotatableTokenServer {
+	s := &rotatableTokenServer{accepted: map[string]bool{}}
+	for _, tok := range acceptedTokens {
+		s.accepted[tok] = true
+	}
+	s.lastAuth.Store("")
+	s.Server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		s.lastAuth.Store(auth)
+
+		token := strings.TrimPrefix(auth, "Bearer ")
+		s.mu.Lock()
+		ok := s.accepted[token]
+		s.mu.Unlock()
+		if !ok {
+			s.unauthorized.Add(1)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"apiVersion":"v1","kind":"Node","metadata":{"name":"foo"}}`))
+	}))
+	return s
+}
+
+// accept replaces the set of tokens the server will accept.
+func (s *rotatableTokenServer) accept(tokens ...string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.accepted = map[string]bool{}
+	for _, tok := range tokens {
+		s.accepted[tok] = true
+	}
+}
+
+func (s *rotatableTokenServer) seenAuth() string { return s.lastAuth.Load().(string) }
+
+const (
+	tokenRotateTimeout  = 2 * time.Second
+	tokenRotatePollRate = 5 * time.Millisecond
+)
+
+// buildRotationClient builds a long-lived client (as the informers do) pointed at
+// srv, backed by a Secret holding initialToken. It returns the client and the
+// host client so the test can rotate the Secret afterwards.
+func buildRotationClient(t *testing.T, srv *rotatableTokenServer, clusterName, initialToken string) (*ClusterClient, client.Client) {
+	t.Helper()
+	hostClient := fakeclient.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(
+		&clusterv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+			Spec: clusterv1alpha1.ClusterSpec{
+				APIEndpoint: srv.URL,
+				SecretRef:   &clusterv1alpha1.LocalSecretReference{Namespace: "ns1", Name: "secret1"},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "secret1"},
+			Data: map[string][]byte{
+				clusterv1alpha1.SecretTokenKey:  []byte(initialToken),
+				clusterv1alpha1.SecretCADataKey: getCACertFromGTestServer(t, srv.Server),
+			},
+		},
+	).Build()
+
+	clusterClient, err := NewClusterClientSet(clusterName, hostClient, nil)
+	assert.NoError(t, err)
+	return clusterClient, hostClient
+}
+
+// rotateSecretToken updates the token stored in the Karmada Secret.
+func rotateSecretToken(t *testing.T, hostClient client.Client, newToken string) {
+	t.Helper()
+	secret := &corev1.Secret{}
+	assert.NoError(t, hostClient.Get(context.TODO(), types.NamespacedName{Namespace: "ns1", Name: "secret1"}, secret))
+	secret.Data[clusterv1alpha1.SecretTokenKey] = []byte(newToken)
+	assert.NoError(t, hostClient.Update(context.TODO(), secret))
+}
+
+// TestBuildClusterConfig_PeriodicRefreshPicksUpRotatedToken verifies the common
+// rotation case: the new token is written while the old one is still valid
+// (overlap), so the periodic re-read swaps to it with no 401 ever occurring.
+func TestBuildClusterConfig_PeriodicRefreshPicksUpRotatedToken(t *testing.T) {
+	// Short period so the cached token expires quickly within the test.
+	orig := tokenRefreshPeriod
+	tokenRefreshPeriod = 10 * time.Millisecond
+	t.Cleanup(func() { tokenRefreshPeriod = orig })
+
+	// Server accepts both tokens for the whole test: models an overlap window.
+	srv := newRotatableTokenServer("token-A", "token-B")
+	defer srv.Close()
+
+	clusterClient, host := buildRotationClient(t, srv, "member-periodic", "token-A")
+
+	_, err := clusterClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), "foo", metav1.GetOptions{})
+	assert.NoError(t, err, "baseline request with token-A should succeed")
+
+	rotateSecretToken(t, host, "token-B")
+
+	assert.Eventually(t, func() bool {
+		_, err := clusterClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), "foo", metav1.GetOptions{})
+		return err == nil && srv.seenAuth() == "Bearer token-B"
+	}, tokenRotateTimeout, tokenRotatePollRate,
+		"after the period elapses the long-lived client must re-read and send token-B without a rebuild")
+
+	assert.Zero(t, srv.unauthorized.Load(), "with an overlap window no request should ever be rejected")
+}
+
+// TestBuildClusterConfig_Recovers401AfterHardRevocation verifies the
+// hard-revocation case: the old token is rejected immediately (no overlap). The
+// period is long so recovery cannot come from a periodic re-read; it must come
+// from the 401-triggered cache reset. Recovery needs a second request because the
+// 401'd request itself is not retried inline.
+func TestBuildClusterConfig_Recovers401AfterHardRevocation(t *testing.T) {
+	// Long period so the periodic path does not fire during the test.
+	orig := tokenRefreshPeriod
+	tokenRefreshPeriod = 10 * time.Minute
+	t.Cleanup(func() { tokenRefreshPeriod = orig })
+
+	srv := newRotatableTokenServer("token-A")
+	defer srv.Close()
+
+	clusterClient, host := buildRotationClient(t, srv, "member-revoke", "token-A")
+
+	_, err := clusterClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), "foo", metav1.GetOptions{})
+	assert.NoError(t, err, "baseline request with token-A should succeed and warm the cache")
+
+	// Hard revocation: server rejects token-A and only accepts token-B.
+	srv.accept("token-B")
+	rotateSecretToken(t, host, "token-B")
+
+	assert.Eventually(t, func() bool {
+		_, err := clusterClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), "foo", metav1.GetOptions{})
+		return err == nil && srv.seenAuth() == "Bearer token-B"
+	}, tokenRotateTimeout, tokenRotatePollRate,
+		"a 401 must reset the cached token so a subsequent request re-reads and sends token-B")
+
+	assert.GreaterOrEqual(t, srv.unauthorized.Load(), int32(1),
+		"recovery must go through at least one 401 (the reset path), not a periodic refresh")
+}
+
+func TestSecretTokenSource_Token(t *testing.T) {
+	const clusterName = "member1"
+
+	t.Run("success returns token with a future expiry", func(t *testing.T) {
+		getter := func(string, string) (*corev1.Secret, error) {
+			return &corev1.Secret{Data: map[string][]byte{clusterv1alpha1.SecretTokenKey: []byte("tok")}}, nil
+		}
+		src := newSecretTokenSource(clusterName, "ns", "name", getter)
+
+		before := time.Now()
+		tok, err := src.Token()
+		assert.NoError(t, err)
+		assert.Equal(t, "tok", tok.AccessToken)
+		assert.WithinDuration(t, before.Add(tokenRefreshPeriod), tok.Expiry, time.Second,
+			"expiry must be stamped ~tokenRefreshPeriod in the future so the cache re-reads")
+	})
+
+	t.Run("getter error is propagated and names the cluster", func(t *testing.T) {
+		getter := func(string, string) (*corev1.Secret, error) { return nil, errors.New("temporarily unavailable") }
+		src := newSecretTokenSource(clusterName, "ns", "name", getter)
+
+		_, err := src.Token()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), clusterName)
+	})
+
+	t.Run("missing token key errors", func(t *testing.T) {
+		getter := func(string, string) (*corev1.Secret, error) {
+			return &corev1.Secret{Data: map[string][]byte{}}, nil
+		}
+		src := newSecretTokenSource(clusterName, "ns", "name", getter)
+
+		_, err := src.Token()
+		assert.Error(t, err)
+	})
+
+	t.Run("empty token value errors", func(t *testing.T) {
+		getter := func(string, string) (*corev1.Secret, error) {
+			return &corev1.Secret{Data: map[string][]byte{clusterv1alpha1.SecretTokenKey: []byte("")}}, nil
+		}
+		src := newSecretTokenSource(clusterName, "ns", "name", getter)
+
+		_, err := src.Token()
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
Cherry-pick of #7663 onto `release-1.16`.

The `/cherry-pick` plugin failed (empty commit in the source PR, plus a `go.mod` conflict), so this was done manually and squashed into one commit.

## Detailed logs on cherry-pick (since it's manual)

<details>
<summary><b>Applying the patch halts because the one we pick has empty commit</b></summary>

```
$ git am -3 /tmp/7663.patch
Applying: fix: push-mode informers pick up rotated bearer token without restart
Applying: address review feedback: 5m token TTL, framework poll defaults, simpler error path, doc/comment tidies
Patch is empty.
```

</details>

<details>
<summary><b>Resolve go.mod</b></summary>

```
$ git am --skip
Applying: fix: refresh push-mode informer bearer token via client-go transport
Using index info to reconstruct a base tree...
M	go.mod
Falling back to patching base and 3-way merge...
Removing pkg/util/round_trippers_token_test.go
Auto-merging go.mod
CONFLICT (content): Merge conflict in go.mod
error: Failed to merge in the changes.
Patch failed at 0004 fix: refresh push-mode informer bearer token via client-go transport

$ git checkout --ours go.mod
$ go mod tidy
$ go mod vendor
$ git add -A

$ git am --continue
Applying: fix: refresh push-mode informer bearer token via client-go transport
Applying: test: drop e2e token rotation test per review discussion

$ git diff upstream/release-1.16 -- go.mod
+	golang.org/x/oauth2 v0.30.0
-	golang.org/x/oauth2 v0.30.0 // indirect
```

</details>

<details>
<summary><b>Validate & Squash</b></summary>

```
$ go build ./...

$ go test ./pkg/util/ -count=1
ok  	github.com/karmada-io/karmada/pkg/util	13.659s

$ git diff --stat upstream/release-1.16
 go.mod                                         |   2 +-
 pkg/util/membercluster_client.go               |  66 ++++++-
 pkg/util/membercluster_client_rotation_test.go | 238 +++++++++++++++++++++++++
 3 files changed, 299 insertions(+), 7 deletions(-)

$ git reset --soft upstream/release-1.16
$ git commit -s -m "fix: push-mode informers pick up rotated bearer token without restart" -m "Cherry-pick of #7663 onto release-1.16." -m "Co-authored-by: Hongcai Ren <qdurenhongcai@gmail.com>"

$ git log --oneline upstream/release-1.16..HEAD
6ffd29f90 fix: push-mode informers pick up rotated bearer token without restart
```

</details>

```release-note
`karmada-controller-manager`: Fixed push-mode informers silently breaking after member cluster token rotation. Long-lived resource watches now pick up rotated credentials automatically via a token-refreshing transport layer.
```
