### PR TITLE
refactor: use sync.Map and lifecycle lock in generic informer manager

### DIFF
--- a/pkg/util/fedinformer/genericmanager/single-cluster-manager.go
+++ b/pkg/util/fedinformer/genericmanager/single-cluster-manager.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -78,8 +79,6 @@ func NewSingleClusterInformerManager(ctx context.Context, client dynamic.Interfa
 	ctx, cancel := context.WithCancel(ctx)
 	return &singleClusterInformerManagerImpl{
 		informerFactory: dynamicinformer.NewDynamicSharedInformerFactory(client, defaultResync),
-		handlers:        make(map[schema.GroupVersionResource][]cache.ResourceEventHandler),
-		syncedInformers: make(map[schema.GroupVersionResource]struct{}),
 		ctx:             ctx,
 		cancel:          cancel,
 		client:          client,
@@ -92,25 +91,44 @@ type singleClusterInformerManagerImpl struct {
 
 	informerFactory dynamicinformer.DynamicSharedInformerFactory
 
-	syncedInformers map[schema.GroupVersionResource]struct{}
+	// initializedInformers caches the informers that have been created by the
+	// informer factory, used to avoid the lock contention in the informer factory
+	// when getting an informer for a resource.
+	// The key is schema.GroupVersionResource, and the value is informers.GenericInformer.
+	initializedInformers sync.Map
 
-	handlers map[schema.GroupVersionResource][]cache.ResourceEventHandler
+	// syncedInformers records the resources whose informer caches have been synced,
+	// used to quickly answer IsInformerSynced without waiting for cache sync again.
+	// The key is schema.GroupVersionResource, and the value is struct{}{} (a placeholder).
+	syncedInformers sync.Map
+
+	// handlers records the event handlers that have been added to each resource's
+	// informer, used to prevent the same handler from being added more than once.
+	// The key is schema.GroupVersionResource, and the value is []cache.ResourceEventHandler.
+	handlers sync.Map
 
 	client dynamic.Interface
 
-	lock sync.RWMutex
+	lock sync.Mutex
 }
 
 func (s *singleClusterInformerManagerImpl) ForResource(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	// if handler already exist, just return, nothing changed.
 	if s.isHandlerExist(resource, handler) {
 		return
 	}
 
-	_, err := s.informerFactory.ForResource(resource).Informer().AddEventHandler(handler)
+	resourceInformer := s.getOrCreateInformer(resource)
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// check again, if handler already exist, just return, nothing changed.
+	if s.isHandlerExist(resource, handler) {
+		return
+	}
+
+	_, err := resourceInformer.Informer().AddEventHandler(handler)
 	if err != nil {
 		klog.Errorf("Failed to add handler for resource(%s): %v", resource.String(), err)
 		return
@@ -120,42 +138,66 @@ func (s *singleClusterInformerManagerImpl) ForResource(resource schema.GroupVers
 }
 
 func (s *singleClusterInformerManagerImpl) IsInformerSynced(resource schema.GroupVersionResource) bool {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-
-	_, exist := s.syncedInformers[resource]
+	_, exist := s.syncedInformers.Load(resource)
 	return exist
 }
 
 func (s *singleClusterInformerManagerImpl) IsHandlerExist(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) bool {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-
 	return s.isHandlerExist(resource, handler)
 }
 
 func (s *singleClusterInformerManagerImpl) isHandlerExist(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) bool {
-	handlers, exist := s.handlers[resource]
-	if !exist {
+	handlers, ok := s.handlers.Load(resource)
+	if !ok {
 		return false
 	}
-
-	return slices.Contains(handlers, handler)
+	return slices.Contains(handlers.([]cache.ResourceEventHandler), handler)
 }
 
 func (s *singleClusterInformerManagerImpl) Lister(resource schema.GroupVersionResource) cache.GenericLister {
-	return s.informerFactory.ForResource(resource).Lister()
+	return s.getOrCreateInformer(resource).Lister()
 }
 
 func (s *singleClusterInformerManagerImpl) appendHandler(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) {
-	// assume the handler list exist, caller should ensure for that.
-	handlers := s.handlers[resource]
+	var handlers []cache.ResourceEventHandler
+	if currentHandlers, ok := s.handlers.Load(resource); ok {
+		handlers = currentHandlers.([]cache.ResourceEventHandler)
+	}
+	// Publish a new slice so concurrent lock-free readers never observe a slice being modified.
+	s.handlers.Store(resource, append(slices.Clone(handlers), handler))
+}
 
-	// assume the handler not exist in it, caller should ensure for that.
-	s.handlers[resource] = append(handlers, handler)
+// getOrCreateInformer returns the informer for the given resource, creating it
+// if it doesn't exist yet. It first tries a lock-free lookup in initializedInformers,
+// and creates the informer if not found.
+func (s *singleClusterInformerManagerImpl) getOrCreateInformer(resource schema.GroupVersionResource) informers.GenericInformer {
+	if resourceInformer, exists := s.initializedInformers.Load(resource); exists {
+		return resourceInformer.(informers.GenericInformer)
+	}
+	return s.createInformer(resource)
+}
+
+// createInformer creates the informer for the given resource and records it
+// in initializedInformers.
+func (s *singleClusterInformerManagerImpl) createInformer(resource schema.GroupVersionResource) informers.GenericInformer {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Recheck after acquiring the lock, as another caller may have created
+	// the informer while this caller was waiting for the lock.
+	if resourceInformer, exists := s.initializedInformers.Load(resource); exists {
+		return resourceInformer.(informers.GenericInformer)
+	}
+
+	resourceInformer := s.informerFactory.ForResource(resource)
+	s.initializedInformers.Store(resource, resourceInformer)
+	return resourceInformer
 }
 
 func (s *singleClusterInformerManagerImpl) Start() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	s.informerFactory.Start(s.ctx.Done())
 }
 
@@ -178,26 +220,21 @@ func (s *singleClusterInformerManagerImpl) waitForCacheSync(ctx context.Context)
 	res := s.informerFactory.WaitForCacheSync(ctx.Done())
 
 	var newlySynced []schema.GroupVersionResource
-
-	s.lock.RLock()
 	for resource, synced := range res {
 		if !synced {
 			continue
 		}
-		if _, exists := s.syncedInformers[resource]; !exists {
+		if _, ok := s.syncedInformers.Load(resource); !ok {
 			newlySynced = append(newlySynced, resource)
 		}
 	}
-	s.lock.RUnlock()
 
 	if len(newlySynced) == 0 {
 		return res
 	}
 
-	s.lock.Lock()
-	defer s.lock.Unlock()
 	for _, resource := range newlySynced {
-		s.syncedInformers[resource] = struct{}{}
+		s.syncedInformers.Store(resource, struct{}{})
 	}
 	return res
 }

--- a/pkg/util/fedinformer/genericmanager/single-cluster-manager_test.go
+++ b/pkg/util/fedinformer/genericmanager/single-cluster-manager_test.go
@@ -1,0 +1,331 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericmanager
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+var testResourceGVR = schema.GroupVersionResource{
+	Group:    "example.io",
+	Version:  "v1",
+	Resource: "widgets",
+}
+
+func TestSingleClusterInformerManagerCreateInformerRechecksInitializedInformer(t *testing.T) {
+	cachedInformer := newRecordingGenericInformer()
+	factoryInformer := newRecordingGenericInformer()
+	factory := &recordingDynamicInformerFactory{informer: factoryInformer}
+	manager := newTestSingleClusterInformerManager(t, factory)
+	manager.initializedInformers.Store(testResourceGVR, cachedInformer)
+
+	got := manager.createInformer(testResourceGVR)
+	if got != cachedInformer {
+		t.Fatal("createInformer did not reuse the informer initialized by another caller")
+	}
+	if got := factory.forResourceCalls.Load(); got != 0 {
+		t.Fatalf("factory.ForResource() called %d times, want 0", got)
+	}
+}
+
+func TestSingleClusterInformerManagerCachedLookupSkipsLock(t *testing.T) {
+	genericInformer := newRecordingGenericInformer()
+	factory := &recordingDynamicInformerFactory{informer: genericInformer}
+	manager := newTestSingleClusterInformerManager(t, factory)
+
+	got := manager.Lister(testResourceGVR)
+	if got != genericInformer.lister {
+		t.Fatal("Lister() returned a different lister during initialization")
+	}
+
+	manager.lock.Lock()
+	lockHeld := true
+	defer func() {
+		if lockHeld {
+			manager.lock.Unlock()
+		}
+	}()
+
+	lookupResult := make(chan cache.GenericLister, 1)
+	go func() {
+		lookupResult <- manager.Lister(testResourceGVR)
+	}()
+
+	select {
+	case got := <-lookupResult:
+		manager.lock.Unlock()
+		lockHeld = false
+		if got != genericInformer.lister {
+			t.Fatal("cached lookup returned a different lister")
+		}
+	case <-time.After(time.Second):
+		manager.lock.Unlock()
+		lockHeld = false
+		waitForTestValue(t, lookupResult, "cached lookup after releasing lock")
+		t.Fatal("cached lookup blocked on lock")
+	}
+
+	if got := factory.forResourceCalls.Load(); got != 1 {
+		t.Fatalf("factory.ForResource() called %d times, want 1", got)
+	}
+}
+
+func TestSingleClusterInformerManagerConcurrentHandlerRegistration(t *testing.T) {
+	genericInformer := newRecordingGenericInformer()
+	factory := &recordingDynamicInformerFactory{informer: genericInformer}
+	manager := newTestSingleClusterInformerManager(t, factory)
+	handler := &testResourceEventHandler{}
+
+	const goroutines = 32
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	workers.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer workers.Done()
+			<-start
+			manager.ForResource(testResourceGVR, handler)
+		}()
+	}
+	close(start)
+	workers.Wait()
+
+	if !manager.IsHandlerExist(testResourceGVR, handler) {
+		t.Fatal("handler was not recorded after registration")
+	}
+	handlers, ok := manager.handlers.Load(testResourceGVR)
+	if !ok {
+		t.Fatal("handler slice was not stored")
+	}
+	if got := len(handlers.([]cache.ResourceEventHandler)); got != 1 {
+		t.Fatalf("stored %d handlers, want 1", got)
+	}
+	if got := factory.forResourceCalls.Load(); got != 1 {
+		t.Fatalf("factory.ForResource() called %d times, want 1", got)
+	}
+	if got := genericInformer.informer.addEventHandlerCalls.Load(); got != 1 {
+		t.Fatalf("AddEventHandler() called %d times, want 1", got)
+	}
+}
+
+func TestSingleClusterInformerManagerSerializesInitializationWithStart(t *testing.T) {
+	genericInformer := newRecordingGenericInformer()
+	factory := &recordingDynamicInformerFactory{informer: genericInformer}
+	manager := newTestSingleClusterInformerManager(t, factory)
+
+	factoryEntered := make(chan struct{})
+	releaseFactory := make(chan struct{})
+	var releaseFactoryOnce sync.Once
+	release := func() {
+		releaseFactoryOnce.Do(func() { close(releaseFactory) })
+	}
+	t.Cleanup(release)
+
+	factory.onForResource = func() {
+		assertMutexHeld(t, &manager.lock, "factory.ForResource")
+		close(factoryEntered)
+		<-releaseFactory
+	}
+	genericInformer.onInformer = func() {
+		assertMutexHeld(t, &manager.lock, "GenericInformer.Informer")
+	}
+	var startBeforeInformerPublished atomic.Bool
+	factory.onStart = func() {
+		if _, exists := manager.initializedInformers.Load(testResourceGVR); !exists {
+			startBeforeInformerPublished.Store(true)
+		}
+	}
+
+	initializationDone := make(chan struct{})
+	go func() {
+		manager.getOrCreateInformer(testResourceGVR)
+		close(initializationDone)
+	}()
+	waitForTestSignal(t, factoryEntered, "factory.ForResource")
+
+	startAttempted := make(chan struct{})
+	startDone := make(chan struct{})
+	go func() {
+		close(startAttempted)
+		manager.Start()
+		close(startDone)
+	}()
+	waitForTestSignal(t, startAttempted, "Start attempt")
+
+	startReturnedBeforeInitialization := false
+	select {
+	case <-startDone:
+		startReturnedBeforeInitialization = true
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+	waitForTestSignal(t, initializationDone, "informer initialization")
+	if !startReturnedBeforeInitialization {
+		waitForTestSignal(t, startDone, "Start")
+	}
+
+	if startReturnedBeforeInitialization {
+		t.Fatal("Start returned before informer initialization completed")
+	}
+	if startBeforeInformerPublished.Load() {
+		t.Fatal("factory.Start() ran before the initialized informer was published")
+	}
+	if got := factory.startCalls.Load(); got != 1 {
+		t.Fatalf("factory.Start() called %d times, want 1", got)
+	}
+}
+
+func TestSingleClusterInformerManagerStartUsesLifecycleLock(t *testing.T) {
+	factory := &recordingDynamicInformerFactory{informer: newRecordingGenericInformer()}
+	manager := newTestSingleClusterInformerManager(t, factory)
+	factory.onStart = func() {
+		assertMutexHeld(t, &manager.lock, "factory.Start")
+	}
+
+	manager.Start()
+
+	if got := factory.startCalls.Load(); got != 1 {
+		t.Fatalf("factory.Start() called %d times, want 1", got)
+	}
+}
+
+func newTestSingleClusterInformerManager(
+	t *testing.T,
+	factory dynamicinformer.DynamicSharedInformerFactory,
+) *singleClusterInformerManagerImpl {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	return &singleClusterInformerManagerImpl{
+		ctx:             ctx,
+		cancel:          cancel,
+		informerFactory: factory,
+	}
+}
+
+func assertMutexHeld(t *testing.T, mutex *sync.Mutex, operation string) {
+	t.Helper()
+	if mutex.TryLock() {
+		mutex.Unlock()
+		t.Errorf("lock is not held during %s", operation)
+	}
+}
+
+type recordingDynamicInformerFactory struct {
+	informer informers.GenericInformer
+
+	forResourceCalls atomic.Int64
+	startCalls       atomic.Int64
+	onForResource    func()
+	onStart          func()
+}
+
+func (f *recordingDynamicInformerFactory) ForResource(_ schema.GroupVersionResource) informers.GenericInformer {
+	f.forResourceCalls.Add(1)
+	if f.onForResource != nil {
+		f.onForResource()
+	}
+	return f.informer
+}
+
+func (f *recordingDynamicInformerFactory) Start(_ <-chan struct{}) {
+	f.startCalls.Add(1)
+	if f.onStart != nil {
+		f.onStart()
+	}
+}
+
+func (f *recordingDynamicInformerFactory) WaitForCacheSync(_ <-chan struct{}) map[schema.GroupVersionResource]bool {
+	return nil
+}
+
+func (f *recordingDynamicInformerFactory) Shutdown() {}
+
+type recordingGenericInformer struct {
+	informer   *recordingSharedIndexInformer
+	lister     cache.GenericLister
+	onInformer func()
+}
+
+func (i *recordingGenericInformer) Informer() cache.SharedIndexInformer {
+	if i.onInformer != nil {
+		i.onInformer()
+	}
+	return i.informer
+}
+
+func (i *recordingGenericInformer) Lister() cache.GenericLister {
+	return i.lister
+}
+
+// recordingSharedIndexInformer implements only the SharedIndexInformer methods exercised by these tests.
+type recordingSharedIndexInformer struct {
+	cache.SharedIndexInformer
+
+	addEventHandlerCalls atomic.Int64
+}
+
+type testResourceEventHandler struct{}
+
+func (*testResourceEventHandler) OnAdd(_ any, _ bool) {}
+func (*testResourceEventHandler) OnUpdate(_, _ any)   {}
+func (*testResourceEventHandler) OnDelete(_ any)      {}
+
+func (i *recordingSharedIndexInformer) AddEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	i.addEventHandlerCalls.Add(1)
+	return nil, nil
+}
+
+func newRecordingGenericInformer() *recordingGenericInformer {
+	return &recordingGenericInformer{
+		informer: &recordingSharedIndexInformer{},
+		lister: cache.NewGenericLister(
+			cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}),
+			testResourceGVR.GroupResource(),
+		),
+	}
+}
+
+func waitForTestSignal(t *testing.T, signal <-chan struct{}, operation string) {
+	t.Helper()
+	waitForTestValue(t, signal, operation)
+}
+
+func waitForTestValue[T any](t *testing.T, values <-chan T, operation string) T {
+	t.Helper()
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", operation)
+		var zero T
+		return zero
+	}
+}
+
+var _ dynamicinformer.DynamicSharedInformerFactory = (*recordingDynamicInformerFactory)(nil)
+var _ informers.GenericInformer = (*recordingGenericInformer)(nil)


### PR DESCRIPTION
**What type of PR is this?**


/kind cleanup


<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

This PR simplifies synchronization in the generic and typed single-cluster informer managers.
It replaces manager-owned maps with sync.Map, caches initialized informers for lock-free repeated lookups, and uses one lifecycle lock to serialize informer initialization—including transform installation in the typed manager—with Start.
This reduces lock contention, removes duplicated informer lifecycle bookkeeping, and avoids holding the manager lock during cache-sync waits. Existing public method signatures remain unchanged.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

