### PR TITLE
fix: avoid nil pointer dereference on a dangling kubeconfig context in karmadactl

### DIFF
--- a/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo.go
+++ b/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo.go
@@ -48,12 +48,21 @@ func CreateBootstrapConfigMapIfNotExists(clientSet kubernetes.Interface, file st
 		return err
 	}
 
-	adminCluster := adminConfig.Contexts[adminConfig.CurrentContext].Cluster
+	adminContext, ok := adminConfig.Contexts[adminConfig.CurrentContext]
+	if !ok {
+		return fmt.Errorf("the current context %q is not present in the admin kubeconfig", adminConfig.CurrentContext)
+	}
+
+	adminCluster, ok := adminConfig.Clusters[adminContext.Cluster]
+	if !ok {
+		return fmt.Errorf("the cluster %q referenced by context %q is not present in the admin kubeconfig", adminContext.Cluster, adminConfig.CurrentContext)
+	}
+
 	// Copy the cluster from admin.conf to the bootstrap kubeconfig, contains the CA cert and the server URL
 	klog.V(1).Infoln("[bootstrap-token] copying the cluster from admin.conf to the bootstrap kubeconfig")
 	bootstrapConfig := &clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{
-			"": adminConfig.Clusters[adminCluster],
+			"": adminCluster,
 		},
 	}
 	bootstrapBytes, err := clientcmd.Write(*bootstrapConfig)

--- a/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo_test.go
+++ b/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo_test.go
@@ -111,6 +111,37 @@ users:
 			},
 			wantErr: false,
 		},
+		{
+			// Config.Contexts is a map of pointers, so a current-context that names
+			// no entry yields a nil *api.Context.
+			name:    "CreateBootstrapConfigMapIfNotExists_CurrentContextNotPresent_FailedToResolveContext",
+			client:  fakeclientset.NewClientset(),
+			cfgFile: filepath.Join(os.TempDir(), "config-missing-context.txt"),
+			prep: func(cfgFile string) error {
+				return os.WriteFile(cfgFile, []byte(kubeConfigMissingCurrentContext), 0600)
+			},
+			cleanup: func(cfgFile string) error {
+				return os.Remove(cfgFile)
+			},
+			verify:  func(kubernetes.Interface) error { return nil },
+			wantErr: true,
+			errMsg:  "is not present in the admin kubeconfig",
+		},
+		{
+			// Likewise, the context may name a cluster that "clusters" does not define.
+			name:    "CreateBootstrapConfigMapIfNotExists_ClusterNotPresent_FailedToResolveCluster",
+			client:  fakeclientset.NewClientset(),
+			cfgFile: filepath.Join(os.TempDir(), "config-missing-cluster.txt"),
+			prep: func(cfgFile string) error {
+				return os.WriteFile(cfgFile, []byte(kubeConfigMissingCluster), 0600)
+			},
+			cleanup: func(cfgFile string) error {
+				return os.Remove(cfgFile)
+			},
+			verify:  func(kubernetes.Interface) error { return nil },
+			wantErr: true,
+			errMsg:  "is not present in the admin kubeconfig",
+		},
 		// TODO: Update ConfigMap if it exists.
 	}
 	for _, test := range tests {
@@ -206,3 +237,41 @@ func verifyKubeAdminKubeConfig(client kubernetes.Interface) error {
 	}
 	return nil
 }
+
+// kubeConfigMissingCurrentContext has a current-context that names no entry in contexts.
+const kubeConfigMissingCurrentContext = `apiVersion: v1
+clusters:
+- cluster:
+    server: https://test-cluster:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: does-not-exist
+kind: Config
+preferences: {}
+users:
+- name: test-user
+  user: {}
+`
+
+// kubeConfigMissingCluster has a context referencing a cluster that is not defined.
+const kubeConfigMissingCluster = `apiVersion: v1
+clusters:
+- cluster:
+    server: https://test-cluster:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: not-a-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+kind: Config
+preferences: {}
+users:
+- name: test-user
+  user: {}
+`

--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -283,7 +283,18 @@ func (o *CommandRegisterOption) Complete(args []string) error {
 			return err
 		}
 
-		o.ClusterName = config.Contexts[config.CurrentContext].Cluster
+		// Resolve the same context that RestConfig above used, so that --context is
+		// honoured here too. Contexts is a map of pointers, so an unknown name would
+		// otherwise yield a nil *api.Context and panic on the field access.
+		contextName := config.CurrentContext
+		if o.Context != "" {
+			contextName = o.Context
+		}
+		kubeContext, ok := config.Contexts[contextName]
+		if !ok {
+			return fmt.Errorf("the context %q is not present in kubeconfig file %s", contextName, o.KubeConfig)
+		}
+		o.ClusterName = kubeContext.Cluster
 	}
 
 	o.rbacResources = GenerateRBACResources(o.ClusterName, o.ClusterNamespace)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`Config.Contexts` and `Config.Clusters` are maps of pointers, so an absent key yields a nil `*api.Context` / `*api.Cluster`. Two `karmadactl` paths index them with a name taken from a user-supplied kubeconfig and dereference the result on the same line, so a malformed file becomes a panic instead of an error.

**1. `clusterinfo.CreateBootstrapConfigMapIfNotExists`**

```go
adminCluster := adminConfig.Contexts[adminConfig.CurrentContext].Cluster
...
Clusters: map[string]*clientcmdapi.Cluster{"": adminConfig.Clusters[adminCluster]},
```

A dangling `current-context` panics on the field access. Separately, a context naming a cluster that `clusters` does not define stores a nil `*api.Cluster` into the bootstrap config, which panics a few lines later inside `clientcmd.Write`. Both are covered by the new tests.

**2. `CommandRegisterOption.Complete`**

```go
o.ClusterName = config.Contexts[config.CurrentContext].Cluster
```

This one is a little subtler. The rest config built a few lines above goes through `apiclient.RestConfig`, which applies the `--context` flag as a `clientcmd.ConfigOverrides.CurrentContext` override. This line instead reads the kubeconfig's own `current-context`. So `karmadactl register --context <valid>` against a kubeconfig whose `current-context` is empty or dangling passes `RestConfig` and then panics here — and when it does not panic, the two can disagree about which context is actually in use.

This PR resolves `--context` first and falls back to `current-context`, matching how the rest config was built, and looks every entry up with the comma-ok form.

**Which issue(s) this PR fixes**:

None — found by inspection while auditing this pattern after #7851. Happy to open an issue first if you prefer.

**Special notes for your reviewer**:

Two regression tests are added to `TestCreateBootstrapConfigMapIfNotExists`. Both panic against the current code:

```
panic: runtime error: invalid memory address or nil pointer dereference
    .../clusterinfo/clusterinfo.go:51    # dangling current-context
    .../clusterinfo/clusterinfo.go:59    # context names an undefined cluster (inside clientcmd.Write)
```

and pass with the fix. Verified by reverting only `clusterinfo.go` and re-running.

`pkg/karmadactl/register` has no test files at all, so that path is fixed by inspection only — I did not want to stand up test scaffolding for the whole package inside a bugfix PR. Glad to add it if you would like it here.

The `--context` fallback in `Complete` is a small behaviour change rather than a pure panic guard. I believe it is the correct resolution order given how `RestConfig` is called, but say the word and I will narrow this PR to the nil check alone.

This is the same class of bug as #7851, in a different component.

**Does this PR introduce a user-facing change?**:

```release-note
`karmadactl`: Fixed the issue that `karmadactl init` and `karmadactl register` panicked instead of reporting an error when the kubeconfig had a current-context that named no context, or a context that named an undefined cluster.
```
