### PR TITLE
Fix flaky karmada-operator readiness check in deploy script

### DIFF
--- a/hack/deploy-karmada-operator.sh
+++ b/hack/deploy-karmada-operator.sh
@@ -70,4 +70,4 @@ kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" apply -f "${REP
 kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" apply -f "${REPO_ROOT}/operator/config/deploy/karmada-operator-deployment.yaml"
 
 # wait karmada-operator ready
-kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" wait --for=condition=Ready --timeout=30s pods -l app.kubernetes.io/name=karmada-operator -n ${KARMADA_SYSTEM_NAMESPACE}
+kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" -n "${KARMADA_SYSTEM_NAMESPACE}" rollout status deployment/karmada-operator --timeout=30s


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The deploy script waits for karmada-operator pods right after applying the Deployment. If the pods have not been created yet, `kubectl wait` fails with `error: no matching resources found`, as seen in
https://github.com/karmada-io/karmada/actions/runs/32942536376/job/98096327364?pr=7860.

Switch to `kubectl rollout status deployment/karmada-operator`, which works because the Deployment object exists immediately after apply, and it also correctly tracks the latest rollout.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

