### PR TITLE
fix: avoid nil pointer dereference on incomplete karmada-agent kubeconfig

### DIFF
--- a/pkg/controllers/certificate/cert_rotation_controller.go
+++ b/pkg/controllers/certificate/cert_rotation_controller.go
@@ -139,18 +139,44 @@ func (c *CertRotationController) SetupWithManager(mgr controllerruntime.Manager)
 		Complete(c)
 }
 
+// resolveCurrentAuthInfo returns the name of the user referenced by the kubeconfig's
+// current context, along with that user's entry.
+//
+// Contexts and AuthInfos are maps of pointers, so a name with no matching entry yields
+// a nil pointer rather than a zero value. clientcmd.Load does not check that
+// current-context names an existing context, or that a context names an existing user,
+// so both are looked up explicitly here.
+func resolveCurrentAuthInfo(config *clientcmdapi.Config) (string, *clientcmdapi.AuthInfo, error) {
+	currentContext, ok := config.Contexts[config.CurrentContext]
+	if !ok {
+		return "", nil, fmt.Errorf("the current context %q is not present in the karmada-agent kubeconfig", config.CurrentContext)
+	}
+
+	clusterName := currentContext.AuthInfo
+	if clusterName == "" {
+		return "", nil, fmt.Errorf("failed to get cluster name, the current context is %s", config.CurrentContext)
+	}
+
+	authInfo, ok := config.AuthInfos[clusterName]
+	if !ok {
+		return "", nil, fmt.Errorf("the user %q referenced by context %q is not present in the karmada-agent kubeconfig", clusterName, config.CurrentContext)
+	}
+
+	return clusterName, authInfo, nil
+}
+
 func (c *CertRotationController) syncCertRotation(ctx context.Context, secret *corev1.Secret) error {
 	karmadaKubeconfig, err := getKubeconfigFromSecret(secret)
 	if err != nil {
 		return err
 	}
 
-	clusterName := karmadaKubeconfig.Contexts[karmadaKubeconfig.CurrentContext].AuthInfo
-	if clusterName == "" {
-		return fmt.Errorf("failed to get cluster name, the current context is %s", karmadaKubeconfig.CurrentContext)
+	clusterName, authInfo, err := resolveCurrentAuthInfo(karmadaKubeconfig)
+	if err != nil {
+		return err
 	}
 
-	oldCertData := karmadaKubeconfig.AuthInfos[clusterName].ClientCertificateData
+	oldCertData := authInfo.ClientCertificateData
 
 	shouldRotate, err := c.shouldRotateCert(oldCertData)
 	if err != nil {
@@ -202,8 +228,8 @@ func (c *CertRotationController) syncCertRotation(ctx context.Context, secret *c
 		return err
 	}
 
-	karmadaKubeconfig.AuthInfos[clusterName].ClientCertificateData = newCertData
-	karmadaKubeconfig.AuthInfos[clusterName].ClientKeyData = keyData
+	authInfo.ClientCertificateData = newCertData
+	authInfo.ClientKeyData = keyData
 
 	karmadaKubeconfigBytes, err := clientcmd.Write(*karmadaKubeconfig)
 	if err != nil {

--- a/pkg/controllers/certificate/cert_rotation_controller_test.go
+++ b/pkg/controllers/certificate/cert_rotation_controller_test.go
@@ -223,6 +223,87 @@ users:
 			signer:    true,
 			wantErr:   true,
 		},
+		{
+			// The kubeconfig maps hold pointers, so a current-context that names no
+			// entry in "contexts" yields a nil *api.Context.
+			name: "current context is not present in contexts",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "secret"},
+				Data: map[string][]byte{"karmada-kubeconfig": []byte(`apiVersion: v1
+clusters:
+- cluster:
+    server: https://192.168.0.180:56016
+  name: kind-member1
+contexts:
+- context:
+    cluster: kind-member1
+    user: kind-member1
+  name: member1
+current-context: not-a-context
+kind: Config
+preferences: {}
+users:
+- name: kind-member1
+  user: {}
+`)},
+			},
+			threshold: 0,
+			signer:    false,
+			wantErr:   true,
+		},
+		{
+			// A context with no user set at all resolves to an empty name, which is
+			// not a valid lookup key for AuthInfos either.
+			name: "current context does not name a user",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "secret"},
+				Data: map[string][]byte{"karmada-kubeconfig": []byte(`apiVersion: v1
+clusters:
+- cluster:
+    server: https://192.168.0.180:56016
+  name: kind-member1
+contexts:
+- name: member1
+current-context: member1
+kind: Config
+preferences: {}
+users:
+- name: kind-member1
+  user: {}
+`)},
+			},
+			threshold: 0,
+			signer:    false,
+			wantErr:   true,
+		},
+		{
+			// Likewise, a context may reference a user that "users" does not define,
+			// yielding a nil *api.AuthInfo.
+			name: "context references a user that is not present in users",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "secret"},
+				Data: map[string][]byte{"karmada-kubeconfig": []byte(`apiVersion: v1
+clusters:
+- cluster:
+    server: https://192.168.0.180:56016
+  name: kind-member1
+contexts:
+- context:
+    cluster: kind-member1
+    user: not-a-user
+  name: member1
+current-context: member1
+kind: Config
+preferences: {}
+users:
+- name: kind-member1
+  user: {}
+`)},
+			},
+			threshold: 0,
+			signer:    false,
+			wantErr:   true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`syncCertRotation` resolved the current context and its user by indexing the kubeconfig maps directly:

```go
clusterName := karmadaKubeconfig.Contexts[karmadaKubeconfig.CurrentContext].AuthInfo
...
oldCertData := karmadaKubeconfig.AuthInfos[clusterName].ClientCertificateData
```

`Config.Contexts` is a `map[string]*api.Context` and `Config.AuthInfos` a `map[string]*api.AuthInfo`, so an absent key yields a nil pointer and the field access on the same line panics.

`clientcmd.Load` only unmarshals — it does not check that `current-context` names an existing context, or that a context references an existing user. So a `karmada-kubeconfig` secret in a member cluster that is truncated, hand-edited, or partially written crashes the cert rotation controller with a nil pointer dereference instead of returning an error, taking down `karmada-agent`.

Note the existing `if clusterName == ""` guard sits *after* the first dereference, so it never protects against this.

This PR looks both entries up with the comma-ok form and returns a descriptive error when either is missing. The resolved `*api.AuthInfo` is reused when writing the rotated certificate back, so the lookup happens once instead of twice.

**Which issue(s) this PR fixes**:

None — found by inspection while reading the cert rotation flow. Happy to open an issue first if you would prefer that.

**Special notes for your reviewer**:

Two regression tests are added to `TestCertRotationController_syncCertRotation`, one per nil case. Both panic against the current code:

```
panic: runtime error: invalid memory address or nil pointer dereference
    .../pkg/controllers/certificate/cert_rotation_controller.go:148
FAIL    github.com/karmada-io/karmada/pkg/controllers/certificate
```

and pass with the fix. I verified this by reverting only the source change and re-running the tests.

The existing cases in that table all use well-formed kubeconfigs, so this path was previously uncovered.

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-controller-manager`: Fixed the issue that the cert rotation controller panicked with a nil pointer dereference when a member cluster's karmada-kubeconfig secret had a current-context or user entry that was not present in the kubeconfig.
```
