### PR TITLE
cleanup: remove recreate metric label and format helper signatures

### DIFF
--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -360,7 +360,7 @@ func (c *Controller) tryCreateOrUpdateWorkload(ctx context.Context, clusterName 
 			return err
 		}
 		err = c.ObjectWatcher.Create(ctx, clusterName, workload)
-		metrics.CountCreateResourceToCluster(err, workload.GetAPIVersion(), workload.GetKind(), clusterName, false)
+		metrics.CountCreateResourceToCluster(err, workload.GetAPIVersion(), workload.GetKind(), clusterName)
 		if err != nil {
 			return err
 		}

--- a/pkg/metrics/resource.go
+++ b/pkg/metrics/resource.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metrics
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -73,8 +72,8 @@ var (
 
 	createResourceWhenSyncWork = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: createResourceToCluster,
-		Help: "Number of creation operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'), 'recreate' indicates whether the operation is recreated (true/false); the 'recreate' label is deprecated since v1.19, always reports 'false' now that resource recreation is handled through the execution controller's normal reconciliation path, and will be removed in a future release. Labels 'apiversion', 'kind', and 'member_cluster' specify the resource type, API version, and target cluster respectively.",
-	}, []string{"result", "apiversion", "kind", memberClusterLabel, "recreate"})
+		Help: "Number of creation operations against a target member cluster. The 'result' label indicates the outcome ('success' or 'error'). Labels 'apiversion', 'kind', and 'member_cluster' specify the API version, resource kind, and target cluster respectively.",
+	}, []string{"result", "apiversion", "kind", memberClusterLabel})
 
 	updateResourceWhenSyncWork = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: updateResourceToCluster,
@@ -138,13 +137,12 @@ func ObserveSyncWorkloadLatency(err error, start time.Time) {
 }
 
 // CountCreateResourceToCluster records the number of creation operations of the resource for a target member cluster.
-func CountCreateResourceToCluster(err error, apiVersion, kind, cluster string, recreate bool) {
+func CountCreateResourceToCluster(err error, apiVersion, kind, cluster string) {
 	createResourceWhenSyncWork.WithLabelValues(
 		utilmetrics.GetResultByError(err),
 		apiVersion,
 		kind,
 		cluster,
-		strconv.FormatBool(recreate),
 	).Inc()
 }
 

--- a/pkg/metrics/resource_test.go
+++ b/pkg/metrics/resource_test.go
@@ -32,14 +32,14 @@ func TestCountCreateResourceToCluster(t *testing.T) {
 	apiVersion := "v1"
 	kind := "Pod"
 
-	CountCreateResourceToCluster(nil, apiVersion, kind, cluster, true)
-	CountCreateResourceToCluster(fmt.Errorf("boom"), apiVersion, kind, cluster, false)
+	CountCreateResourceToCluster(nil, apiVersion, kind, cluster)
+	CountCreateResourceToCluster(fmt.Errorf("boom"), apiVersion, kind, cluster)
 
 	want := `
-# HELP create_resource_to_cluster Number of creation operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'), 'recreate' indicates whether the operation is recreated (true/false); the 'recreate' label is deprecated since v1.19, always reports 'false' now that resource recreation is handled through the execution controller's normal reconciliation path, and will be removed in a future release. Labels 'apiversion', 'kind', and 'member_cluster' specify the resource type, API version, and target cluster respectively.
+# HELP create_resource_to_cluster Number of creation operations against a target member cluster. The 'result' label indicates the outcome ('success' or 'error'). Labels 'apiversion', 'kind', and 'member_cluster' specify the API version, resource kind, and target cluster respectively.
 # TYPE create_resource_to_cluster counter
-create_resource_to_cluster{apiversion="v1",kind="Pod",member_cluster="member-1",recreate="false",result="error"} 1
-create_resource_to_cluster{apiversion="v1",kind="Pod",member_cluster="member-1",recreate="true",result="success"} 1
+create_resource_to_cluster{apiversion="v1",kind="Pod",member_cluster="member-1",result="error"} 1
+create_resource_to_cluster{apiversion="v1",kind="Pod",member_cluster="member-1",result="success"} 1
 `
 	if err := promtestutil.CollectAndCompare(createResourceWhenSyncWork, strings.NewReader(want), createResourceToCluster); err != nil {
 		t.Fatalf("unexpected collecting result:\n%s", err)

--- a/pkg/util/helper/cache.go
+++ b/pkg/util/helper/cache.go
@@ -41,15 +41,7 @@ import (
 // RegisterInformerHandlerAndCheckSynced registers the handler with the member-cluster informers
 // for the given resources, creating the informers if necessary. It returns whether those informers
 // have already synced without waiting.
-func RegisterInformerHandlerAndCheckSynced(
-	cluster *clusterv1alpha1.Cluster,
-	gvrTargets []schema.GroupVersionResource,
-	handler cache.ResourceEventHandler,
-	manager genericmanager.MultiClusterInformerManager,
-	clusterClientSetFunc util.NewClusterDynamicClientSetFunc,
-	kubeClientSet client.Client,
-	clusterClientOption *util.ClientOption,
-) (bool, error) {
+func RegisterInformerHandlerAndCheckSynced(cluster *clusterv1alpha1.Cluster, gvrTargets []schema.GroupVersionResource, handler cache.ResourceEventHandler, manager genericmanager.MultiClusterInformerManager, clusterClientSetFunc util.NewClusterDynamicClientSetFunc, kubeClientSet client.Client, clusterClientOption *util.ClientOption) (bool, error) {
 	singleClusterInformerManager, err := getSingleClusterManager(cluster, manager, clusterClientSetFunc, kubeClientSet, clusterClientOption)
 	if err != nil {
 		return false, err
@@ -90,13 +82,7 @@ func RegisterInformerHandlerAndCheckSynced(
 	return false, nil
 }
 
-func getSingleClusterManager(
-	cluster *clusterv1alpha1.Cluster,
-	manager genericmanager.MultiClusterInformerManager,
-	clusterClientSetFunc util.NewClusterDynamicClientSetFunc,
-	kubeClientSet client.Client,
-	clusterClientOption *util.ClientOption,
-) (genericmanager.SingleClusterInformerManager, error) {
+func getSingleClusterManager(cluster *clusterv1alpha1.Cluster, manager genericmanager.MultiClusterInformerManager, clusterClientSetFunc util.NewClusterDynamicClientSetFunc, kubeClientSet client.Client, clusterClientOption *util.ClientOption) (genericmanager.SingleClusterInformerManager, error) {
 	singleClusterInformerManager := manager.GetSingleClusterManager(cluster.Name)
 	if singleClusterInformerManager != nil {
 		return singleClusterInformerManager, nil
@@ -111,11 +97,7 @@ func getSingleClusterManager(
 }
 
 // GetObjectFromCache gets full object information from cache by key in worker queue.
-func GetObjectFromCache(
-	restMapper meta.RESTMapper,
-	manager genericmanager.MultiClusterInformerManager,
-	fedKey keys.FederatedKey,
-) (*unstructured.Unstructured, error) {
+func GetObjectFromCache(restMapper meta.RESTMapper, manager genericmanager.MultiClusterInformerManager, fedKey keys.FederatedKey) (*unstructured.Unstructured, error) {
 	gvr, err := restmapper.GetGroupVersionResource(restMapper, fedKey.GroupVersionKind())
 	if err != nil {
 		klog.Errorf("Failed to get GVR from GVK %s. Error: %v", fedKey.GroupVersionKind(), err)
@@ -152,8 +134,7 @@ func GetObjectFromCache(
 }
 
 // GetObjectFromSingleClusterCache gets full object information from single cluster cache by key in worker queue.
-func GetObjectFromSingleClusterCache(restMapper meta.RESTMapper, manager genericmanager.SingleClusterInformerManager,
-	cwk *keys.ClusterWideKey) (*unstructured.Unstructured, error) {
+func GetObjectFromSingleClusterCache(restMapper meta.RESTMapper, manager genericmanager.SingleClusterInformerManager, cwk *keys.ClusterWideKey) (*unstructured.Unstructured, error) {
 	gvr, err := restmapper.GetGroupVersionResource(restMapper, cwk.GroupVersionKind())
 	if err != nil {
 		klog.Errorf("Failed to get GVR from GVK %s. Error: %v", cwk.GroupVersionKind(), err)
@@ -181,11 +162,7 @@ func GetObjectFromSingleClusterCache(restMapper meta.RESTMapper, manager generic
 }
 
 // getObjectFromSingleCluster will try to get resource from single cluster by DynamicClientSet.
-func getObjectFromSingleCluster(
-	gvr schema.GroupVersionResource,
-	cwk *keys.ClusterWideKey,
-	dynamicClient dynamic.Interface,
-) (*unstructured.Unstructured, error) {
+func getObjectFromSingleCluster(gvr schema.GroupVersionResource, cwk *keys.ClusterWideKey, dynamicClient dynamic.Interface) (*unstructured.Unstructured, error) {
 	obj, err := dynamicClient.Resource(gvr).Namespace(cwk.Namespace).Get(context.TODO(), cwk.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

After #7552, resource recreation is handled through the execution controller's normal reconciliation path, leaving `recreate` always `false`.

This PR removes the obsolete parameter and metric label, and formats function signatures in `pkg/util/helper/cache.go`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-controller-manager`: Removed the `recreate` label from the `create_resource_to_cluster` metric, which was deprecated in v1.19 and always reported `false`. Users should update any PromQL queries, alerts, and dashboards that filter on or group by this label.
```
