### PR TITLE
refactor: use sync.Map for lock-free informer lookups and propagate init errors

### DIFF
--- a/pkg/clusterdiscovery/clusterapi/clusterapi.go
+++ b/pkg/clusterdiscovery/clusterapi/clusterapi.go
@@ -91,7 +91,9 @@ func (d *ClusterDetector) discoveryCluster() {
 	for _, gvr := range clusterGVRs {
 		if !d.InformerManager.IsHandlerExist(gvr, d.EventHandler) {
 			klog.Infof("Setup informer fo %s", gvr.String())
-			d.InformerManager.ForResource(gvr, d.EventHandler)
+			if err := d.InformerManager.ForResource(gvr, d.EventHandler); err != nil {
+				klog.ErrorS(err, "Failed to setup informer", "resource", gvr.String())
+			}
 		}
 	}
 
@@ -165,7 +167,12 @@ func (d *ClusterDetector) GetUnstructuredObject(objectKey keys.ClusterWideKey) (
 		Resource: resourceCluster,
 	}
 
-	object, err := d.InformerManager.Lister(objectGVR).Get(objectKey.NamespaceKey())
+	lister, err := d.InformerManager.Lister(objectGVR)
+	if err != nil {
+		klog.Errorf("Failed to get lister for object(%s), error: %v", objectKey, err)
+		return nil, err
+	}
+	object, err := lister.Get(objectKey.NamespaceKey())
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			klog.Errorf("Failed to get object(%s), error: %v", objectKey, err)

--- a/pkg/controllers/execution/execution_controller_test.go
+++ b/pkg/controllers/execution/execution_controller_test.go
@@ -450,7 +450,7 @@ func newController(work *workv1alpha1.Work, recorder *record.FakeRecorder) Contr
 		Build()
 	dynamicClientSet := dynamicfake.NewSimpleDynamicClient(scheme.Scheme, pod)
 	informerManager := genericmanager.NewMultiClusterInformerManager(context.Background())
-	informerManager.ForCluster(cluster.Name, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+	_, _ = informerManager.ForCluster(cluster.Name, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 	informerManager.Start(cluster.Name)
 	informerManager.WaitForCacheSync(cluster.Name)
 	clusterClientSetFunc := func(string, client.Client, *util.ClientOption) (*util.DynamicClusterClient, error) {

--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -279,7 +279,10 @@ func (c *ServiceExportController) registerInformersAndStart(cluster *clusterv1al
 	for _, gvr := range gvrTargets {
 		if !singleClusterInformerManager.IsInformerSynced(gvr) || !singleClusterInformerManager.IsHandlerExist(gvr, c.getEventHandler(cluster.Name)) {
 			allSynced = false
-			singleClusterInformerManager.ForResource(gvr, c.getEventHandler(cluster.Name))
+			if err := singleClusterInformerManager.ForResource(gvr, c.getEventHandler(cluster.Name)); err != nil {
+				klog.ErrorS(err, "Failed to register handler for resource", "cluster", cluster.Name, "resource", gvr.String())
+				return err
+			}
 		}
 	}
 	if allSynced {
@@ -441,7 +444,11 @@ func (c *ServiceExportController) reportEndpointSliceWithServiceExportCreate(ctx
 		return fmt.Errorf("the informer for cluster %s has not been synced, wait a retry at the next time", serviceExportKey.Cluster)
 	}
 
-	endpointSliceLister := singleClusterManager.Lister(endpointSliceGVR)
+	endpointSliceLister, err := singleClusterManager.Lister(endpointSliceGVR)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get lister for EndpointSlice", "cluster", serviceExportKey.Cluster)
+		return err
+	}
 	if endpointSliceObjects, err = endpointSliceLister.ByNamespace(serviceExportKey.Namespace).List(labels.SelectorFromSet(labels.Set{
 		discoveryv1.LabelServiceName: serviceExportKey.Name,
 	})); err != nil {
@@ -546,8 +553,12 @@ func (c *ServiceExportController) reportEndpointSliceWithEndpointSliceCreateOrUp
 		return fmt.Errorf("the informer for cluster %s has not been synced, wait a retry at the next time", clusterName)
 	}
 
-	serviceExportLister := singleClusterManager.Lister(serviceExportGVR)
-	_, err := serviceExportLister.ByNamespace(endpointSlice.GetNamespace()).Get(relatedServiceName)
+	serviceExportLister, err := singleClusterManager.Lister(serviceExportGVR)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get lister for ServiceExport", "cluster", clusterName)
+		return err
+	}
+	_, err = serviceExportLister.ByNamespace(endpointSlice.GetNamespace()).Get(relatedServiceName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil

--- a/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
@@ -204,7 +204,10 @@ func (c *EndpointSliceCollectController) registerInformersAndStart(cluster *clus
 	for _, gvr := range gvrTargets {
 		if !singleClusterInformerManager.IsInformerSynced(gvr) || !singleClusterInformerManager.IsHandlerExist(gvr, c.getEventHandler(cluster.Name)) {
 			allSynced = false
-			singleClusterInformerManager.ForResource(gvr, c.getEventHandler(cluster.Name))
+			if err := singleClusterInformerManager.ForResource(gvr, c.getEventHandler(cluster.Name)); err != nil {
+				klog.ErrorS(err, "Failed to register handler for resource", "cluster", cluster.Name, "resource", gvr.String())
+				return err
+			}
 		}
 	}
 	if allSynced {
@@ -351,7 +354,12 @@ func (c *EndpointSliceCollectController) collectTargetEndpointSlice(ctx context.
 	selector := labels.SelectorFromSet(labels.Set{
 		discoveryv1.LabelServiceName: svcName,
 	})
-	epsList, err := manager.Lister(discoveryv1.SchemeGroupVersion.WithResource("endpointslices")).ByNamespace(svcNamespace).List(selector)
+	epsLister, err := manager.Lister(discoveryv1.SchemeGroupVersion.WithResource("endpointslices"))
+	if err != nil {
+		klog.ErrorS(err, "Failed to get lister for EndpointSlice", "cluster", clusterName)
+		return err
+	}
+	epsList, err := epsLister.ByNamespace(svcNamespace).List(selector)
 	if err != nil {
 		klog.ErrorS(err, "Failed to list EndpointSlice for Service in a cluster", "namespace", svcNamespace, "name", svcName, "cluster", clusterName)
 		return err

--- a/pkg/controllers/status/crb_status_controller_test.go
+++ b/pkg/controllers/status/crb_status_controller_test.go
@@ -47,7 +47,7 @@ func generateCRBStatusController() *CRBStatusController {
 	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}})
 	m := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0)
-	m.Lister(corev1.SchemeGroupVersion.WithResource("namespaces"))
+	_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("namespaces"))
 	m.Start()
 	m.WaitForCacheSync()
 

--- a/pkg/controllers/status/rb_status_controller_test.go
+++ b/pkg/controllers/status/rb_status_controller_test.go
@@ -48,7 +48,7 @@ func generateRBStatusController() *RBStatusController {
 	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "default"}})
 	m := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0)
-	m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+	_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 	m.Start()
 	m.WaitForCacheSync()
 

--- a/pkg/controllers/status/work_status_controller_test.go
+++ b/pkg/controllers/status/work_status_controller_test.go
@@ -811,7 +811,7 @@ func newWorkStatusController(cluster *clusterv1alpha1.Cluster, dynamicClientSets
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		m := genericmanager.NewMultiClusterInformerManager(ctx)
-		m.ForCluster(clusterName, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
+		_, _ = m.ForCluster(clusterName, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 		m.Start(clusterName)
 		m.WaitForCacheSync(clusterName)
 		c.InformerManager = m

--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -414,8 +414,11 @@ func (d *DependenciesDistributor) syncScheduleResultToAttachedBindings(ctx conte
 			continue
 		}
 		if !d.InformerManager.IsHandlerExist(gvr, d.eventHandler) {
-			d.InformerManager.ForResource(gvr, d.eventHandler)
-			startInformerManager = true
+			if err := d.InformerManager.ForResource(gvr, d.eventHandler); err != nil {
+				errs = append(errs, err)
+			} else {
+				startInformerManager = true
+			}
 		}
 		errs = append(errs, d.handleDependentResource(ctx, independentBinding, dependent))
 	}

--- a/pkg/dependenciesdistributor/dependencies_distributor_test.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor_test.go
@@ -1234,7 +1234,7 @@ func Test_removeOrphanAttachedBindings(t *testing.T) {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
 					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
 					return m
@@ -1380,7 +1380,7 @@ func Test_handleDependentResource(t *testing.T) {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
 					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
 					return m
@@ -1488,7 +1488,7 @@ func Test_handleDependentResource(t *testing.T) {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
 					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
 					return m
@@ -1567,7 +1567,7 @@ func Test_handleDependentResource(t *testing.T) {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
 					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
 					return m
@@ -1937,7 +1937,7 @@ func Test_syncScheduleResultToAttachedBindings_doesNotWaitForInformerCacheSync(t
 		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}},
 	)
 	baseInformerManager := genericmanager.NewSingleClusterInformerManager(context.TODO(), dynamicClient, 0)
-	baseInformerManager.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+	_, _ = baseInformerManager.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 	trackingManager := &trackingInformerManager{SingleClusterInformerManager: baseInformerManager}
 
 	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{appsv1.SchemeGroupVersion, corev1.SchemeGroupVersion})
@@ -2026,7 +2026,7 @@ func Test_findOrphanAttachedBindings(t *testing.T) {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
 					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
 					return m
@@ -2123,7 +2123,7 @@ func Test_findOrphanAttachedBindings(t *testing.T) {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"resourcebinding.karmada.io/depended-by-5dbb6dc9c8": "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"}}})
 					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
 					return m
@@ -2232,7 +2232,7 @@ func TestDependenciesDistributor_findOrphanAttachedBindingsByDependencies(t *tes
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"bar": "bar"}}})
 					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
 					return m
@@ -2283,7 +2283,7 @@ func TestDependenciesDistributor_findOrphanAttachedBindingsByDependencies(t *tes
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"bar": "foo"}}})
 					m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
 					return m

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -192,7 +192,9 @@ func (d *ResourceDetector) discoverResources(ctx context.Context, period time.Du
 				continue
 			}
 			klog.Infof("Setup informer for %s", r.String())
-			d.InformerManager.ForResource(r, d.EventHandler)
+			if err := d.InformerManager.ForResource(r, d.EventHandler); err != nil {
+				klog.ErrorS(err, "Failed to setup informer", "resource", r.String())
+			}
 		}
 		d.InformerManager.Start()
 	}, period, ctx.Done())
@@ -673,7 +675,12 @@ func (d *ResourceDetector) GetUnstructuredObject(objectKey keys.ClusterWideKey) 
 		return nil, err
 	}
 
-	object, err := d.InformerManager.Lister(objectGVR).Get(objectKey.NamespaceKey())
+	lister, err := d.InformerManager.Lister(objectGVR)
+	if err != nil {
+		klog.Errorf("Failed to get lister for object: %s, error: %v", objectKey, err)
+		return nil, err
+	}
+	object, err := lister.Get(objectKey.NamespaceKey())
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// If the target object is not found in the informer cache,

--- a/pkg/estimator/server/server.go
+++ b/pkg/estimator/server/server.go
@@ -129,7 +129,9 @@ func NewEstimatorServer(
 
 	es.informerManager = genericmanager.NewSingleClusterInformerManager(ctx, dynamicClient, 0)
 	for _, gvr := range supportedGVRs {
-		es.informerManager.Lister(gvr)
+		if _, err := es.informerManager.Lister(gvr); err != nil {
+			return nil, err
+		}
 	}
 
 	registry := frameworkplugins.NewInTreeRegistry()

--- a/pkg/karmadactl/interpret/execute.go
+++ b/pkg/karmadactl/interpret/execute.go
@@ -96,7 +96,10 @@ func (o *Options) runExecute() error {
 		Replica:  int64(o.DesiredReplica),
 	}
 
-	configurableInterpreter := declarative.NewConfigurableInterpreter(nil)
+	configurableInterpreter, err := declarative.NewConfigurableInterpreter(nil)
+	if err != nil {
+		return err
+	}
 	configurableInterpreter.LoadConfig(customizations)
 
 	r := o.Rules.GetByOperation(o.Operation)

--- a/pkg/karmadactl/promote/promote.go
+++ b/pkg/karmadactl/promote/promote.go
@@ -450,25 +450,16 @@ func (o *CommandPromoteOption) promoteDeps(memberClusterFactory cmdutil.Factory,
 	if o.DryRun {
 		return nil
 	}
-	// create resource interpreter
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	dynamicClientSet := dynamicClientBuilder(config)
-
-	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, 0)
-	controlPlaneKubeClientSet := kubeClientBuilder(config)
-	sharedFactory := informers.NewSharedInformerFactory(controlPlaneKubeClientSet, 0)
-	serviceLister := sharedFactory.Core().V1().Services().Lister()
-	sharedFactory.Start(ctx.Done())
-	sharedFactory.WaitForCacheSync(ctx.Done())
+	controlPlaneInformerManager, configurableInterpreter, customizedInterpreter, err := newDependencyInterpreters(ctx, config)
+	if err != nil {
+		return err
+	}
 
 	defaultInterpreter := native.NewDefaultInterpreter()
 	thirdpartyInterpreter := thirdparty.NewConfigurableInterpreter()
-	configurableInterpreter := declarative.NewConfigurableInterpreter(controlPlaneInformerManager)
-	customizedInterpreter, err := webhook.NewCustomizedInterpreter(controlPlaneInformerManager, serviceLister)
-	if err != nil {
-		return fmt.Errorf("failed to create customized interpreter: %v", err)
-	}
 
 	controlPlaneInformerManager.Start()
 	if syncs := controlPlaneInformerManager.WaitForCacheSync(); len(syncs) == 0 {
@@ -529,6 +520,26 @@ func (o *CommandPromoteOption) promoteDeps(memberClusterFactory cmdutil.Factory,
 	fmt.Println("use default interpreter")
 	err = o.doPromoteDeps(memberClusterFactory, dependencies, mapper, config)
 	return err
+}
+
+func newDependencyInterpreters(ctx context.Context, config *rest.Config) (genericmanager.SingleClusterInformerManager,
+	*declarative.ConfigurableInterpreter, *webhook.CustomizedInterpreter, error) {
+	dynamicClientSet := dynamicClientBuilder(config)
+	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, 0)
+	sharedFactory := informers.NewSharedInformerFactory(kubeClientBuilder(config), 0)
+	serviceLister := sharedFactory.Core().V1().Services().Lister()
+	sharedFactory.Start(ctx.Done())
+	sharedFactory.WaitForCacheSync(ctx.Done())
+
+	configurableInterpreter, err := declarative.NewConfigurableInterpreter(controlPlaneInformerManager)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	customizedInterpreter, err := webhook.NewCustomizedInterpreter(controlPlaneInformerManager, serviceLister)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return controlPlaneInformerManager, configurableInterpreter, customizedInterpreter, nil
 }
 
 func (o *CommandPromoteOption) promote(controlPlaneRestConfig *rest.Config, obj *unstructured.Unstructured, gvr schema.GroupVersionResource) error {

--- a/pkg/registry/search/storage/cache.go
+++ b/pkg/registry/search/storage/cache.go
@@ -122,7 +122,12 @@ func (r *SearchREST) getObjectItemsFromClusters(
 		}
 
 		var err error
-		objLister := singleClusterManger.Lister(objGVR)
+		objLister, err := singleClusterManger.Lister(objGVR)
+		if err != nil {
+			klog.Errorf("Failed to get lister for %s from cluster(%s)'s informer cache: %v",
+				objGVR, cluster.Name, err)
+			continue
+		}
 		if len(name) > 0 {
 			var resourceObject runtime.Object
 			if len(namespace) > 0 {

--- a/pkg/resourceinterpreter/customized/declarative/configmanager/manager.go
+++ b/pkg/resourceinterpreter/customized/declarative/configmanager/manager.go
@@ -74,22 +74,30 @@ func (configManager *interpreterConfigManager) HasSynced() bool {
 
 // NewInterpreterConfigManager watches ResourceInterpreterCustomization and organizes
 // the configurations in the cache.
-func NewInterpreterConfigManager(informer genericmanager.SingleClusterInformerManager) ConfigManager {
+func NewInterpreterConfigManager(informer genericmanager.SingleClusterInformerManager) (ConfigManager, error) {
 	manager := &interpreterConfigManager{}
 	manager.configuration.Store(make(map[schema.GroupVersionKind]CustomAccessor))
 
 	// In interpret command, rules are not loaded from server, so we don't start informer for it.
 	if informer != nil {
 		manager.informer = informer
-		manager.lister = informer.Lister(util.ResourceInterpreterCustomizationsGVR)
+		lister, err := informer.Lister(util.ResourceInterpreterCustomizationsGVR)
+		if err != nil {
+			klog.ErrorS(err, "Failed to get lister for ResourceInterpreterCustomization")
+			return nil, err
+		}
+		manager.lister = lister
 		configHandlers := fedinformer.NewHandlerOnEvents(
 			func(_ any, _ bool) { _ = manager.updateConfiguration() },
 			func(_, _ any) { _ = manager.updateConfiguration() },
 			func(_ any) { _ = manager.updateConfiguration() })
-		informer.ForResource(util.ResourceInterpreterCustomizationsGVR, configHandlers)
+		if err := informer.ForResource(util.ResourceInterpreterCustomizationsGVR, configHandlers); err != nil {
+			klog.ErrorS(err, "Failed to register handler for ResourceInterpreterCustomization")
+			return nil, err
+		}
 	}
 
-	return manager
+	return manager, nil
 }
 
 // updateConfiguration is used as the event handler for the ResourceInterpreterCustomization resource.

--- a/pkg/resourceinterpreter/customized/declarative/configmanager/manager_test.go
+++ b/pkg/resourceinterpreter/customized/declarative/configmanager/manager_test.go
@@ -129,7 +129,10 @@ func Test_interpreterConfigManager_LuaScriptAccessors(t *testing.T) {
 
 			client := fake.NewSimpleDynamicClient(gclient.NewSchema(), tt.args.customizations...)
 			informer := genericmanager.NewSingleClusterInformerManager(ctx, client, 0)
-			configManager := NewInterpreterConfigManager(informer)
+			configManager, err := NewInterpreterConfigManager(informer)
+			if err != nil {
+				t.Fatalf("NewInterpreterConfigManager() returned an unexpected error: %v", err)
+			}
 
 			informer.Start()
 			defer informer.Stop()
@@ -464,11 +467,12 @@ func (m *mockSingleClusterInformerManager) IsInformerSynced(_ schema.GroupVersio
 	return m.isSynced
 }
 
-func (m *mockSingleClusterInformerManager) Lister(_ schema.GroupVersionResource) cache.GenericLister {
-	return nil
+func (m *mockSingleClusterInformerManager) Lister(_ schema.GroupVersionResource) (cache.GenericLister, error) {
+	return nil, nil
 }
 
-func (m *mockSingleClusterInformerManager) ForResource(_ schema.GroupVersionResource, _ cache.ResourceEventHandler) {
+func (m *mockSingleClusterInformerManager) ForResource(_ schema.GroupVersionResource, _ cache.ResourceEventHandler) error {
+	return nil
 }
 
 func (m *mockSingleClusterInformerManager) Start() {

--- a/pkg/resourceinterpreter/customized/declarative/configurable.go
+++ b/pkg/resourceinterpreter/customized/declarative/configurable.go
@@ -42,12 +42,16 @@ type ConfigurableInterpreter struct {
 
 // NewConfigurableInterpreter builds a new interpreter by registering the
 // event handler to the provided informer instance.
-func NewConfigurableInterpreter(informer genericmanager.SingleClusterInformerManager) *ConfigurableInterpreter {
+func NewConfigurableInterpreter(informer genericmanager.SingleClusterInformerManager) (*ConfigurableInterpreter, error) {
+	configManager, err := configmanager.NewInterpreterConfigManager(informer)
+	if err != nil {
+		return nil, err
+	}
 	return &ConfigurableInterpreter{
-		configManager: configmanager.NewInterpreterConfigManager(informer),
+		configManager: configManager,
 		// TODO: set an appropriate pool size.
 		luaVM: luavm.New(false, 10),
-	}
+	}, nil
 }
 
 // HookEnabled tells if any hook exist for specific resource gvk and operation type.

--- a/pkg/resourceinterpreter/customized/webhook/configmanager/manager.go
+++ b/pkg/resourceinterpreter/customized/webhook/configmanager/manager.go
@@ -73,9 +73,14 @@ func (m *interpreterConfigManager) HasSynced() bool {
 }
 
 // NewExploreConfigManager return a new interpreterConfigManager with resourceinterpreterwebhookconfigurations handlers.
-func NewExploreConfigManager(inform genericmanager.SingleClusterInformerManager) ConfigManager {
+func NewExploreConfigManager(inform genericmanager.SingleClusterInformerManager) (ConfigManager, error) {
+	lister, err := inform.Lister(util.ResourceInterpreterWebhookConfigurationsGVR)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get lister for ResourceInterpreterWebhookConfiguration")
+		return nil, err
+	}
 	manager := &interpreterConfigManager{
-		lister: inform.Lister(util.ResourceInterpreterWebhookConfigurationsGVR),
+		lister: lister,
 	}
 
 	manager.configuration.Store([]WebhookAccessor{})
@@ -85,9 +90,12 @@ func NewExploreConfigManager(inform genericmanager.SingleClusterInformerManager)
 		func(_ any, _ bool) { _ = manager.updateConfiguration() },
 		func(_, _ any) { _ = manager.updateConfiguration() },
 		func(_ any) { _ = manager.updateConfiguration() })
-	inform.ForResource(util.ResourceInterpreterWebhookConfigurationsGVR, configHandlers)
+	if err := inform.ForResource(util.ResourceInterpreterWebhookConfigurationsGVR, configHandlers); err != nil {
+		klog.ErrorS(err, "Failed to register handler for ResourceInterpreterWebhookConfiguration")
+		return nil, err
+	}
 
-	return manager
+	return manager, nil
 }
 
 // updateConfiguration is used as the event handler for the ResourceInterpreterWebhookConfiguration resource.

--- a/pkg/resourceinterpreter/customized/webhook/configmanager/manager_test.go
+++ b/pkg/resourceinterpreter/customized/webhook/configmanager/manager_test.go
@@ -62,7 +62,10 @@ func TestNewExploreConfigManager(t *testing.T) {
 			informerManager := &mockInformerManager{
 				lister: &mockLister{items: tt.initObjs},
 			}
-			manager := NewExploreConfigManager(informerManager)
+			manager, err := NewExploreConfigManager(informerManager)
+			if err != nil {
+				t.Fatalf("NewExploreConfigManager() returned an unexpected error: %v", err)
+			}
 
 			assert.NotNil(t, manager, "Manager should not be nil")
 			assert.NotNil(t, manager.HookAccessors(), "Accessors should be initialized")
@@ -328,11 +331,12 @@ func (m *mockSingleClusterInformerManager) IsInformerSynced(_ schema.GroupVersio
 	return m.isSynced
 }
 
-func (m *mockSingleClusterInformerManager) Lister(_ schema.GroupVersionResource) cache.GenericLister {
-	return nil
+func (m *mockSingleClusterInformerManager) Lister(_ schema.GroupVersionResource) (cache.GenericLister, error) {
+	return nil, nil
 }
 
-func (m *mockSingleClusterInformerManager) ForResource(_ schema.GroupVersionResource, _ cache.ResourceEventHandler) {
+func (m *mockSingleClusterInformerManager) ForResource(_ schema.GroupVersionResource, _ cache.ResourceEventHandler) error {
+	return nil
 }
 
 func (m *mockSingleClusterInformerManager) Start() {
@@ -386,9 +390,10 @@ type mockInformerManager struct {
 	lister cache.GenericLister
 }
 
-func (m *mockInformerManager) Lister(_ schema.GroupVersionResource) cache.GenericLister {
-	return m.lister
+func (m *mockInformerManager) Lister(_ schema.GroupVersionResource) (cache.GenericLister, error) {
+	return m.lister, nil
 }
 
-func (m *mockInformerManager) ForResource(_ schema.GroupVersionResource, _ cache.ResourceEventHandler) {
+func (m *mockInformerManager) ForResource(_ schema.GroupVersionResource, _ cache.ResourceEventHandler) error {
+	return nil
 }

--- a/pkg/resourceinterpreter/customized/webhook/customized.go
+++ b/pkg/resourceinterpreter/customized/webhook/customized.go
@@ -71,8 +71,13 @@ func NewCustomizedInterpreter(informer genericmanager.SingleClusterInformerManag
 	cm.SetAuthenticationInfoResolver(authInfoResolver)
 	cm.SetServiceResolver(NewServiceResolver(serviceLister))
 
+	hookManager, err := configmanager.NewExploreConfigManager(informer)
+	if err != nil {
+		return nil, err
+	}
+
 	return &CustomizedInterpreter{
-		hookManager:   configmanager.NewExploreConfigManager(informer),
+		hookManager:   hookManager,
 		clientManager: &cm,
 	}, nil
 }

--- a/pkg/resourceinterpreter/default/thirdparty/thirdparty_test.go
+++ b/pkg/resourceinterpreter/default/thirdparty/thirdparty_test.go
@@ -78,13 +78,15 @@ type IndividualTest struct {
 }
 
 func checkInterpretationRule(t *testing.T, path string, configs []*configv1alpha1.ResourceInterpreterCustomization) {
-	ipt := declarative.NewConfigurableInterpreter(nil)
+	ipt, err := declarative.NewConfigurableInterpreter(nil)
+	if err != nil {
+		t.Fatalf("NewConfigurableInterpreter() returned an unexpected error: %v", err)
+	}
 	ipt.LoadConfig(configs)
 
 	dir := filepath.Dir(path)
 	testDataDir := filepath.Join(dir, "testdata")
 
-	var err error
 	for _, customization := range configs {
 		for _, input := range getAllTestCases(t, testDataDir).Tests {
 			t.Run(fmt.Sprintf("[%s/%s]:%s", customization.Name, input.Operation, input.Name), func(t *testing.T) {

--- a/pkg/resourceinterpreter/interpreter.go
+++ b/pkg/resourceinterpreter/interpreter.go
@@ -109,7 +109,10 @@ func (i *customResourceInterpreterImpl) Start(_ context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	i.configurableInterpreter = declarative.NewConfigurableInterpreter(i.informer)
+	i.configurableInterpreter, err = declarative.NewConfigurableInterpreter(i.informer)
+	if err != nil {
+		return err
+	}
 
 	i.thirdpartyInterpreter = thirdparty.NewConfigurableInterpreter()
 	i.defaultInterpreter = native.NewDefaultInterpreter()
@@ -401,7 +404,12 @@ func (i *customResourceInterpreterImpl) InterpretHealth(object *unstructured.Uns
 // ResourceInterpreterWebhookConfiguration configurations into the cache. It avoids resource interpreter
 // parsing errors when the resource interpreter starts and the cache is not synchronized.
 func (i *customResourceInterpreterImpl) loadConfig() error {
-	customizations, err := i.informer.Lister(util.ResourceInterpreterCustomizationsGVR).List(labels.Everything())
+	customizationsLister, err := i.informer.Lister(util.ResourceInterpreterCustomizationsGVR)
+	if err != nil {
+		klog.Errorf("Failed to get lister for resourceinterpretercustomizations: %v", err)
+		return err
+	}
+	customizations, err := customizationsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("Failed to list resourceinterpretercustomizations: %v", err)
 		return err
@@ -419,7 +427,12 @@ func (i *customResourceInterpreterImpl) loadConfig() error {
 	}
 	i.configurableInterpreter.LoadConfig(declareConfigs)
 
-	webhooks, err := i.informer.Lister(util.ResourceInterpreterWebhookConfigurationsGVR).List(labels.Everything())
+	webhooksLister, err := i.informer.Lister(util.ResourceInterpreterWebhookConfigurationsGVR)
+	if err != nil {
+		klog.Errorf("Failed to get lister for resourceinterpreterwebhookconfigurations: %v", err)
+		return err
+	}
+	webhooks, err := webhooksLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("Failed to list resourceinterpreterwebhookconfigurations: %v", err)
 		return err

--- a/pkg/search/controller.go
+++ b/pkg/search/controller.go
@@ -406,6 +406,19 @@ func (c *Controller) doCacheCluster(cluster string) error {
 	}
 
 	sci := c.InformerManager.GetSingleClusterManager(cluster)
+	if err := c.registerResourceInformers(sci, cls, cr, handler); err != nil {
+		return err
+	}
+	klog.Infof("Start informer for %s", cluster)
+	sci.Start()
+	_ = sci.WaitForCacheSync()
+	klog.Infof("Start informer for %s done", cluster)
+
+	return nil
+}
+
+func (c *Controller) registerResourceInformers(sci genericmanager.SingleClusterInformerManager, cls *clusterv1alpha1.Cluster,
+	cr *clusterRegistry, handler cache.ResourceEventHandler) error {
 	for gvr := range cr.resources {
 		gvk, err := c.restMapper.KindFor(gvr)
 		if err != nil {
@@ -413,17 +426,14 @@ func (c *Controller) doCacheCluster(cluster string) error {
 			continue
 		}
 		if cls.APIEnablement(gvk) == clusterv1alpha1.APIDisabled {
-			klog.Warningf("Resource %s is not enabled for cluster %s", gvr.String(), cluster)
+			klog.Warningf("Resource %s is not enabled for cluster %s", gvr.String(), cls.Name)
 			continue
 		}
-		klog.Infof("Add informer for %s, %v", cluster, gvr)
-		sci.ForResource(gvr, handler)
+		klog.Infof("Add informer for %s, %v", cls.Name, gvr)
+		if err := sci.ForResource(gvr, handler); err != nil {
+			return err
+		}
 	}
-	klog.Infof("Start informer for %s", cluster)
-	sci.Start()
-	_ = sci.WaitForCacheSync()
-	klog.Infof("Start informer for %s done", cluster)
-
 	return nil
 }
 

--- a/pkg/util/fedinformer/genericmanager/single-cluster-manager.go
+++ b/pkg/util/fedinformer/genericmanager/single-cluster-manager.go
@@ -18,13 +18,15 @@ package genericmanager
 
 import (
 	"context"
-	"slices"
+	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -34,8 +36,8 @@ import (
 type SingleClusterInformerManager interface {
 	// ForResource builds a dynamic shared informer for 'resource' then set event handler.
 	// If the informer already exist, the event handler will be appended to the informer.
-	// The handler should not be nil.
-	ForResource(resource schema.GroupVersionResource, handler cache.ResourceEventHandler)
+	// The handler must be a non-nil pointer.
+	ForResource(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) error
 
 	// IsInformerSynced checks if the resource's informer is synced.
 	// An informer is synced means:
@@ -49,7 +51,7 @@ type SingleClusterInformerManager interface {
 
 	// Lister returns a generic lister used to get 'resource' from informer's store.
 	// The informer for 'resource' will be created if not exist, but without any event handler.
-	Lister(resource schema.GroupVersionResource) cache.GenericLister
+	Lister(resource schema.GroupVersionResource) (cache.GenericLister, error)
 
 	// Start will run all informers, the informers will keep running until the channel closed.
 	// It is intended to be called after create new informer(s), and it's safe to call multi times.
@@ -78,8 +80,6 @@ func NewSingleClusterInformerManager(ctx context.Context, client dynamic.Interfa
 	ctx, cancel := context.WithCancel(ctx)
 	return &singleClusterInformerManagerImpl{
 		informerFactory: dynamicinformer.NewDynamicSharedInformerFactory(client, defaultResync),
-		handlers:        make(map[schema.GroupVersionResource][]cache.ResourceEventHandler),
-		syncedInformers: make(map[schema.GroupVersionResource]struct{}),
 		ctx:             ctx,
 		cancel:          cancel,
 		client:          client,
@@ -92,70 +92,120 @@ type singleClusterInformerManagerImpl struct {
 
 	informerFactory dynamicinformer.DynamicSharedInformerFactory
 
-	syncedInformers map[schema.GroupVersionResource]struct{}
-
-	handlers map[schema.GroupVersionResource][]cache.ResourceEventHandler
+	// initializedInformers contains informers that have been initialized. It also keeps steady-state
+	// informer lookups from taking informerFactory's lock for an already known resource.
+	initializedInformers sync.Map
+	syncedInformers      sync.Map
+	handlers             sync.Map
 
 	client dynamic.Interface
 
-	lock sync.RWMutex
+	lock sync.Mutex
 }
 
-func (s *singleClusterInformerManagerImpl) ForResource(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+func (s *singleClusterInformerManagerImpl) ForResource(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) error {
+	if err := validateResourceEventHandler(handler); err != nil {
+		return err
+	}
 
 	// if handler already exist, just return, nothing changed.
 	if s.isHandlerExist(resource, handler) {
-		return
+		return nil
 	}
 
-	_, err := s.informerFactory.ForResource(resource).Informer().AddEventHandler(handler)
+	resourceInformer, err := s.informerForResource(resource)
+	if err != nil {
+		klog.ErrorS(err, "Failed to initialize informer", "resource", resource.String())
+		return err
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// check again, if handler already exist, just return, nothing changed.
+	if s.isHandlerExist(resource, handler) {
+		return nil
+	}
+
+	_, err = resourceInformer.Informer().AddEventHandler(handler)
 	if err != nil {
 		klog.Errorf("Failed to add handler for resource(%s): %v", resource.String(), err)
-		return
+		return err
 	}
 
 	s.appendHandler(resource, handler)
+	return nil
 }
 
 func (s *singleClusterInformerManagerImpl) IsInformerSynced(resource schema.GroupVersionResource) bool {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-
-	_, exist := s.syncedInformers[resource]
+	_, exist := s.syncedInformers.Load(resource)
 	return exist
 }
 
 func (s *singleClusterInformerManagerImpl) IsHandlerExist(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) bool {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-
+	if validateResourceEventHandler(handler) != nil {
+		return false
+	}
 	return s.isHandlerExist(resource, handler)
 }
 
-func (s *singleClusterInformerManagerImpl) isHandlerExist(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) bool {
-	handlers, exist := s.handlers[resource]
-	if !exist {
-		return false
+func validateResourceEventHandler(handler cache.ResourceEventHandler) error {
+	handlerValue := reflect.ValueOf(handler)
+	if handlerValue.Kind() != reflect.Pointer || handlerValue.IsNil() {
+		return fmt.Errorf("resource event handler must be a non-nil pointer, got %T", handler)
 	}
-
-	return slices.Contains(handlers, handler)
+	return nil
 }
 
-func (s *singleClusterInformerManagerImpl) Lister(resource schema.GroupVersionResource) cache.GenericLister {
-	return s.informerFactory.ForResource(resource).Lister()
+func (s *singleClusterInformerManagerImpl) isHandlerExist(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) bool {
+	handlers, ok := s.handlers.Load(resource)
+	if !ok {
+		return false
+	}
+	_, ok = handlers.(*sync.Map).Load(handler)
+	return ok
+}
+
+func (s *singleClusterInformerManagerImpl) Lister(resource schema.GroupVersionResource) (cache.GenericLister, error) {
+	resourceInformer, err := s.informerForResource(resource)
+	if err != nil {
+		klog.ErrorS(err, "Failed to initialize informer", "resource", resource.String())
+		return nil, err
+	}
+	return resourceInformer.Lister(), nil
 }
 
 func (s *singleClusterInformerManagerImpl) appendHandler(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) {
-	// assume the handler list exist, caller should ensure for that.
-	handlers := s.handlers[resource]
+	handlers, _ := s.handlers.LoadOrStore(resource, &sync.Map{})
+	handlers.(*sync.Map).Store(handler, struct{}{})
+}
 
-	// assume the handler not exist in it, caller should ensure for that.
-	s.handlers[resource] = append(handlers, handler)
+func (s *singleClusterInformerManagerImpl) informerForResource(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+	if resourceInformer, exists := s.initializedInformers.Load(resource); exists {
+		return resourceInformer.(informers.GenericInformer), nil
+	}
+	return s.informerForResourceSlowPath(resource)
+}
+
+// informerForResourceSlowPath handles the cache-miss path. It rechecks initializedInformers after acquiring
+// lock because another caller may have initialized the informer while this caller was waiting.
+func (s *singleClusterInformerManagerImpl) informerForResourceSlowPath(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if resourceInformer, exists := s.initializedInformers.Load(resource); exists {
+		return resourceInformer.(informers.GenericInformer), nil
+	}
+
+	resourceInformer := s.informerFactory.ForResource(resource)
+	s.initializedInformers.Store(resource, resourceInformer)
+	return resourceInformer, nil
 }
 
 func (s *singleClusterInformerManagerImpl) Start() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	s.informerFactory.Start(s.ctx.Done())
 }
 
@@ -178,26 +228,21 @@ func (s *singleClusterInformerManagerImpl) waitForCacheSync(ctx context.Context)
 	res := s.informerFactory.WaitForCacheSync(ctx.Done())
 
 	var newlySynced []schema.GroupVersionResource
-
-	s.lock.RLock()
 	for resource, synced := range res {
 		if !synced {
 			continue
 		}
-		if _, exists := s.syncedInformers[resource]; !exists {
+		if _, ok := s.syncedInformers.Load(resource); !ok {
 			newlySynced = append(newlySynced, resource)
 		}
 	}
-	s.lock.RUnlock()
 
 	if len(newlySynced) == 0 {
 		return res
 	}
 
-	s.lock.Lock()
-	defer s.lock.Unlock()
 	for _, resource := range newlySynced {
-		s.syncedInformers[resource] = struct{}{}
+		s.syncedInformers.Store(resource, struct{}{})
 	}
 	return res
 }

--- a/pkg/util/fedinformer/genericmanager/single-cluster-manager_test.go
+++ b/pkg/util/fedinformer/genericmanager/single-cluster-manager_test.go
@@ -1,0 +1,325 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericmanager
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+var testResourceGVR = schema.GroupVersionResource{
+	Group:    "example.io",
+	Version:  "v1",
+	Resource: "widgets",
+}
+
+func TestSingleClusterInformerManagerRejectsInvalidHandler(t *testing.T) {
+	factory := &recordingDynamicInformerFactory{informer: newRecordingGenericInformer()}
+	manager := newTestSingleClusterInformerManager(t, factory)
+
+	if err := manager.ForResource(testResourceGVR, &cache.ResourceEventHandlerFuncs{}); err != nil {
+		t.Fatalf("ForResource() returned an unexpected error for a pointer handler: %v", err)
+	}
+
+	handler := cache.ResourceEventHandlerFuncs{}
+	if manager.IsHandlerExist(testResourceGVR, handler) {
+		t.Fatal("IsHandlerExist() returned true for a non-pointer handler")
+	}
+	if err := manager.ForResource(testResourceGVR, handler); err == nil {
+		t.Fatal("ForResource() returned nil for a non-pointer handler")
+	}
+
+	var nilHandler *cache.ResourceEventHandlerFuncs
+	if manager.IsHandlerExist(testResourceGVR, nilHandler) {
+		t.Fatal("IsHandlerExist() returned true for a nil pointer handler")
+	}
+	if err := manager.ForResource(testResourceGVR, nilHandler); err == nil {
+		t.Fatal("ForResource() returned nil for a nil pointer handler")
+	}
+}
+
+func TestSingleClusterInformerManagerSlowPathRechecksInitializedInformer(t *testing.T) {
+	cachedInformer := newRecordingGenericInformer()
+	factoryInformer := newRecordingGenericInformer()
+	factory := &recordingDynamicInformerFactory{informer: factoryInformer}
+	manager := newTestSingleClusterInformerManager(t, factory)
+	manager.initializedInformers.Store(testResourceGVR, cachedInformer)
+
+	got, err := manager.informerForResourceSlowPath(testResourceGVR)
+	if err != nil {
+		t.Fatalf("informerForResourceSlowPath() returned an unexpected error: %v", err)
+	}
+	if got != cachedInformer {
+		t.Fatal("slow path did not reuse the informer initialized by another caller")
+	}
+	if got := factory.forResourceCalls.Load(); got != 0 {
+		t.Fatalf("factory.ForResource() called %d times, want 0", got)
+	}
+}
+
+func TestSingleClusterInformerManagerCachedLookupSkipsLock(t *testing.T) {
+	genericInformer := newRecordingGenericInformer()
+	factory := &recordingDynamicInformerFactory{informer: genericInformer}
+	manager := newTestSingleClusterInformerManager(t, factory)
+
+	got, err := manager.Lister(testResourceGVR)
+	if err != nil {
+		t.Fatalf("Lister() returned an unexpected error: %v", err)
+	}
+	if got != genericInformer.lister {
+		t.Fatal("Lister() returned a different lister during initialization")
+	}
+
+	manager.lock.Lock()
+	lockHeld := true
+	defer func() {
+		if lockHeld {
+			manager.lock.Unlock()
+		}
+	}()
+
+	lookupResult := make(chan cache.GenericLister, 1)
+	go func() {
+		lister, err := manager.Lister(testResourceGVR)
+		if err != nil {
+			lookupResult <- nil
+			return
+		}
+		lookupResult <- lister
+	}()
+
+	select {
+	case got := <-lookupResult:
+		manager.lock.Unlock()
+		lockHeld = false
+		if got != genericInformer.lister {
+			t.Fatal("cached lookup returned a different lister")
+		}
+	case <-time.After(time.Second):
+		manager.lock.Unlock()
+		lockHeld = false
+		waitForTestValue(t, lookupResult, "cached lookup after releasing lock")
+		t.Fatal("cached lookup blocked on lock")
+	}
+
+	if got := factory.forResourceCalls.Load(); got != 1 {
+		t.Fatalf("factory.ForResource() called %d times, want 1", got)
+	}
+}
+
+func TestSingleClusterInformerManagerSerializesInitializationWithStart(t *testing.T) {
+	genericInformer := newRecordingGenericInformer()
+	factory := &recordingDynamicInformerFactory{informer: genericInformer}
+	manager := newTestSingleClusterInformerManager(t, factory)
+
+	factoryEntered := make(chan struct{})
+	releaseFactory := make(chan struct{})
+	var releaseFactoryOnce sync.Once
+	release := func() {
+		releaseFactoryOnce.Do(func() { close(releaseFactory) })
+	}
+	t.Cleanup(release)
+
+	factory.onForResource = func() {
+		assertMutexHeld(t, &manager.lock, "factory.ForResource")
+		close(factoryEntered)
+		<-releaseFactory
+	}
+	genericInformer.onInformer = func() {
+		assertMutexHeld(t, &manager.lock, "GenericInformer.Informer")
+	}
+	var startBeforeInformerPublished atomic.Bool
+	factory.onStart = func() {
+		if _, exists := manager.initializedInformers.Load(testResourceGVR); !exists {
+			startBeforeInformerPublished.Store(true)
+		}
+	}
+
+	initializationDone := make(chan error, 1)
+	go func() {
+		_, err := manager.informerForResource(testResourceGVR)
+		initializationDone <- err
+	}()
+	waitForTestSignal(t, factoryEntered, "factory.ForResource")
+
+	startAttempted := make(chan struct{})
+	startDone := make(chan struct{})
+	go func() {
+		close(startAttempted)
+		manager.Start()
+		close(startDone)
+	}()
+	waitForTestSignal(t, startAttempted, "Start attempt")
+
+	startReturnedBeforeInitialization := false
+	select {
+	case <-startDone:
+		startReturnedBeforeInitialization = true
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+	if err := waitForTestValue(t, initializationDone, "informer initialization"); err != nil {
+		t.Fatalf("informerForResource() returned an unexpected error: %v", err)
+	}
+	if !startReturnedBeforeInitialization {
+		waitForTestSignal(t, startDone, "Start")
+	}
+
+	if startReturnedBeforeInitialization {
+		t.Fatal("Start returned before informer initialization completed")
+	}
+	if startBeforeInformerPublished.Load() {
+		t.Fatal("factory.Start() ran before the initialized informer was published")
+	}
+	if got := factory.startCalls.Load(); got != 1 {
+		t.Fatalf("factory.Start() called %d times, want 1", got)
+	}
+}
+
+func TestSingleClusterInformerManagerStartUsesLifecycleLock(t *testing.T) {
+	factory := &recordingDynamicInformerFactory{informer: newRecordingGenericInformer()}
+	manager := newTestSingleClusterInformerManager(t, factory)
+	factory.onStart = func() {
+		assertMutexHeld(t, &manager.lock, "factory.Start")
+	}
+
+	manager.Start()
+
+	if got := factory.startCalls.Load(); got != 1 {
+		t.Fatalf("factory.Start() called %d times, want 1", got)
+	}
+}
+
+func newTestSingleClusterInformerManager(
+	t *testing.T,
+	factory dynamicinformer.DynamicSharedInformerFactory,
+) *singleClusterInformerManagerImpl {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	return &singleClusterInformerManagerImpl{
+		ctx:             ctx,
+		cancel:          cancel,
+		informerFactory: factory,
+	}
+}
+
+func assertMutexHeld(t *testing.T, mutex *sync.Mutex, operation string) {
+	t.Helper()
+	if mutex.TryLock() {
+		mutex.Unlock()
+		t.Errorf("lock is not held during %s", operation)
+	}
+}
+
+type recordingDynamicInformerFactory struct {
+	informer informers.GenericInformer
+
+	forResourceCalls atomic.Int64
+	startCalls       atomic.Int64
+	onForResource    func()
+	onStart          func()
+}
+
+func (f *recordingDynamicInformerFactory) ForResource(_ schema.GroupVersionResource) informers.GenericInformer {
+	f.forResourceCalls.Add(1)
+	if f.onForResource != nil {
+		f.onForResource()
+	}
+	return f.informer
+}
+
+func (f *recordingDynamicInformerFactory) Start(_ <-chan struct{}) {
+	f.startCalls.Add(1)
+	if f.onStart != nil {
+		f.onStart()
+	}
+}
+
+func (f *recordingDynamicInformerFactory) WaitForCacheSync(_ <-chan struct{}) map[schema.GroupVersionResource]bool {
+	return nil
+}
+
+func (f *recordingDynamicInformerFactory) Shutdown() {}
+
+type recordingGenericInformer struct {
+	informer   *recordingSharedIndexInformer
+	lister     cache.GenericLister
+	onInformer func()
+}
+
+func (i *recordingGenericInformer) Informer() cache.SharedIndexInformer {
+	if i.onInformer != nil {
+		i.onInformer()
+	}
+	return i.informer
+}
+
+func (i *recordingGenericInformer) Lister() cache.GenericLister {
+	return i.lister
+}
+
+// recordingSharedIndexInformer implements only the SharedIndexInformer methods exercised by these tests.
+type recordingSharedIndexInformer struct {
+	cache.SharedIndexInformer
+
+	addEventHandlerCalls atomic.Int64
+}
+
+func (i *recordingSharedIndexInformer) AddEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	i.addEventHandlerCalls.Add(1)
+	return nil, nil
+}
+
+func newRecordingGenericInformer() *recordingGenericInformer {
+	return &recordingGenericInformer{
+		informer: &recordingSharedIndexInformer{},
+		lister: cache.NewGenericLister(
+			cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}),
+			testResourceGVR.GroupResource(),
+		),
+	}
+}
+
+func waitForTestSignal(t *testing.T, signal <-chan struct{}, operation string) {
+	t.Helper()
+	waitForTestValue(t, signal, operation)
+}
+
+func waitForTestValue[T any](t *testing.T, values <-chan T, operation string) T {
+	t.Helper()
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", operation)
+		var zero T
+		return zero
+	}
+}
+
+var _ dynamicinformer.DynamicSharedInformerFactory = (*recordingDynamicInformerFactory)(nil)
+var _ informers.GenericInformer = (*recordingGenericInformer)(nil)

--- a/pkg/util/fedinformer/genericmanager/testing/fake.go
+++ b/pkg/util/fedinformer/genericmanager/testing/fake.go
@@ -50,15 +50,16 @@ func (m *FakeSingleClusterManager) IsInformerSynced(_ schema.GroupVersionResourc
 }
 
 // Lister returns the lister for the given GVR.
-func (m *FakeSingleClusterManager) Lister(gvr schema.GroupVersionResource) cache.GenericLister {
+func (m *FakeSingleClusterManager) Lister(gvr schema.GroupVersionResource) (cache.GenericLister, error) {
 	if m.listerFunc != nil {
-		return m.listerFunc(gvr)
+		return m.listerFunc(gvr), nil
 	}
-	return nil
+	return nil, nil
 }
 
 // ForResource adds a resource event handler to the informer.
-func (m *FakeSingleClusterManager) ForResource(_ schema.GroupVersionResource, _ cache.ResourceEventHandler) {
+func (m *FakeSingleClusterManager) ForResource(_ schema.GroupVersionResource, _ cache.ResourceEventHandler) error {
+	return nil
 }
 
 // Start starts the informer.

--- a/pkg/util/fedinformer/typedmanager/multi-cluster-manager_test.go
+++ b/pkg/util/fedinformer/typedmanager/multi-cluster-manager_test.go
@@ -84,22 +84,13 @@ func TestMultiClusterInformerManager(t *testing.T) {
 	t.Run("WaitForCacheSync", func(t *testing.T) {
 		cluster := "test-cluster-3"
 		client := fake.NewClientset()
-		resync := 10 * time.Millisecond
-		singleManager := manager.ForCluster(cluster, client, resync)
+		singleManager := manager.ForCluster(cluster, client, 0)
+		registerPodAndNodeInformers(t, singleManager)
 		manager.Start(cluster)
 
-		_, _ = singleManager.Lister(podGVR)
-		_, _ = singleManager.Lister(nodeGVR)
-
-		time.Sleep(100 * time.Millisecond)
-
 		result := manager.WaitForCacheSync(cluster)
-		if result == nil {
-			t.Fatalf("WaitForCacheSync() returned nil result")
-		}
-
-		for gvr, synced := range result {
-			t.Logf("Resource %v synced: %v", gvr, synced)
+		if !result[podGVR] || !result[nodeGVR] {
+			t.Fatalf("WaitForCacheSync() result = %v, want Pod and Node synced", result)
 		}
 
 		manager.Stop(cluster)
@@ -108,21 +99,13 @@ func TestMultiClusterInformerManager(t *testing.T) {
 	t.Run("WaitForCacheSyncWithTimeout", func(t *testing.T) {
 		cluster := "test-cluster-4"
 		client := fake.NewClientset()
-		resync := 10 * time.Millisecond
-		singleManager := manager.ForCluster(cluster, client, resync)
+		singleManager := manager.ForCluster(cluster, client, 0)
+		registerPodAndNodeInformers(t, singleManager)
 		manager.Start(cluster)
 
-		_, _ = singleManager.Lister(podGVR)
-		_, _ = singleManager.Lister(nodeGVR)
-
-		timeout := 100 * time.Millisecond
-		result := manager.WaitForCacheSyncWithTimeout(cluster, timeout)
-		if result == nil {
-			t.Fatalf("WaitForCacheSyncWithTimeout() returned nil result")
-		}
-
-		for gvr, synced := range result {
-			t.Logf("Resource %v synced: %v", gvr, synced)
+		result := manager.WaitForCacheSyncWithTimeout(cluster, 5*time.Second)
+		if !result[podGVR] || !result[nodeGVR] {
+			t.Fatalf("WaitForCacheSyncWithTimeout() result = %v, want Pod and Node synced", result)
 		}
 
 		manager.Stop(cluster)
@@ -141,6 +124,16 @@ func TestMultiClusterInformerManager(t *testing.T) {
 			t.Fatalf("WaitForCacheSyncWithTimeout() returned non-nil for non-existent cluster")
 		}
 	})
+}
+
+func registerPodAndNodeInformers(t *testing.T, manager SingleClusterInformerManager) {
+	t.Helper()
+	if _, err := manager.Lister(podGVR); err != nil {
+		t.Fatalf("failed to create Pod informer: %v", err)
+	}
+	if _, err := manager.Lister(nodeGVR); err != nil {
+		t.Fatalf("failed to create Node informer: %v", err)
+	}
 }
 
 func TestGetInstance(t *testing.T) {

--- a/pkg/util/fedinformer/typedmanager/single-cluster-manager.go
+++ b/pkg/util/fedinformer/typedmanager/single-cluster-manager.go
@@ -18,8 +18,8 @@ package typedmanager
 
 import (
 	"context"
+	"fmt"
 	"reflect"
-	"slices"
 	"sync"
 	"time"
 
@@ -45,7 +45,7 @@ var (
 type SingleClusterInformerManager interface {
 	// ForResource builds a typed shared informer for 'resource' then set event handler.
 	// If the informer already exist, the event handler will be appended to the informer.
-	// The handler should not be nil.
+	// The handler must be a non-nil pointer.
 	ForResource(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) error
 
 	// IsInformerSynced checks if the resource's informer is synced.
@@ -88,15 +88,11 @@ type SingleClusterInformerManager interface {
 func NewSingleClusterInformerManager(ctx context.Context, client kubernetes.Interface, defaultResync time.Duration, transformFuncs map[schema.GroupVersionResource]cache.TransformFunc) SingleClusterInformerManager {
 	ctx, cancel := context.WithCancel(ctx)
 	return &singleClusterInformerManagerImpl{
-		informerFactory:  informers.NewSharedInformerFactory(client, defaultResync),
-		handlers:         make(map[schema.GroupVersionResource][]cache.ResourceEventHandler),
-		syncedInformers:  make(map[schema.GroupVersionResource]struct{}),
-		informers:        make(map[schema.GroupVersionResource]struct{}),
-		startedInformers: make(map[schema.GroupVersionResource]struct{}),
-		transformFuncs:   transformFuncs,
-		ctx:              ctx,
-		cancel:           cancel,
-		client:           client,
+		informerFactory: informers.NewSharedInformerFactory(client, defaultResync),
+		transformFuncs:  transformFuncs,
+		ctx:             ctx,
+		cancel:          cancel,
+		client:          client,
 	}
 }
 
@@ -106,44 +102,41 @@ type singleClusterInformerManagerImpl struct {
 
 	informerFactory informers.SharedInformerFactory
 
-	syncedInformers map[schema.GroupVersionResource]struct{}
-
-	informers map[schema.GroupVersionResource]struct{}
-
-	startedInformers map[schema.GroupVersionResource]struct{}
-
-	handlers map[schema.GroupVersionResource][]cache.ResourceEventHandler
-
 	transformFuncs map[schema.GroupVersionResource]cache.TransformFunc
+
+	// initializedInformers contains informers whose transform has been installed. It also keeps
+	// steady-state informer lookups from taking informerFactory's lock for an already known resource.
+	initializedInformers sync.Map
+	syncedInformers      sync.Map
+	handlers             sync.Map
 
 	client kubernetes.Interface
 
-	lock sync.RWMutex
+	lock sync.Mutex
 }
 
 func (s *singleClusterInformerManagerImpl) ForResource(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	if err := validateResourceEventHandler(handler); err != nil {
+		return err
+	}
 
 	// if handler already exist, just return, nothing changed.
 	if s.isHandlerExist(resource, handler) {
 		return nil
 	}
 
-	resourceInformer, err := s.informerFactory.ForResource(resource)
+	resourceInformer, err := s.informerForResource(resource)
 	if err != nil {
+		klog.ErrorS(err, "Failed to initialize informer", "resource", resource.String())
 		return err
 	}
 
-	if _, exist := s.informers[resource]; !exist {
-		s.informers[resource] = struct{}{}
-	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
-	if resourceTransformFunc, ok := s.transformFuncs[resource]; ok && !s.isInformerStarted(resource) {
-		err = resourceInformer.Informer().SetTransform(resourceTransformFunc)
-		if err != nil {
-			return err
-		}
+	// check again, if handler already exist, just return, nothing changed.
+	if s.isHandlerExist(resource, handler) {
+		return nil
 	}
 
 	_, err = resourceInformer.Informer().AddEventHandler(handler)
@@ -157,53 +150,38 @@ func (s *singleClusterInformerManagerImpl) ForResource(resource schema.GroupVers
 }
 
 func (s *singleClusterInformerManagerImpl) IsInformerSynced(resource schema.GroupVersionResource) bool {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-
-	_, exist := s.syncedInformers[resource]
-	return exist
-}
-
-func (s *singleClusterInformerManagerImpl) isInformerStarted(resource schema.GroupVersionResource) bool {
-	_, exist := s.startedInformers[resource]
+	_, exist := s.syncedInformers.Load(resource)
 	return exist
 }
 
 func (s *singleClusterInformerManagerImpl) IsHandlerExist(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) bool {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-
+	if validateResourceEventHandler(handler) != nil {
+		return false
+	}
 	return s.isHandlerExist(resource, handler)
 }
 
+func validateResourceEventHandler(handler cache.ResourceEventHandler) error {
+	handlerValue := reflect.ValueOf(handler)
+	if handlerValue.Kind() != reflect.Pointer || handlerValue.IsNil() {
+		return fmt.Errorf("resource event handler must be a non-nil pointer, got %T", handler)
+	}
+	return nil
+}
+
 func (s *singleClusterInformerManagerImpl) isHandlerExist(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) bool {
-	handlers, exist := s.handlers[resource]
-	if !exist {
+	handlers, ok := s.handlers.Load(resource)
+	if !ok {
 		return false
 	}
-
-	return slices.Contains(handlers, handler)
+	_, ok = handlers.(*sync.Map).Load(handler)
+	return ok
 }
 
 func (s *singleClusterInformerManagerImpl) Lister(resource schema.GroupVersionResource) (any, error) {
-	resourceInformer, err := s.informerFactory.ForResource(resource)
+	resourceInformer, err := s.informerForResource(resource)
 	if err != nil {
 		return nil, err
-	}
-
-	s.lock.Lock()
-	if _, exist := s.informers[resource]; !exist {
-		s.informers[resource] = struct{}{}
-	}
-	s.lock.Unlock()
-
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	if resourceTransformFunc, ok := s.transformFuncs[resource]; ok && !s.isInformerStarted(resource) {
-		err = resourceInformer.Informer().SetTransform(resourceTransformFunc)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	if resource == nodeGVR {
@@ -217,22 +195,46 @@ func (s *singleClusterInformerManagerImpl) Lister(resource schema.GroupVersionRe
 }
 
 func (s *singleClusterInformerManagerImpl) appendHandler(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) {
-	// assume the handler list exist, caller should ensure for that.
-	handlers := s.handlers[resource]
+	handlers, _ := s.handlers.LoadOrStore(resource, &sync.Map{})
+	handlers.(*sync.Map).Store(handler, struct{}{})
+}
 
-	// assume the handler not exist in it, caller should ensure for that.
-	s.handlers[resource] = append(handlers, handler)
+func (s *singleClusterInformerManagerImpl) informerForResource(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+	if resourceInformer, exists := s.initializedInformers.Load(resource); exists {
+		return resourceInformer.(informers.GenericInformer), nil
+	}
+	return s.informerForResourceSlowPath(resource)
+}
+
+// informerForResourceSlowPath handles the cache-miss path. It rechecks initializedInformers after acquiring
+// lock because another caller may have initialized the informer while this caller was waiting.
+func (s *singleClusterInformerManagerImpl) informerForResourceSlowPath(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if resourceInformer, exists := s.initializedInformers.Load(resource); exists {
+		return resourceInformer.(informers.GenericInformer), nil
+	}
+
+	resourceInformer, err := s.informerFactory.ForResource(resource)
+	if err != nil {
+		return nil, err
+	}
+	if resourceTransformFunc, ok := s.transformFuncs[resource]; ok {
+		if err := resourceInformer.Informer().SetTransform(resourceTransformFunc); err != nil {
+			return resourceInformer, fmt.Errorf("failed to set transform for resource %s: %w", resource.String(), err)
+		}
+	}
+
+	s.initializedInformers.Store(resource, resourceInformer)
+	return resourceInformer, nil
 }
 
 func (s *singleClusterInformerManagerImpl) Start() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+
 	s.informerFactory.Start(s.ctx.Done())
-	for resource := range s.informers {
-		if _, exist := s.startedInformers[resource]; !exist {
-			s.startedInformers[resource] = struct{}{}
-		}
-	}
 }
 
 func (s *singleClusterInformerManagerImpl) Stop() {
@@ -251,15 +253,13 @@ func (s *singleClusterInformerManagerImpl) WaitForCacheSyncWithTimeout(cacheSync
 }
 
 func (s *singleClusterInformerManagerImpl) waitForCacheSync(ctx context.Context) map[schema.GroupVersionResource]bool {
-	s.lock.Lock()
-	defer s.lock.Unlock()
 	res := s.informerFactory.WaitForCacheSync(ctx.Done())
 	m := make(map[schema.GroupVersionResource]bool)
 	for resource, synced := range res {
 		if gvr, exist := gvrTypeMap[resource]; exist {
 			m[gvr] = synced
-			if _, exist = s.syncedInformers[gvr]; !exist && synced {
-				s.syncedInformers[gvr] = struct{}{}
+			if synced {
+				s.syncedInformers.Store(gvr, struct{}{})
 			}
 		}
 	}

--- a/pkg/util/fedinformer/typedmanager/single-cluster-manager_test.go
+++ b/pkg/util/fedinformer/typedmanager/single-cluster-manager_test.go
@@ -17,162 +17,583 @@ limitations under the License.
 package typedmanager
 
 import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
-func TestSingleClusterInformerManager(t *testing.T) {
-	client := fake.NewClientset()
-	ctx := t.Context()
+func TestSingleClusterInformerManagerRejectsInvalidHandler(t *testing.T) {
+	informer := newRecordingTypedGenericInformer()
+	factory := &recordingTypedInformerFactory{informer: informer}
+	manager := newTestTypedSingleClusterInformerManager(t, factory, nil)
 
-	manager := NewSingleClusterInformerManager(ctx, client, 0, nil)
-
-	t.Run("ForResource", func(t *testing.T) {
-		handler := &testResourceEventHandler{}
-		err := manager.ForResource(podGVR, handler)
-		require.NoError(t, err, "ForResource failed")
-
-		assert.True(t, manager.IsHandlerExist(podGVR, handler), "Handler should exist for podGVR")
-	})
-
-	t.Run("Lister", func(t *testing.T) {
-		lister, err := manager.Lister(podGVR)
-		require.NoError(t, err, "Lister failed")
-		assert.NotNil(t, lister, "Lister should not be nil")
-	})
-
-	t.Run("Start and Stop", func(_ *testing.T) {
-		manager.Start()
-		// Sleep to allow informers to start
-		time.Sleep(100 * time.Millisecond)
-		manager.Stop()
-	})
-
-	t.Run("WaitForCacheSync", func(t *testing.T) {
-		manager.Start()
-		defer manager.Stop()
-
-		synced := manager.WaitForCacheSync()
-		assert.NotEmpty(t, synced, "WaitForCacheSync should return non-empty map")
-	})
-
-	t.Run("WaitForCacheSyncWithTimeout", func(t *testing.T) {
-		manager.Start()
-		defer manager.Stop()
-
-		synced := manager.WaitForCacheSyncWithTimeout(5 * time.Second)
-		assert.NotEmpty(t, synced, "WaitForCacheSyncWithTimeout should return non-empty map")
-	})
-
-	t.Run("Context", func(t *testing.T) {
-		ctx := manager.Context()
-		assert.NotNil(t, ctx, "Context should not be nil")
-	})
-
-	t.Run("GetClient", func(t *testing.T) {
-		c := manager.GetClient()
-		assert.NotNil(t, c, "GetClient should not return nil")
-	})
-}
-
-func TestSingleClusterInformerManagerWithTransformFunc(t *testing.T) {
-	client := fake.NewClientset()
-	ctx := t.Context()
-
-	transformFunc := func(i any) (any, error) {
-		return i, nil
+	if err := manager.ForResource(podGVR, &cache.ResourceEventHandlerFuncs{}); err != nil {
+		t.Fatalf("ForResource() returned an unexpected error for a pointer handler: %v", err)
 	}
 
-	transformFuncs := map[schema.GroupVersionResource]cache.TransformFunc{
-		podGVR: transformFunc,
+	handler := cache.ResourceEventHandlerFuncs{}
+	if manager.IsHandlerExist(podGVR, handler) {
+		t.Fatal("IsHandlerExist() returned true for a non-pointer handler")
+	}
+	if err := manager.ForResource(podGVR, handler); err == nil {
+		t.Fatal("ForResource() returned nil for a non-pointer handler")
 	}
 
-	manager := NewSingleClusterInformerManager(ctx, client, 0, transformFuncs)
-
-	t.Run("ForResourceWithTransform", func(t *testing.T) {
-		handler := &testResourceEventHandler{}
-		err := manager.ForResource(podGVR, handler)
-		require.NoError(t, err, "ForResource with transform failed")
-	})
+	var nilHandler *cache.ResourceEventHandlerFuncs
+	if manager.IsHandlerExist(podGVR, nilHandler) {
+		t.Fatal("IsHandlerExist() returned true for a nil pointer handler")
+	}
+	if err := manager.ForResource(podGVR, nilHandler); err == nil {
+		t.Fatal("ForResource() returned nil for a nil pointer handler")
+	}
 }
 
-func TestSingleClusterInformerManagerMultipleHandlers(t *testing.T) {
-	client := fake.NewClientset()
-	ctx := t.Context()
+func TestSingleClusterInformerManagerAppliesTransform(t *testing.T) {
+	tests := []struct {
+		name          string
+		observeObject func(t *testing.T, manager SingleClusterInformerManager) *corev1.Pod
+	}{
+		{
+			name: "ForResource",
+			observeObject: func(t *testing.T, manager SingleClusterInformerManager) *corev1.Pod {
+				observed := make(chan any, 1)
+				handler := &cache.ResourceEventHandlerDetailedFuncs{
+					AddFunc: func(obj any, _ bool) {
+						observed <- obj
+					},
+				}
+				if err := manager.ForResource(podGVR, handler); err != nil {
+					t.Fatalf("ForResource() returned an unexpected error: %v", err)
+				}
+				manager.Start()
+				waitForTypedTestInformerSync(t, manager, podGVR)
 
-	manager := NewSingleClusterInformerManager(ctx, client, 0, nil)
+				select {
+				case obj := <-observed:
+					pod, ok := obj.(*corev1.Pod)
+					if !ok {
+						t.Fatalf("got object type %T, want *corev1.Pod", obj)
+					}
+					return pod
+				case <-time.After(5 * time.Second):
+					t.Fatal("timed out waiting for informer add event")
+					return nil
+				}
+			},
+		},
+		{
+			name: "Lister",
+			observeObject: func(t *testing.T, manager SingleClusterInformerManager) *corev1.Pod {
+				lister, err := manager.Lister(podGVR)
+				if err != nil {
+					t.Fatalf("Lister() returned an unexpected error: %v", err)
+				}
+				podLister, ok := lister.(corev1listers.PodLister)
+				if !ok {
+					t.Fatalf("got lister type %T, want corev1listers.PodLister", lister)
+				}
+				manager.Start()
+				waitForTypedTestInformerSync(t, manager, podGVR)
 
-	handler1 := &testResourceEventHandler{}
-	handler2 := &testResourceEventHandler{}
+				pod, err := podLister.Pods("default").Get("test-pod")
+				if err != nil {
+					t.Fatalf("failed to get Pod from informer cache: %v", err)
+				}
+				return pod
+			},
+		},
+	}
 
-	t.Run("MultipleHandlers", func(t *testing.T) {
-		err := manager.ForResource(podGVR, handler1)
-		require.NoError(t, err, "ForResource failed for handler1")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewClientset(newTypedTransformTestPod())
+			manager := NewSingleClusterInformerManager(
+				t.Context(),
+				client,
+				0,
+				map[schema.GroupVersionResource]cache.TransformFunc{podGVR: stripTypedManagedFields},
+			)
+			t.Cleanup(manager.Stop)
 
-		err = manager.ForResource(podGVR, handler2)
-		require.NoError(t, err, "ForResource failed for handler2")
-
-		assert.True(t, manager.IsHandlerExist(podGVR, handler1), "Handler1 should exist for podGVR")
-		assert.True(t, manager.IsHandlerExist(podGVR, handler2), "Handler2 should exist for podGVR")
-	})
+			assertTransformedTypedTestPod(t, tt.observeObject(t, manager))
+		})
+	}
 }
 
-func TestSingleClusterInformerManagerDifferentResources(t *testing.T) {
-	client := fake.NewClientset()
-	ctx := t.Context()
+func TestSingleClusterInformerManagerReturnsTypedListers(t *testing.T) {
+	manager := NewSingleClusterInformerManager(t.Context(), fake.NewClientset(), 0, nil)
+	t.Cleanup(manager.Stop)
 
-	manager := NewSingleClusterInformerManager(ctx, client, 0, nil)
+	tests := []struct {
+		name     string
+		resource schema.GroupVersionResource
+		assert   func(t *testing.T, lister any)
+	}{
+		{
+			name:     "Pod",
+			resource: podGVR,
+			assert: func(t *testing.T, lister any) {
+				if _, ok := lister.(corev1listers.PodLister); !ok {
+					t.Fatalf("got lister type %T, want corev1listers.PodLister", lister)
+				}
+			},
+		},
+		{
+			name:     "Node",
+			resource: nodeGVR,
+			assert: func(t *testing.T, lister any) {
+				if _, ok := lister.(corev1listers.NodeLister); !ok {
+					t.Fatalf("got lister type %T, want corev1listers.NodeLister", lister)
+				}
+			},
+		},
+	}
 
-	t.Run("DifferentResources", func(t *testing.T) {
-		podHandler := &testResourceEventHandler{}
-		err := manager.ForResource(podGVR, podHandler)
-		require.NoError(t, err, "ForResource failed for podGVR")
-
-		nodeHandler := &testResourceEventHandler{}
-		err = manager.ForResource(nodeGVR, nodeHandler)
-		require.NoError(t, err, "ForResource failed for nodeGVR")
-
-		assert.True(t, manager.IsHandlerExist(podGVR, podHandler), "PodHandler should exist for podGVR")
-		assert.True(t, manager.IsHandlerExist(nodeGVR, nodeHandler), "NodeHandler should exist for nodeGVR")
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lister, err := manager.Lister(tt.resource)
+			if err != nil {
+				t.Fatalf("Lister() returned an unexpected error: %v", err)
+			}
+			tt.assert(t, lister)
+		})
+	}
 }
 
-func TestIsInformerSynced(t *testing.T) {
-	client := fake.NewClientset()
-	ctx := t.Context()
-	manager := NewSingleClusterInformerManager(ctx, client, 0, nil)
+func TestSingleClusterInformerManagerConcurrentHandlerRegistration(t *testing.T) {
+	genericInformer := newRecordingTypedGenericInformer()
+	factory := &recordingTypedInformerFactory{informer: genericInformer}
+	manager := newTestTypedSingleClusterInformerManager(t, factory, nil)
+	handler := &testResourceEventHandler{id: 1}
 
-	assert.False(t, manager.IsInformerSynced(podGVR))
-	assert.False(t, manager.IsInformerSynced(nodeGVR))
+	const goroutines = 32
+	start := make(chan struct{})
+	errors := make(chan error, goroutines)
+	var workers sync.WaitGroup
+	workers.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer workers.Done()
+			<-start
+			errors <- manager.ForResource(podGVR, handler)
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(errors)
 
-	handler := &testResourceEventHandler{}
-	err := manager.ForResource(podGVR, handler)
-	require.NoError(t, err)
-	err = manager.ForResource(nodeGVR, handler)
-	require.NoError(t, err)
-
-	manager.Start()
-	defer manager.Stop()
-
-	synced := manager.WaitForCacheSyncWithTimeout(5 * time.Second)
-
-	assert.True(t, synced[podGVR], "Pod informer should be synced")
-	assert.True(t, synced[nodeGVR], "Node informer should be synced")
-
-	time.Sleep(100 * time.Millisecond)
-
-	assert.True(t, manager.IsInformerSynced(podGVR), "Pod informer should be reported as synced")
-	assert.True(t, manager.IsInformerSynced(nodeGVR), "Node informer should be reported as synced")
+	for err := range errors {
+		if err != nil {
+			t.Fatalf("ForResource() returned an unexpected error: %v", err)
+		}
+	}
+	if !manager.IsHandlerExist(podGVR, handler) {
+		t.Fatal("handler was not recorded after registration")
+	}
+	if got := factory.forResourceCalls.Load(); got != 1 {
+		t.Fatalf("factory.ForResource() called %d times, want 1", got)
+	}
+	if got := genericInformer.informer.addEventHandlerCalls.Load(); got != 1 {
+		t.Fatalf("AddEventHandler() called %d times, want 1", got)
+	}
 }
 
-type testResourceEventHandler struct{}
+func TestSingleClusterInformerManagerCachedReadsSkipLock(t *testing.T) {
+	manager := NewSingleClusterInformerManager(t.Context(), fake.NewClientset(), 0, nil).(*singleClusterInformerManagerImpl)
+	t.Cleanup(manager.Stop)
+	handler := &testResourceEventHandler{id: 1}
+	if err := manager.ForResource(podGVR, handler); err != nil {
+		t.Fatalf("ForResource() returned an unexpected error: %v", err)
+	}
+	manager.syncedInformers.Store(podGVR, struct{}{})
+
+	manager.lock.Lock()
+	lockHeld := true
+	defer func() {
+		if lockHeld {
+			manager.lock.Unlock()
+		}
+	}()
+
+	lookupDone := make(chan error, 1)
+	go func() {
+		if _, err := manager.Lister(podGVR); err != nil {
+			lookupDone <- err
+			return
+		}
+		if !manager.IsHandlerExist(podGVR, handler) {
+			lookupDone <- errors.New("registered handler was not found")
+			return
+		}
+		if !manager.IsInformerSynced(podGVR) {
+			lookupDone <- errors.New("synced informer was not found")
+			return
+		}
+		lookupDone <- nil
+	}()
+
+	select {
+	case err := <-lookupDone:
+		manager.lock.Unlock()
+		lockHeld = false
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		manager.lock.Unlock()
+		lockHeld = false
+		if err := waitForTypedTestValue(t, lookupDone, "cached reads after releasing lock"); err != nil {
+			t.Fatal(err)
+		}
+		t.Fatal("cached reads blocked on lock")
+	}
+}
+
+func TestSingleClusterInformerManagerSerializesInitializationWithStart(t *testing.T) {
+	genericInformer := newRecordingTypedGenericInformer()
+	factory := &recordingTypedInformerFactory{informer: genericInformer}
+	manager := newTestTypedSingleClusterInformerManager(
+		t,
+		factory,
+		map[schema.GroupVersionResource]cache.TransformFunc{podGVR: stripTypedManagedFields},
+	)
+
+	factoryEntered := make(chan struct{})
+	releaseFactory := make(chan struct{})
+	var releaseFactoryOnce sync.Once
+	release := func() {
+		releaseFactoryOnce.Do(func() { close(releaseFactory) })
+	}
+	t.Cleanup(release)
+
+	factory.onForResource = func() {
+		assertTypedMutexHeld(t, &manager.lock, "factory.ForResource")
+		close(factoryEntered)
+		<-releaseFactory
+	}
+	var transformInstalled atomic.Bool
+	genericInformer.informer.onSetTransform = func() {
+		assertTypedMutexHeld(t, &manager.lock, "SetTransform")
+		transformInstalled.Store(true)
+	}
+	var startBeforeTransform atomic.Bool
+	var startBeforeInformerPublished atomic.Bool
+	factory.onStart = func() {
+		if !transformInstalled.Load() {
+			startBeforeTransform.Store(true)
+		}
+		if _, exists := manager.initializedInformers.Load(podGVR); !exists {
+			startBeforeInformerPublished.Store(true)
+		}
+	}
+
+	initializationDone := make(chan error, 1)
+	go func() {
+		_, err := manager.informerForResource(podGVR)
+		initializationDone <- err
+	}()
+	waitForTypedTestSignal(t, factoryEntered, "factory.ForResource")
+
+	startAttempted := make(chan struct{})
+	startDone := make(chan struct{})
+	go func() {
+		close(startAttempted)
+		manager.Start()
+		close(startDone)
+	}()
+	waitForTypedTestSignal(t, startAttempted, "Start attempt")
+
+	startReturnedBeforeInitialization := false
+	select {
+	case <-startDone:
+		startReturnedBeforeInitialization = true
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+	if err := waitForTypedTestValue(t, initializationDone, "informer initialization"); err != nil {
+		t.Fatalf("informerForResource() returned an unexpected error: %v", err)
+	}
+	if !startReturnedBeforeInitialization {
+		waitForTypedTestSignal(t, startDone, "Start")
+	}
+
+	if startReturnedBeforeInitialization {
+		t.Fatal("Start returned before informer initialization completed")
+	}
+	if startBeforeTransform.Load() {
+		t.Fatal("factory.Start() ran before SetTransform() completed")
+	}
+	if startBeforeInformerPublished.Load() {
+		t.Fatal("factory.Start() ran before the initialized informer was published")
+	}
+}
+
+func TestSingleClusterInformerManagerRetriesFailedTransformWithoutPublishing(t *testing.T) {
+	wantErr := errors.New("failed to install transform")
+	genericInformer := newRecordingTypedGenericInformer()
+	genericInformer.informer.setTransformErr = wantErr
+	factory := &recordingTypedInformerFactory{informer: genericInformer}
+	manager := newTestTypedSingleClusterInformerManager(
+		t,
+		factory,
+		map[schema.GroupVersionResource]cache.TransformFunc{podGVR: stripTypedManagedFields},
+	)
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		resourceInformer, err := manager.informerForResource(podGVR)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("attempt %d: informerForResource() error = %v, want %v", attempt, err, wantErr)
+		}
+		if resourceInformer != genericInformer {
+			t.Fatalf("attempt %d: failed transform returned a different GenericInformer", attempt)
+		}
+		if _, exists := manager.initializedInformers.Load(podGVR); exists {
+			t.Fatalf("attempt %d: failed transform published an initialized informer", attempt)
+		}
+	}
+
+	genericInformer.informer.setTransformErr = nil
+	resourceInformer, err := manager.informerForResource(podGVR)
+	if err != nil {
+		t.Fatalf("informerForResource() returned an unexpected error after recovery: %v", err)
+	}
+	if resourceInformer != genericInformer {
+		t.Fatal("successful retry returned a different GenericInformer")
+	}
+	if _, exists := manager.initializedInformers.Load(podGVR); !exists {
+		t.Fatal("successful retry did not publish the initialized informer")
+	}
+	if got := factory.forResourceCalls.Load(); got != 3 {
+		t.Fatalf("factory.ForResource() called %d times, want 3", got)
+	}
+	if got := genericInformer.informer.setTransformCalls.Load(); got != 3 {
+		t.Fatalf("SetTransform() called %d times, want 3", got)
+	}
+}
+
+func TestSingleClusterInformerManagerWaitForCacheSyncSkipsLock(t *testing.T) {
+	factory := &recordingTypedInformerFactory{
+		informer: newRecordingTypedGenericInformer(),
+		waitForCacheSyncResult: map[reflect.Type]bool{
+			reflect.TypeFor[*corev1.Pod]():  true,
+			reflect.TypeFor[*corev1.Node](): false,
+		},
+	}
+	manager := newTestTypedSingleClusterInformerManager(t, factory, nil)
+	factory.onWaitForCacheSync = func() {
+		if !manager.lock.TryLock() {
+			t.Error("WaitForCacheSync() called while lock was held")
+			return
+		}
+		manager.lock.Unlock()
+	}
+
+	result := manager.waitForCacheSync(t.Context())
+	if !result[podGVR] {
+		t.Fatalf("Pod informer sync result = %v, want true", result[podGVR])
+	}
+	if result[nodeGVR] {
+		t.Fatalf("Node informer sync result = %v, want false", result[nodeGVR])
+	}
+	if !manager.IsInformerSynced(podGVR) {
+		t.Fatal("Pod informer was not recorded as synced")
+	}
+	if manager.IsInformerSynced(nodeGVR) {
+		t.Fatal("Node informer was recorded as synced")
+	}
+}
+
+func newTypedTransformTestPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-pod",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:    "test-manager",
+					Operation:  metav1.ManagedFieldsOperationUpdate,
+					APIVersion: "v1",
+					FieldsType: "FieldsV1",
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}},
+		},
+	}
+}
+
+func stripTypedManagedFields(obj any) (any, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	accessor.SetManagedFields(nil)
+	return obj, nil
+}
+
+func assertTransformedTypedTestPod(t *testing.T, pod *corev1.Pod) {
+	t.Helper()
+	if len(pod.GetManagedFields()) != 0 {
+		t.Fatalf("managedFields were not stripped: %v", pod.GetManagedFields())
+	}
+	if len(pod.Spec.Containers) != 1 || pod.Spec.Containers[0].Image != "test-image" {
+		t.Fatalf("Pod spec was not preserved: %#v", pod.Spec)
+	}
+}
+
+func waitForTypedTestInformerSync(t *testing.T, manager SingleClusterInformerManager, resource schema.GroupVersionResource) {
+	t.Helper()
+	if synced := manager.WaitForCacheSyncWithTimeout(5 * time.Second); !synced[resource] {
+		t.Fatalf("informer failed to sync: %v", synced)
+	}
+}
+
+func newTestTypedSingleClusterInformerManager(
+	t *testing.T,
+	factory informers.SharedInformerFactory,
+	transforms map[schema.GroupVersionResource]cache.TransformFunc,
+) *singleClusterInformerManagerImpl {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	return &singleClusterInformerManagerImpl{
+		ctx:             ctx,
+		cancel:          cancel,
+		informerFactory: factory,
+		transformFuncs:  transforms,
+	}
+}
+
+func assertTypedMutexHeld(t *testing.T, mutex *sync.Mutex, operation string) {
+	t.Helper()
+	if mutex.TryLock() {
+		mutex.Unlock()
+		t.Errorf("lock is not held during %s", operation)
+	}
+}
+
+type recordingTypedInformerFactory struct {
+	informers.SharedInformerFactory
+
+	informer informers.GenericInformer
+
+	forResourceCalls       atomic.Int64
+	startCalls             atomic.Int64
+	onForResource          func()
+	onStart                func()
+	onWaitForCacheSync     func()
+	waitForCacheSyncResult map[reflect.Type]bool
+}
+
+func (f *recordingTypedInformerFactory) ForResource(_ schema.GroupVersionResource) (informers.GenericInformer, error) {
+	f.forResourceCalls.Add(1)
+	if f.onForResource != nil {
+		f.onForResource()
+	}
+	return f.informer, nil
+}
+
+func (f *recordingTypedInformerFactory) Start(_ <-chan struct{}) {
+	f.startCalls.Add(1)
+	if f.onStart != nil {
+		f.onStart()
+	}
+}
+
+func (f *recordingTypedInformerFactory) WaitForCacheSync(_ <-chan struct{}) map[reflect.Type]bool {
+	if f.onWaitForCacheSync != nil {
+		f.onWaitForCacheSync()
+	}
+	return f.waitForCacheSyncResult
+}
+
+type recordingTypedGenericInformer struct {
+	informer *recordingTypedSharedIndexInformer
+	lister   cache.GenericLister
+}
+
+func (i *recordingTypedGenericInformer) Informer() cache.SharedIndexInformer {
+	return i.informer
+}
+
+func (i *recordingTypedGenericInformer) Lister() cache.GenericLister {
+	return i.lister
+}
+
+type recordingTypedSharedIndexInformer struct {
+	cache.SharedIndexInformer
+
+	indexer              cache.Indexer
+	setTransformCalls    atomic.Int64
+	addEventHandlerCalls atomic.Int64
+	setTransformErr      error
+	onSetTransform       func()
+}
+
+func (i *recordingTypedSharedIndexInformer) SetTransform(_ cache.TransformFunc) error {
+	i.setTransformCalls.Add(1)
+	if i.onSetTransform != nil {
+		i.onSetTransform()
+	}
+	return i.setTransformErr
+}
+
+func (i *recordingTypedSharedIndexInformer) AddEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	i.addEventHandlerCalls.Add(1)
+	return nil, nil
+}
+
+func (i *recordingTypedSharedIndexInformer) GetIndexer() cache.Indexer {
+	return i.indexer
+}
+
+func newRecordingTypedGenericInformer() *recordingTypedGenericInformer {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	return &recordingTypedGenericInformer{
+		informer: &recordingTypedSharedIndexInformer{indexer: indexer},
+		lister:   cache.NewGenericLister(indexer, podGVR.GroupResource()),
+	}
+}
+
+func waitForTypedTestSignal(t *testing.T, signal <-chan struct{}, operation string) {
+	t.Helper()
+	waitForTypedTestValue(t, signal, operation)
+}
+
+func waitForTypedTestValue[T any](t *testing.T, values <-chan T, operation string) T {
+	t.Helper()
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", operation)
+		var zero T
+		return zero
+	}
+}
+
+type testResourceEventHandler struct {
+	id int
+}
 
 func (t *testResourceEventHandler) OnAdd(_ any, _ bool) {}
 func (t *testResourceEventHandler) OnUpdate(_, _ any)   {}
 func (t *testResourceEventHandler) OnDelete(_ any)      {}
+
+var _ informers.SharedInformerFactory = (*recordingTypedInformerFactory)(nil)
+var _ informers.GenericInformer = (*recordingTypedGenericInformer)(nil)

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -298,12 +298,16 @@ func FetchResourceTemplate(
 	}
 
 	var object runtime.Object
-
+	lister, err := informerManager.Lister(gvr)
+	if err != nil {
+		klog.Errorf("Failed to get lister for %s, Error: %v", gvr.String(), err)
+		return nil, err
+	}
 	if len(resource.Namespace) == 0 {
 		// cluster-scoped resource
-		object, err = informerManager.Lister(gvr).Get(resource.Name)
+		object, err = lister.Get(resource.Name)
 	} else {
-		object, err = informerManager.Lister(gvr).ByNamespace(resource.Namespace).Get(resource.Name)
+		object, err = lister.ByNamespace(resource.Namespace).Get(resource.Name)
 	}
 	if err != nil {
 		// fall back to call api server in case the cache has not been synchronized yet
@@ -344,11 +348,16 @@ func FetchResourceTemplatesByLabelSelector(
 		return nil, err
 	}
 	var objectList []runtime.Object
+	lister, err := informerManager.Lister(gvr)
+	if err != nil {
+		klog.Errorf("Failed to get lister for %s, Error: %v", gvr.String(), err)
+		return nil, err
+	}
 	if len(resource.Namespace) == 0 {
 		// cluster-scoped resource
-		objectList, err = informerManager.Lister(gvr).List(selector)
+		objectList, err = lister.List(selector)
 	} else {
-		objectList, err = informerManager.Lister(gvr).ByNamespace(resource.Namespace).List(selector)
+		objectList, err = lister.ByNamespace(resource.Namespace).List(selector)
 	}
 	var objects []*unstructured.Unstructured
 	if err != nil || len(objectList) == 0 {

--- a/pkg/util/helper/binding_test.go
+++ b/pkg/util/helper/binding_test.go
@@ -18,6 +18,7 @@ package helper
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -34,6 +35,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -56,6 +58,14 @@ const (
 	evenUID        = "4858ca61-3ff8-4095-8267-f3d059d8074c"
 	oddUID         = "d43fdeeb-d750-4e2b-bee3-64eb94534f4c"
 )
+
+type listerErrorInformerManager struct {
+	genericmanager.SingleClusterInformerManager
+}
+
+func (m *listerErrorInformerManager) Lister(_ schema.GroupVersionResource) (cache.GenericLister, error) {
+	return nil, errors.New("lister initialization failed")
+}
 
 func Test_dispenser_AllocateByWeight(t *testing.T) {
 	tests := []struct {
@@ -1037,6 +1047,29 @@ func TestFetchWorkload(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "lister initialization error fails fast",
+			args: args{
+				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
+					&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}}),
+				informerManager: func(context.Context) genericmanager.SingleClusterInformerManager {
+					return &listerErrorInformerManager{}
+				},
+				restMapper: func() meta.RESTMapper {
+					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
+					m.Add(corev1.SchemeGroupVersion.WithKind("Pod"), meta.RESTScopeNamespace)
+					return m
+				}(),
+				resource: workv1alpha2.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Namespace:  "default",
+					Name:       "pod",
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "namespace scope: get from client",
 			args: args{
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
@@ -1074,7 +1107,7 @@ func TestFetchWorkload(t *testing.T) {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}})
 					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
 					return m
@@ -1137,7 +1170,7 @@ func TestFetchWorkload(t *testing.T) {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node"}})
 					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("nodes"))
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("nodes"))
 					m.Start()
 					m.WaitForCacheSync()
 					return m
@@ -1212,6 +1245,34 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "lister initialization error fails fast",
+			args: args{
+				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
+					&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod",
+						Namespace: "default",
+						Labels:    map[string]string{"foo": "foo"},
+					}}),
+				informerManager: func(context.Context) genericmanager.SingleClusterInformerManager {
+					return &listerErrorInformerManager{}
+				},
+				restMapper: func() meta.RESTMapper {
+					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
+					m.Add(corev1.SchemeGroupVersion.WithKind("Pod"), meta.RESTScopeNamespace)
+					return m
+				}(),
+				resource: workv1alpha2.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Namespace:  "default",
+					Name:       "pod",
+				},
+				selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "foo"}},
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
 			name: "namespace scope: get from client",
 			args: args{
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
@@ -1242,7 +1303,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"bar": "foo"}}})
 					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 					m.Start()
 					m.WaitForCacheSync()
 					return m
@@ -1294,7 +1355,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 					c := dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node", Labels: map[string]string{"bar": "foo"}}})
 					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("nodes"))
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("nodes"))
 					m.Start()
 					m.WaitForCacheSync()
 					return m

--- a/pkg/util/helper/cache.go
+++ b/pkg/util/helper/cache.go
@@ -74,7 +74,10 @@ func RegisterInformerHandlerAndCheckSynced(
 	for _, gvr := range gvrTargets {
 		if !singleClusterInformerManager.IsHandlerExist(gvr, handler) {
 			allSynced = false
-			singleClusterInformerManager.ForResource(gvr, handler)
+			if err := singleClusterInformerManager.ForResource(gvr, handler); err != nil {
+				klog.ErrorS(err, "Failed to register handler for resource", "resource", gvr.String())
+				return false, err
+			}
 			continue
 		}
 
@@ -137,7 +140,11 @@ func GetObjectFromCache(
 	}
 
 	var obj runtime.Object
-	lister := singleClusterManager.Lister(gvr)
+	lister, err := singleClusterManager.Lister(gvr)
+	if err != nil {
+		klog.Errorf("Failed to get lister for %s from cluster(%s). error: %v.", gvr.String(), fedKey.Cluster, err)
+		return nil, err
+	}
 	obj, err = lister.Get(fedKey.NamespaceKey())
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -165,7 +172,11 @@ func GetObjectFromSingleClusterCache(restMapper meta.RESTMapper, manager generic
 		return getObjectFromSingleCluster(gvr, cwk, manager.GetClient())
 	}
 
-	lister := manager.Lister(gvr)
+	lister, err := manager.Lister(gvr)
+	if err != nil {
+		klog.Errorf("Failed to get lister for %s. error: %v.", gvr.String(), err)
+		return nil, err
+	}
 	obj, err := lister.Get(cwk.NamespaceKey())
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/util/helper/cache_test.go
+++ b/pkg/util/helper/cache_test.go
@@ -70,7 +70,7 @@ func TestRegisterInformerHandlerAndCheckSynced(t *testing.T) {
 			name: "returns synced when handler exists and informer synced",
 			manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
 				m := genericmanager.NewMultiClusterInformerManager(ctx)
-				m.ForCluster(cluster.Name, dynamicClient, 0).ForResource(gvr, handler)
+				_ = m.ForCluster(cluster.Name, dynamicClient, 0).ForResource(gvr, handler)
 				m.Start(cluster.Name)
 				m.WaitForCacheSync(cluster.Name)
 				return m
@@ -233,7 +233,7 @@ func TestGetObjectFromCache(t *testing.T) {
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
 					m := genericmanager.NewMultiClusterInformerManager(ctx)
-					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme), 0).
+					_, _ = m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme), 0).
 						Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start("cluster")
 					m.WaitForCacheSync("cluster")
@@ -256,7 +256,7 @@ func TestGetObjectFromCache(t *testing.T) {
 				}(),
 				manager: func(ctx context.Context) genericmanager.MultiClusterInformerManager {
 					m := genericmanager.NewMultiClusterInformerManager(ctx)
-					m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme,
+					_, _ = m.ForCluster("cluster", fake.NewSimpleDynamicClient(scheme.Scheme,
 						&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}},
 					), 0).Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start("cluster")
@@ -364,7 +364,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 				}(),
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					m := genericmanager.NewSingleClusterInformerManager(ctx, fake.NewSimpleDynamicClient(scheme.Scheme), 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start()
 					m.WaitForCacheSync()
 					return m
@@ -385,7 +385,7 @@ func TestGetObjectFromSingleClusterCache(t *testing.T) {
 				manager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
 					c := fake.NewSimpleDynamicClient(scheme.Scheme, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}})
 					m := genericmanager.NewSingleClusterInformerManager(ctx, c, 0)
-					m.Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
+					_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource("pods")) // register pod informer
 					m.Start()
 					m.WaitForCacheSync()
 					return m

--- a/pkg/util/testing/mock_manager.go
+++ b/pkg/util/testing/mock_manager.go
@@ -31,7 +31,7 @@ import (
 func NewSingleClusterInformerManagerByRS(src string, obj runtime.Object) genericmanager.SingleClusterInformerManager {
 	c := fakedynamic.NewSimpleDynamicClient(scheme.Scheme, obj)
 	m := genericmanager.NewSingleClusterInformerManager(context.TODO(), c, 0)
-	m.Lister(corev1.SchemeGroupVersion.WithResource(src))
+	_, _ = m.Lister(corev1.SchemeGroupVersion.WithResource(src))
 	m.Start()
 	m.WaitForCacheSync()
 	return m


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

- Replaces the RWMutex-protected informer maps with sync.Map, keeping the lock only for first initialization and Start, so steady-state informer lookups are lock-free.
- Makes informer initialization errors explicit and propagates them to callers, so Lister/ForResource failures fail fast instead of falling back or continuing with a nil lister.
- Adds lifecycle, transform, concurrency, and fail-fast tests for the informer managers and affected callers.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

