### PR TITLE
add generating release notes skills

### DIFF
--- a/.claude/skills/generating-release-notes/SKILL.md
+++ b/.claude/skills/generating-release-notes/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: generating-release-notes
+description: "Use when preparing changelogs or release notes from merged pull requests for a patch, minor, or preview release."
+argument-hint: "Target release version, for example v1.14.5 or v1.15.0-rc.0"
+---
+
+# Generating Release Notes
+
+## Overview
+
+Generate release notes from merged pull requests. Complete each gate in order; do not draft content until the target version, comparison range, and format plugin are resolved.
+
+## Inputs
+
+Require a target version. If it is absent or ambiguous, ask for it and stop. Do not infer "the next release."
+
+Derive these values only after the target is known:
+
+- Release type: patch, minor, or preview.
+- Previous version or preview tag.
+- Comparison branch.
+- Output changelog path.
+
+The selected format plugin defines repository-specific derivation rules.
+
+## Select a Format Plugin
+
+1. Determine the Git repository root directory name with `basename "$(git rev-parse --show-toplevel)"`.
+2. Inspect Markdown files under [references](./references/). Select a plugin whose `Repository Match` includes that directory name.
+3. If exactly one plugin matches, load it and follow it as authoritative.
+4. If multiple plugins match, ask the user to choose.
+5. If no plugin matches, stop and report the directory name. Ask for a new repository format plugin. Never silently use another repository's format.
+
+Repository format plugins are pluggable. Add `<repository>-release-note-format.md` under `references/` with these sections:
+
+- `Repository Match`
+- `Upstream Data Source`
+- `Version Resolution`
+- `Output Location`
+- `Document Structure`
+- `Entry Format and Classification`
+- `Language and Style`
+- `Validation`
+
+## Mandatory Workflow
+
+### Gate 1: Resolve the Release Range
+
+1. Classify the target as patch, minor, or preview using the selected plugin.
+2. Resolve the previous tag and head branch using the plugin's rules.
+3. Verify the target, previous tag, branch, and output path against the user-visible task context.
+4. Stop on any ambiguity. Do not substitute a different tag or branch without confirmation.
+
+Do not continue until Gate 1 passes.
+
+### Gate 2: Collect Merged Pull Requests
+
+1. Verify that `python3` and the bundled [fetch_pr_info.py](./scripts/fetch_pr_info.py) exist.
+2. Verify that `GITHUB_TOKEN` is set, but do not verify its scopes. If it is not set, ask the user to set a token with the `public_repo` scope in their environment. Never ask the user to send a token through chat.
+3. From the repository root, run the bundled script with the base tag and head branch resolved in Gate 1 and the `owner/repository` value declared under the plugin's `Upstream Data Source`:
+
+	```bash
+	python3 .claude/skills/generating-release-notes/scripts/fetch_pr_info.py <base-tag> <head-branch> --repo <owner/repository>
+	```
+
+4. Use only the `SUMMARY OF PRS WITH USER-FACING CHANGES` section. Ignore diagnostic and non-user-facing PR output.
+5. Preserve PR number, title, author, kind, and every user-facing change. Split multiple user-facing changes into separate candidate entries.
+
+Do not continue if collection fails or credentials are invalid.
+
+### Gate 3: Collect Contributors
+
+Run this gate only when the selected format plugin requires a Contributors section.
+
+1. Reuse the same base tag and head branch resolved in Gate 1. Contributor collection and PR collection must use the same comparison range.
+2. From the repository root, run the bundled [fetch_contributors.sh](./scripts/fetch_contributors.sh) with the owner and repository declared under `Upstream Data Source`:
+
+	```bash
+	.claude/skills/generating-release-notes/scripts/fetch_contributors.sh <owner> <repository> <base-tag> <head-branch>
+	```
+
+3. Treat the output as the GitHub authors of commits merged in that comparison range.
+4. Keep unique GitHub handles sorted alphabetically.
+
+Do not continue if contributor collection fails.
+
+### Gate 4: Classify and Draft
+
+1. Use the PR kind supplied by the collection script as the primary classification signal.
+2. Apply the plugin's category precedence rules.
+3. Rewrite each entry into the plugin's required tense and entry syntax without changing its technical meaning. Make the leading verb and sentence framing match the final category; moving an entry between categories requires reviewing and, when necessary, rewriting its wording.
+4. Group entries as required by the plugin.
+5. Build the complete release section using the structure for the target release type.
+6. Add the commit authors collected in Gate 3 when the release requires a Contributors section.
+
+Do not invent user-facing changes or infer undocumented behavior from a PR title alone.
+
+### Gate 5: Update the Changelog
+
+1. Read the existing changelog before editing.
+2. Insert the new release in the ordering required by the plugin.
+3. Preserve existing release sections and unrelated user changes.
+4. Run the plugin's TOC or formatting command after content is final.
+
+### Gate 6: Validate
+
+Verify the repository-independent requirements:
+
+- No user-facing change is duplicated or omitted.
+- Existing changelog content and unrelated user changes are preserved.
+
+Run every check in the selected plugin's `Validation` section. Fix all failures before finishing.
+
+### Gate 7: Improve this skill
+
+After the release-note generation is done, review what you learned. If you found something that would help future release-note runs — a new failure pattern, a better command, a log location not listed here, or a wrong assumption in this document — propose an update to this skill file:
+
+- Show the user the proposed change and let them decide whether to apply it.
+- Do not commit the change yourself.
+
+## Common Failures
+
+| Failure | Required response |
+|---|---|
+| Target version is missing | Ask for it; do not guess. |
+| No format plugin matches | Stop and request a plugin. |
+| PR or contributor collection fails | Report the error and stop; do not invent or substitute data. |

--- a/.claude/skills/generating-release-notes/references/karmada-release-note-format.md
+++ b/.claude/skills/generating-release-notes/references/karmada-release-note-format.md
@@ -1,0 +1,142 @@
+# Karmada Release Note Format
+
+## Repository Match
+
+- Git repository root directory name: `karmada`
+
+Select this format whenever the Git repository root directory is named `karmada`.
+
+## Upstream Data Source
+
+- GitHub owner: `karmada-io`
+- GitHub repository: `karmada`
+- Script `--repo` value: `karmada-io/karmada`
+
+Always collect comparison and pull request data from `karmada-io/karmada`, regardless of the local fork owner. Do not derive the data source owner from the local `origin` URL.
+
+## Version Resolution
+
+Classify versions as follows:
+
+- Patch: `vX.Y.Z` where `Z > 0`. The base is `vX.Y.(Z-1)`, and the head is `release-X.Y`.
+- Minor: `vX.Y.0`. Use `vX.Y.0-alpha.0` as the base and `master` as the head.
+- Preview: `vX.Y.0-alpha.1`, `vX.Y.0-alpha.2`, `vX.Y.0-beta.0`, or `vX.Y.0-rc.0`. Use the previous preview tag and `master` as the head.
+
+The expected preview sequence is:
+
+1. `vX.Y.0-alpha.1`, based on `vX.Y.0-alpha.0`
+2. `vX.Y.0-alpha.2`, based on `vX.Y.0-alpha.1`
+3. `vX.Y.0-beta.0`, based on `vX.Y.0-alpha.2`
+4. `vX.Y.0-rc.0`, based on `vX.Y.0-beta.0`
+
+Confirm unusual or skipped preview sequences with the user.
+
+## Output Location
+
+Update `docs/CHANGELOG/CHANGELOG-X.Y.md`. This file contains the minor, preview, and all patch release notes for release line `X.Y`.
+
+Order patch sections by version descending. Preserve the established placement of minor and preview sections in the existing file.
+
+## Document Structure
+
+### Patch Release
+
+```markdown
+# vX.Y.Z
+## Downloads for vX.Y.Z
+## Changelog since vX.Y.(Z-1)
+### Changes by Kind
+#### Bug Fixes
+#### Others
+```
+
+Place fixes under `Bug Fixes`. Place other changes, including dependency upgrades, under `Others`. Preserve the exact capitalization already used by the target changelog when it differs from this schematic.
+
+### Minor Release
+
+```markdown
+# vX.Y.0
+## Downloads for vX.Y.0
+## Urgent Update Notes
+## What's New
+## Other Notable Changes
+### API Changes
+### Features & Enhancements
+### Deprecation
+### Bug Fixes
+### Security
+## Other
+### Dependencies
+### Helm Charts
+### Instrumentation
+### Performance
+## Contributors
+
+Thank you to everyone who contributed to this release!
+
+Users whose commits are in this release (alphabetically by username)
+
+- @xxxA
+- @xxxB
+```
+
+`Urgent Update Notes` and `What's New` remain empty and are reserved for manual completion. Build `Contributors` from the commit authors collected with the same comparison range used for pull requests, excluding accounts whose usernames end in `[bot]`, such as `dependabot[bot]` and `github-actions[bot]`.
+
+### Preview Release
+
+```markdown
+# vX.Y.0-<preview>
+## Downloads for vX.Y.0-<preview>
+## Changelog since <previous-preview-version>
+## Urgent Update Notes
+## Changes by Kind
+### API Changes
+### Features & Enhancements
+### Deprecation
+### Bug Fixes
+### Security
+## Other
+### Dependencies
+### Helm Charts
+### Instrumentation
+### Performance
+```
+
+## Entry Format and Classification
+
+Every entry uses this syntax:
+
+```markdown
+- `<component>`: <change> ([#<PR>](https://github.com/karmada-io/karmada/pull/<PR>), @<author>)
+```
+
+Rules:
+
+- Mark component names with backticks, for example `karmada-controller-manager`.
+- Keep entries for the same component together within a category.
+- If one PR contains multiple user-facing changes, write one entry for each change and retain the same PR attribution.
+- Use the PR's kind as the primary classification signal. For example, `feature` maps to `Features & Enhancements` and `bug` maps to `Bug Fixes`.
+- Only use the title, description, and user-facing change as the primary signal when the kind is empty.
+- Specialized categories may override the kind-based category when the user-facing change clearly belongs to them. Classify API changes in `API Changes`, dependency version changes in `Dependencies`, Helm packaging changes in `Helm Charts`, metrics or observability changes in `Instrumentation`, performance work in `Performance`, deprecations in `Deprecation`, and security corrections in `Security`.
+- Outside those specialized categories, wording such as "fix" or "feature" in the title, description, or user-facing change must not override an available kind.
+- When one PR contains changes belonging to different categories, classify each split entry independently.
+
+## Language and Style
+
+- Write all release-note content in English.
+- Match the leading verb to the final category, even when the original user-facing change uses different framing.
+- `Features & Enhancements` entries describe the capability that was introduced or enabled and normally begin with verbs such as "Added," "Introduced," "Enabled," or "Supported." Do not leave a feature entry framed as "Fixed" merely because the original PR description used that word.
+- `Bug Fixes` entries describe the corrected defect and normally begin with "Fixed" or "Corrected."
+- `API Changes` entries describe the API operation directly, using verbs such as "Added," "Introduced," "Updated," "Removed," or "Deprecated" as appropriate.
+- Deprecation entries use present perfect tense, for example, "has been deprecated."
+- Dependency entries use present perfect or simple past tense, for example, "has been upgraded to" or "Upgraded to."
+- Features, fixes, and all other categories use simple past tense.
+- Present-tense constructions such as "now supports" or "no longer relies on" are allowed only for a newly introduced capability or behavioral change.
+- Correct spelling and grammar while preserving technical meaning and exact identifiers.
+
+## Validation
+
+1. Confirm category, component grouping, tense, PR URL, and author syntax for every entry.
+2. For minor releases, confirm contributors exclude usernames ending in `[bot]`, are unique, and are alphabetically sorted.
+3. Run `doctoc docs/CHANGELOG/CHANGELOG-X.Y.md` after the release section is complete.
+4. The final changelog should have correct release ordering, an updated TOC, and no unrelated changes.

--- a/.claude/skills/generating-release-notes/scripts/fetch_contributors.sh
+++ b/.claude/skills/generating-release-notes/scripts/fetch_contributors.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function usage() {
+  echo "Usage: $0 <owner> <repository> <base-ref> <head-ref>" >&2
+}
+
+if [[ $# -ne 4 ]]; then
+  usage
+  exit 2
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "Error: GITHUB_TOKEN is not set" >&2
+  exit 2
+fi
+
+for command in curl jq; do
+  if ! command -v "${command}" > /dev/null 2>&1; then
+    echo "Error: required command '${command}' was not found" >&2
+    exit 2
+  fi
+done
+
+repo_owner=$1
+repo_name=$2
+base_ref=$3
+head_ref=$4
+encoded_base_ref=$(printf '%s' "${base_ref}" | jq -sRr @uri)
+encoded_head_ref=$(printf '%s' "${head_ref}" | jq -sRr @uri)
+
+temp_dir=$(mktemp -d)
+trap 'rm -rf "${temp_dir}"' EXIT
+authors_file="${temp_dir}/authors"
+touch "${authors_file}"
+unresolved_commits_file="${temp_dir}/unresolved-commits"
+touch "${unresolved_commits_file}"
+
+page=1
+fetched_commits=0
+total_commits=1
+
+while (( fetched_commits < total_commits )); do
+  url="https://api.github.com/repos/${repo_owner}/${repo_name}/compare/${encoded_base_ref}...${encoded_head_ref}?per_page=100&page=${page}"
+  response_file="${temp_dir}/response-${page}.json"
+
+  curl --fail --silent --show-error --location \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "${url}" > "${response_file}"
+
+  total_commits=$(jq -er '.total_commits | numbers' "${response_file}")
+  page_commits=$(jq -er '.commits | length' "${response_file}")
+  jq -r '.commits[].author.login // empty' "${response_file}" >> "${authors_file}"
+  jq -r '
+    .commits[]
+    | select(.author.login == null)
+    | (.commit.message | split("\n")[0]) as $title
+    | [
+        .sha,
+        if ($title | test("^Merge pull request #[0-9]+\\b")) then
+          ($title | capture("^Merge pull request #(?<number>[0-9]+)\\b").number)
+        elif ($title | test("\\(#[0-9]+\\)$")) then
+          ($title | capture("\\(#(?<number>[0-9]+)\\)$").number)
+        else
+          ""
+        end
+      ]
+    | @tsv
+  ' \
+    "${response_file}" >> "${unresolved_commits_file}"
+
+  if (( page_commits == 0 )); then
+    break
+  fi
+
+  fetched_commits=$((fetched_commits + page_commits))
+  page=$((page + 1))
+done
+
+failed_commits_file="${temp_dir}/failed-commits"
+touch "${failed_commits_file}"
+while IFS=$'\t' read -r commit_sha pr_number; do
+  [[ -n "${commit_sha}" ]] || continue
+  if [[ -z "${pr_number}" ]]; then
+    printf '%s\n' "${commit_sha}" >> "${failed_commits_file}"
+    continue
+  fi
+  url="https://api.github.com/repos/${repo_owner}/${repo_name}/pulls/${pr_number}"
+  response_file="${temp_dir}/pull-${pr_number}.json"
+
+  if ! curl --fail --silent --show-error --location \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "${url}" > "${response_file}"; then
+    echo "Error: failed to fetch PR #${pr_number} for commit ${commit_sha}" >&2
+    exit 1
+  fi
+
+  if login=$(jq -er --arg sha "${commit_sha}" '
+    if .merged_at != null
+      and ((.head.sha // "") == $sha or (.merge_commit_sha // "") == $sha)
+      and (.user.login // "") != ""
+      then .user.login
+      else empty
+    end
+  ' "${response_file}"); then
+    printf '%s\n' "${login}" >> "${authors_file}"
+  else
+    printf '%s\n' "${commit_sha}" >> "${failed_commits_file}"
+  fi
+done < "${unresolved_commits_file}"
+
+if [[ -s "${failed_commits_file}" ]]; then
+  echo "Error: unable to resolve contributors for these commits:" >&2
+  while IFS= read -r commit_sha; do
+    echo "  ${commit_sha}" >&2
+  done < "${failed_commits_file}"
+  exit 1
+fi
+
+LC_ALL=C sort -fu "${authors_file}"

--- a/.claude/skills/generating-release-notes/scripts/fetch_pr_info.py
+++ b/.claude/skills/generating-release-notes/scripts/fetch_pr_info.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fetch merged PR metadata and user-facing changes for release notes."""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+
+GITHUB_API_BASE = "https://api.github.com"
+NO_RELEASE_NOTE_VALUES = {
+    "",
+    "n/a",
+    "na",
+    "no",
+    "none",
+    "noop",
+    "nope",
+    "nothing",
+}
+
+
+def github_request(url, token, payload=None):
+    """Send an authenticated GitHub API request and decode its JSON body."""
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "Release-Note-Generator",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    data = None
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(payload).encode("utf-8")
+
+    request = urllib.request.Request(url, data=data, headers=headers)
+    try:
+        with urllib.request.urlopen(request) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        print(f"GitHub request failed ({error.code}): {detail}", file=sys.stderr)
+    except urllib.error.URLError as error:
+        print(f"GitHub request failed: {error.reason}", file=sys.stderr)
+    return None
+
+
+def get_commit_comparison(repo_owner, repo_name, base_tag, head_branch, token):
+    """Get the GitHub comparison between the base tag and head branch."""
+    base_url = (
+        f"{GITHUB_API_BASE}/repos/{repo_owner}/{repo_name}/compare/"
+        f"{base_tag}...{head_branch}"
+    )
+    comparison = None
+    commits = []
+    page = 1
+
+    while True:
+        response = github_request(f"{base_url}?per_page=100&page={page}", token)
+        if not response:
+            break
+        if comparison is None:
+            comparison = response.copy()
+
+        page_commits = response.get("commits", [])
+        commits.extend(page_commits)
+        total_commits = comparison.get("total_commits", len(commits))
+        if len(commits) >= total_commits or len(page_commits) < 100:
+            break
+        page += 1
+
+    if comparison is not None:
+        comparison["commits"] = commits
+    return comparison
+
+
+def get_pr_details_batch(repo_owner, repo_name, pr_numbers, token):
+    """Fetch pull request title, body, and author in one GraphQL request."""
+    if not pr_numbers:
+        return {}
+
+    query_parts = []
+    for index, number in enumerate(pr_numbers):
+        query_parts.append(
+            f"pr{index}: pullRequest(number: {number}) {{ "
+            "number title body author { login } "
+            "labels(first: 100) { nodes { name } } }"
+        )
+    query = (
+        "{ repository(owner: \""
+        + repo_owner
+        + "\", name: \""
+        + repo_name
+        + "\") { "
+        + " ".join(query_parts)
+        + " } }"
+    )
+    response = github_request(
+        "https://api.github.com/graphql", token, {"query": query}
+    )
+    if not response:
+        return None
+    if response.get("errors"):
+        print(f"GraphQL errors: {response['errors']}", file=sys.stderr)
+        return None
+
+    repository = response.get("data", {}).get("repository", {})
+    result = {}
+    for index, number in enumerate(pr_numbers):
+        pull_request = repository.get(f"pr{index}")
+        if pull_request:
+            result[number] = pull_request
+    return result
+
+
+def normalize_release_note(content):
+    """Normalize a candidate release note and reject standard empty values."""
+    normalized = re.sub(r"\s+", " ", content.strip())
+    if normalized.lower() in NO_RELEASE_NOTE_VALUES or len(normalized) <= 3:
+        return None
+    return normalized
+
+
+def extract_user_facing_change(pr_body):
+    """Extract a user-facing change from supported PR template formats."""
+    if not pr_body:
+        return None
+
+    release_note_patterns = [
+        r"```release-note[^\r\n]*[\r\n]+(.*?)^[ \t]*```[ \t]*$",
+        r"```release-note\s*[\r\n]+([^\r\n]+(?:[\r\n]+[^\r\n`]+)*)",
+    ]
+    for pattern in release_note_patterns:
+        match = re.search(pattern, pr_body, re.MULTILINE | re.DOTALL)
+        if match:
+            return normalize_release_note(match.group(1))
+
+    fallback = re.search(
+        r"\*\*Does this PR introduce a user-facing change\?\*\*:\s*"
+        r"```[^\r\n]*[\r\n]+([\s\S]*?)```",
+        pr_body,
+        re.IGNORECASE,
+    )
+    if fallback:
+        return normalize_release_note(fallback.group(1))
+    return None
+
+
+def extract_pr_kind_from_labels(labels):
+    """Extract PR kinds from kind-prefixed labels."""
+    kinds = []
+    for label in (labels or {}).get("nodes", []):
+        name = (label or {}).get("name", "")
+        if name.startswith("kind/") and len(name) > len("kind/"):
+            kind = name[len("kind/") :]
+            if kind not in kinds:
+                kinds.append(kind)
+    return kinds or None
+
+
+def extract_pr_kind_from_body(pr_body):
+    """Extract PR kinds from the Karmada pull request template body."""
+    if not pr_body:
+        return None
+
+    section = re.search(
+        r"\*\*What type of PR is this\?\*\*(.*?)"
+        r"\*\*What this PR does / why we need it\*\*:",
+        pr_body,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if not section:
+        return None
+
+    without_comments = re.sub(r"<!--.*?-->", "", section.group(1), flags=re.DOTALL)
+    kinds = re.findall(
+        r"^\s*/kind\s+([a-zA-Z0-9-]+)\s*$", without_comments, re.MULTILINE
+    )
+    return kinds or None
+
+
+def extract_pr_kind(labels, pr_body):
+    """Extract PR kinds from labels, falling back to the PR body."""
+    return extract_pr_kind_from_labels(labels) or extract_pr_kind_from_body(pr_body)
+
+
+def extract_pr_number(commit_message):
+    """Extract a PR number from a GitHub merge or squash commit title."""
+    title = commit_message.splitlines()[0] if commit_message else ""
+    merge_match = re.match(r"Merge pull request #(\d+)\b", title)
+    if merge_match:
+        return int(merge_match.group(1))
+
+    squash_match = re.search(r"\(#(\d+)\)$", title)
+    if squash_match:
+        return int(squash_match.group(1))
+    return None
+
+
+def comparison_is_truncated(comparison):
+    """Report whether the compare response omitted commits from its list."""
+    commits = comparison.get("commits", [])
+    return comparison.get("total_commits", len(commits)) > len(commits)
+
+
+def parse_arguments():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Fetch merged PR information for release note generation."
+    )
+    parser.add_argument("base_tag", help="Base tag or branch to compare from")
+    parser.add_argument("head_branch", help="Head tag or branch to compare to")
+    parser.add_argument(
+        "--repo",
+        required=True,
+        help="GitHub repository in owner/name format",
+    )
+    return parser.parse_args()
+
+
+def main():
+    """Fetch and print PRs that contain user-facing changes."""
+    args = parse_arguments()
+    if args.repo.count("/") != 1:
+        print("Error: --repo must use owner/name format", file=sys.stderr)
+        return 2
+
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("Error: GITHUB_TOKEN is not set", file=sys.stderr)
+        return 2
+
+    repo_owner, repo_name = args.repo.split("/", 1)
+    print(f"Fetching PR information for {args.repo}...")
+    print(f"Comparing {args.base_tag}...{args.head_branch}")
+    print("=" * 80)
+
+    comparison = get_commit_comparison(
+        repo_owner, repo_name, args.base_tag, args.head_branch, token
+    )
+    if not comparison:
+        print("Failed to get commit comparison", file=sys.stderr)
+        return 1
+
+    commits = comparison.get("commits", [])
+    if comparison_is_truncated(comparison):
+        print(
+            "Error: GitHub returned only "
+            f"{len(commits)} of {comparison['total_commits']} commits; "
+            "refusing to generate incomplete release notes",
+            file=sys.stderr,
+        )
+        return 1
+
+    pr_numbers = set()
+    for commit in commits:
+        message = commit.get("commit", {}).get("message", "")
+        pr_number = extract_pr_number(message)
+        if pr_number is not None:
+            pr_numbers.add(pr_number)
+
+    sorted_pr_numbers = sorted(pr_numbers)
+    print(f"Found {len(commits)} commits")
+    print(f"Found {len(sorted_pr_numbers)} merged PRs")
+    print("=" * 80)
+
+    pr_details = get_pr_details_batch(
+        repo_owner, repo_name, sorted_pr_numbers, token
+    )
+    if pr_details is None:
+        print("Failed to get pull request details", file=sys.stderr)
+        return 1
+
+    release_notes = []
+    for pr_number in sorted_pr_numbers:
+        pull_request = pr_details.get(pr_number)
+        if not pull_request:
+            continue
+        change = extract_user_facing_change(pull_request.get("body") or "")
+        if not change:
+            continue
+        author = pull_request.get("author") or {}
+        release_notes.append(
+            {
+                "number": pr_number,
+                "title": pull_request.get("title", ""),
+                "author": author.get("login", "unknown"),
+                "kind": extract_pr_kind(
+                    pull_request.get("labels"), pull_request.get("body") or ""
+                ),
+                "change": change,
+            }
+        )
+
+    print("\n" + "=" * 80)
+    print("SUMMARY OF PRS WITH USER-FACING CHANGES")
+    print("=" * 80)
+    if release_notes:
+        for release_note in release_notes:
+            print(f"\nPR #{release_note['number']} by @{release_note['author']}")
+            print(f"Title: {release_note['title']}")
+            print(f"Kind: {release_note['kind']}")
+            print(f"Change: {release_note['change']}")
+    else:
+        print("No PRs with user-facing changes found.")
+    print(f"\nTotal PRs with user-facing changes: {len(release_notes)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
As a member of the release team, I have consolidated our previous manual release-note process into a reusable skill, with the goal of preserving this knowledge and passing it on to future contributors.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

