### PR TITLE
fix: make the genericresource default constructor decodable and add tests

### DIFF
--- a/pkg/karmadactl/util/genericresource/builder.go
+++ b/pkg/karmadactl/util/genericresource/builder.go
@@ -30,8 +30,11 @@ import (
 
 const defaultHTTPGetAttempts int = 3
 
+// defaultNewFunc builds the object that a document is decoded into when the caller
+// does not supply one through Constructor. It must return a pointer, since the
+// decoding in mapper.infoForData goes through json.Unmarshal.
 var defaultNewFunc = func() any {
-	return map[string]any{}
+	return &map[string]any{}
 }
 
 var errMissingResource = fmt.Errorf(`you must provide one or more resources`)

--- a/pkg/karmadactl/util/genericresource/builder_test.go
+++ b/pkg/karmadactl/util/genericresource/builder_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericresource
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFile writes content into a new file under dir and returns its path.
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	return path
+}
+
+// TestBuilderDefaultConstructor covers the object type used when the caller does
+// not call Constructor. json.Unmarshal rejects a non-pointer target, so a default
+// that is not a pointer fails on every document.
+func TestBuilderDefaultConstructor(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: sample\n")
+
+	objects, err := NewBuilder().Filename(false, path).Do().Objects()
+	require.NoError(t, err)
+	require.Len(t, objects, 1)
+
+	obj, ok := objects[0].(*map[string]any)
+	require.True(t, ok, "unexpected object type %T", objects[0])
+	assert.Equal(t, "ConfigMap", (*obj)["kind"])
+}
+
+func TestBuilderConstructor(t *testing.T) {
+	type configMap struct {
+		Kind     string `json:"kind"`
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+
+	dir := t.TempDir()
+	path := writeFile(t, dir, "cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: sample\n")
+
+	objects, err := NewBuilder().
+		Constructor(func() any { return &configMap{} }).
+		Filename(false, path).
+		Do().
+		Objects()
+	require.NoError(t, err)
+	require.Len(t, objects, 1)
+
+	obj, ok := objects[0].(*configMap)
+	require.True(t, ok, "unexpected object type %T", objects[0])
+	assert.Equal(t, "ConfigMap", obj.Kind)
+	assert.Equal(t, "sample", obj.Metadata.Name)
+}
+
+func TestBuilderErrors(t *testing.T) {
+	dir := t.TempDir()
+	valid := writeFile(t, dir, "cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: sample\n")
+
+	tests := []struct {
+		name         string
+		build        func() *Builder
+		wantErrMatch string
+	}{
+		{
+			name:         "no input at all",
+			build:        func() *Builder { return NewBuilder() },
+			wantErrMatch: "you must provide one or more resources",
+		},
+		{
+			name:         "missing file",
+			build:        func() *Builder { return NewBuilder().Filename(false, filepath.Join(dir, "absent.yaml")) },
+			wantErrMatch: "does not exist",
+		},
+		{
+			// Stdin can only be consumed once.
+			name:         "stdin referenced twice",
+			build:        func() *Builder { return NewBuilder().Filename(false, "-", "-") },
+			wantErrMatch: "standard input cannot be used for multiple arguments",
+		},
+		{
+			name:         "malformed url",
+			build:        func() *Builder { return NewBuilder().Filename(false, "http://[::1") },
+			wantErrMatch: "is not valid",
+		},
+		{
+			name: "directory without recursion still reads its own files",
+			// Included as a control: this one must succeed.
+			build:        func() *Builder { return NewBuilder().Filename(false, valid) },
+			wantErrMatch: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.build().Do().Err()
+			if tt.wantErrMatch == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrMatch)
+		})
+	}
+}
+
+// TestExpandIfFilePattern covers the non-glob paths only. Whether a glob pattern
+// reaches filepath.Glob is platform dependent: on Windows os.Stat rejects "*" as an
+// invalid name rather than reporting it as missing, so the pattern is returned
+// verbatim instead of being expanded.
+func TestExpandIfFilePattern(t *testing.T) {
+	dir := t.TempDir()
+	existing := writeFile(t, dir, "a.yaml", "apiVersion: v1\n")
+
+	tests := []struct {
+		name         string
+		pattern      string
+		want         []string
+		wantErr      bool
+		wantErrMatch string
+	}{
+		{
+			name:    "existing file is returned as is",
+			pattern: existing,
+			want:    []string{existing},
+		},
+		{
+			name:         "missing file with no metacharacters is an error",
+			pattern:      filepath.Join(dir, "absent.yaml"),
+			wantErr:      true,
+			wantErrMatch: "does not exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := expandIfFilePattern(tt.pattern)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMatch)
+				return
+			}
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/karmadactl/util/genericresource/visitor_test.go
+++ b/pkg/karmadactl/util/genericresource/visitor_test.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericresource
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIgnoreFile(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		extensions []string
+		want       bool
+	}{
+		{
+			// No extension filter means every file is accepted.
+			name: "no extensions accepts everything",
+			path: "manifest.txt",
+			want: false,
+		},
+		{
+			name:       "matching extension is kept",
+			path:       "manifest.yaml",
+			extensions: []string{".json", ".yaml", ".yml"},
+			want:       false,
+		},
+		{
+			name:       "unmatched extension is ignored",
+			path:       "README.md",
+			extensions: []string{".json", ".yaml", ".yml"},
+			want:       true,
+		},
+		{
+			// filepath.Ext returns "" here, which is not in the list.
+			name:       "file without extension is ignored",
+			path:       "Makefile",
+			extensions: []string{".json", ".yaml", ".yml"},
+			want:       true,
+		},
+		{
+			name:       "extension match is case sensitive",
+			path:       "manifest.YAML",
+			extensions: []string{".json", ".yaml", ".yml"},
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ignoreFile(tt.path, tt.extensions))
+		})
+	}
+}
+
+// countingBody reports whether the reader was closed, so the retry loop can be
+// checked for leaking response bodies.
+type countingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (c *countingBody) Close() error {
+	c.closed = true
+	return nil
+}
+
+// stubResponse is one canned reply from the stubbed httpget.
+type stubResponse struct {
+	code int
+	err  error
+}
+
+func TestReadHTTPWithRetries(t *testing.T) {
+	tests := []struct {
+		name         string
+		responses    []stubResponse
+		attempts     int
+		wantCalls    int
+		wantErr      bool
+		wantErrMatch string
+	}{
+		{
+			name:         "non positive attempts is rejected without calling get",
+			attempts:     0,
+			wantCalls:    0,
+			wantErr:      true,
+			wantErrMatch: "http attempts must be greater than 0",
+		},
+		{
+			name:      "success on the first attempt",
+			responses: []stubResponse{{code: http.StatusOK}},
+			attempts:  3,
+			wantCalls: 1,
+		},
+		{
+			name: "server errors are retried until one succeeds",
+			responses: []stubResponse{
+				{code: http.StatusInternalServerError},
+				{code: http.StatusBadGateway},
+				{code: http.StatusOK},
+			},
+			attempts:  3,
+			wantCalls: 3,
+		},
+		{
+			// 4xx is a client error, so retrying cannot help.
+			name: "client errors are not retried",
+			responses: []stubResponse{
+				{code: http.StatusNotFound},
+				{code: http.StatusOK},
+			},
+			attempts:     3,
+			wantCalls:    1,
+			wantErr:      true,
+			wantErrMatch: "status code=404",
+		},
+		{
+			name: "transport errors are retried",
+			responses: []stubResponse{
+				{err: errors.New("connection refused")},
+				{code: http.StatusOK},
+			},
+			attempts:  2,
+			wantCalls: 2,
+		},
+		{
+			name: "gives up after the last attempt",
+			responses: []stubResponse{
+				{code: http.StatusInternalServerError},
+				{code: http.StatusInternalServerError},
+			},
+			attempts:     2,
+			wantCalls:    2,
+			wantErr:      true,
+			wantErrMatch: "status code=500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int
+			var bodies []*countingBody
+
+			get := func(string) (int, string, io.ReadCloser, error) {
+				i := calls
+				calls++
+				require.Less(t, i, len(tt.responses), "get called more often than the test has responses")
+				r := tt.responses[i]
+				if r.err != nil {
+					return 0, "", nil, r.err
+				}
+				body := &countingBody{Reader: strings.NewReader("payload")}
+				bodies = append(bodies, body)
+				return r.code, http.StatusText(r.code), body, nil
+			}
+
+			body, err := readHTTPWithRetries(get, time.Nanosecond, "http://example.com/manifest.yaml", tt.attempts)
+
+			assert.Equal(t, tt.wantCalls, calls, "unexpected number of attempts")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrMatch != "" {
+					assert.Contains(t, err.Error(), tt.wantErrMatch)
+				}
+				assert.Nil(t, body)
+				// A body belonging to a failed attempt must not be leaked.
+				for i, b := range bodies {
+					assert.True(t, b.closed, "body from attempt %d was not closed", i)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, body)
+			got, readErr := io.ReadAll(body)
+			require.NoError(t, readErr)
+			assert.Equal(t, "payload", string(got))
+			require.NoError(t, body.Close())
+
+			// Only the body that was handed back stays open; earlier ones are closed.
+			for i, b := range bodies[:len(bodies)-1] {
+				assert.True(t, b.closed, "body from attempt %d was not closed", i)
+			}
+		})
+	}
+}
+
+func TestStreamVisitorVisit(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantNames    []string
+		wantErr      bool
+		wantErrMatch string
+	}{
+		{
+			name:      "single document",
+			input:     "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: first\n",
+			wantNames: []string{"first"},
+		},
+		{
+			name: "multiple documents are visited in order",
+			input: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: first\n" +
+				"---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: second\n",
+			wantNames: []string{"first", "second"},
+		},
+		{
+			// Documents that carry nothing are skipped rather than surfaced.
+			name: "empty documents are skipped",
+			input: "---\n\n---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: only\n" +
+				"---\n\n",
+			wantNames: []string{"only"},
+		},
+		{
+			name:      "explicit null document is skipped",
+			input:     "null\n---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: only\n",
+			wantNames: []string{"only"},
+		},
+		{
+			name:         "malformed document reports the source",
+			input:        "\tbad: indentation\n",
+			wantErr:      true,
+			wantErrMatch: "error parsing testsource",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewStreamVisitor(
+				strings.NewReader(tt.input),
+				&mapper{newFunc: defaultNewFunc},
+				"testsource",
+				nil,
+			)
+
+			var names []string
+			err := v.Visit(func(info *Info, visitErr error) error {
+				if visitErr != nil {
+					return visitErr
+				}
+				obj, ok := info.Object.(*map[string]any)
+				require.True(t, ok, "unexpected object type %T", info.Object)
+				metadata, ok := (*obj)["metadata"].(map[string]any)
+				require.True(t, ok, "object has no metadata")
+				name, ok := metadata["name"].(string)
+				require.True(t, ok, "object has no metadata.name")
+				names = append(names, name)
+				assert.Equal(t, "testsource", info.Source)
+				return nil
+			})
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMatch)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantNames, names)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`Builder.Constructor` lets a caller choose the type each document is decoded into. When it is not called, the builder falls back to `defaultNewFunc`:

```go
var defaultNewFunc = func() any {
	return map[string]any{}
}
```

`mapper.infoForData` decodes through `json.Unmarshal`, which rejects a target that is not a pointer. So the default fails on every document:

```
json: Unmarshal(non-pointer map[string]interface {})
```

The only in-tree caller (`karmadactl interpret`) passes its own constructor, so the broken default has never been exercised — but any new caller relying on the documented default would hit this immediately. This PR returns a pointer and notes the requirement next to it.

I found this while writing the tests below, not by reading the code.

**Which issue(s) this PR fixes**:

None — found while adding test coverage. Happy to open an issue first if you would prefer.

**Special notes for your reviewer**:

This package had no tests at all, so the second half of the PR adds the first ones: the builder and its error paths, `expandIfFilePattern`, `ignoreFile`, the stream visitor (multi-document, empty and `null` documents, malformed input), and `readHTTPWithRetries`. Statement coverage goes from **0% to ~71%**.

The retry tests use the existing `httpget` seam, which already carries the comment *"Exists for unit test stubbing"*. They assert the attempt count as well as the outcome, so they distinguish "retried a 500" from "did not retry a 404", and they check that a non-2xx response body is closed rather than leaked.

`TestBuilderDefaultConstructor` and `TestStreamVisitorVisit` both fail against the unfixed `defaultNewFunc`; I verified that by reverting only `builder.go` and re-running.

One deliberate omission: `expandIfFilePattern`'s glob branch is not covered. Whether a pattern reaches `filepath.Glob` is platform dependent — on Windows `os.Stat("dir/*.yaml")` reports an invalid name rather than a missing file, so the pattern is returned verbatim instead of expanded. That mirrors `k8s.io/cli-runtime`, so I left the behaviour alone and tested only the deterministic paths rather than writing an assertion that passes in CI and fails for contributors on Windows. There is a comment on the test saying so.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
