### PR TITLE
feat: retain replicas for StatefulSet

### DIFF
--- a/pkg/resourceinterpreter/default/native/default_test.go
+++ b/pkg/resourceinterpreter/default/native/default_test.go
@@ -69,6 +69,15 @@ func TestHookEnabled(t *testing.T) {
 			operationType: configv1alpha1.InterpreterOperationRetain,
 			want:          true,
 		}, {
+			name: "statefulset with retain operation enabled",
+			kind: schema.GroupVersionKind{
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "StatefulSet",
+			},
+			operationType: configv1alpha1.InterpreterOperationRetain,
+			want:          true,
+		}, {
 			name: "ingress with aggregatestatus operation enabled",
 			kind: schema.GroupVersionKind{
 				Group:   "networking.k8s.io",

--- a/pkg/resourceinterpreter/default/native/retain.go
+++ b/pkg/resourceinterpreter/default/native/retain.go
@@ -36,6 +36,7 @@ type retentionInterpreter func(desired *unstructured.Unstructured, observed *uns
 func getAllDefaultRetentionInterpreter() map[schema.GroupVersionKind]retentionInterpreter {
 	s := make(map[schema.GroupVersionKind]retentionInterpreter)
 	s[appsv1.SchemeGroupVersion.WithKind(util.DeploymentKind)] = retainWorkloadReplicas
+	s[appsv1.SchemeGroupVersion.WithKind(util.StatefulSetKind)] = retainWorkloadReplicas
 	s[corev1.SchemeGroupVersion.WithKind(util.PodKind)] = retainPodFields
 	s[corev1.SchemeGroupVersion.WithKind(util.ServiceKind)] = lifted.RetainServiceFields
 	s[corev1.SchemeGroupVersion.WithKind(util.ServiceAccountKind)] = lifted.RetainServiceAccountFields

--- a/pkg/resourceinterpreter/default/native/retain_test.go
+++ b/pkg/resourceinterpreter/default/native/retain_test.go
@@ -80,6 +80,42 @@ func Test_retainK8sWorkloadReplicas(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "statefulset is controlled by hpa",
+			args: args{
+				desired: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+						Labels: map[string]string{
+							util.RetainReplicasLabel: util.RetainReplicasValue,
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: &desiredNum,
+					},
+				},
+				observed: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: &observedNum,
+					},
+				},
+			},
+			want: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nginx",
+					Labels: map[string]string{
+						util.RetainReplicasLabel: util.RetainReplicasValue,
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: &observedNum,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "deployment is not control by hpa",
 			args: args{
 				desired: &appsv1.Deployment{
@@ -707,6 +743,7 @@ func Test_retainPodFields(t *testing.T) {
 func Test_getAllDefaultRetentionInterpreter(t *testing.T) {
 	expectedKinds := []schema.GroupVersionKind{
 		{Group: "apps", Version: "v1", Kind: "Deployment"},
+		{Group: "apps", Version: "v1", Kind: "StatefulSet"},
 		{Group: "", Version: "v1", Kind: "Pod"},
 		{Group: "", Version: "v1", Kind: "Service"},
 		{Group: "", Version: "v1", Kind: "ServiceAccount"},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

## What this PR does / why we need it

This PR adds native replica retention support for `apps/v1 StatefulSet`.

Karmada already retains `spec.replicas` for Deployments when the resource
template has the `resourcetemplate.karmada.io/retain-replicas: "true"` label.
StatefulSets did not register the same native retention interpreter, so their
replica count was overwritten by the template during synchronization.

This change reuses the existing `retainWorkloadReplicas` implementation for
StatefulSets. The default behavior remains unchanged: replicas are retained
only when the label is explicitly set to `"true"`.

## Which issue(s) this PR fixes

None.

Related to #3458.

## Special notes for your reviewer

Tests cover:
- retaining observed StatefulSet replicas when the label is set;
- StatefulSet retain hook registration;
- native retention interpreter registry coverage.

## Does this PR introduce a user-facing change?

```release-note
Karmada now supports retaining StatefulSet replicas when the resource template
is labeled with `resourcetemplate.karmada.io/retain-replicas: "true"`.

