### PR TITLE
Fix FederatedResourceQuota enforcement dropping limits.*/requests.* keys

### DIFF
--- a/pkg/webhook/resourcebinding/validating.go
+++ b/pkg/webhook/resourcebinding/validating.go
@@ -515,12 +515,21 @@ func calculateDelta(newUsage, oldUsage corev1.ResourceList) corev1.ResourceList 
 	return delta
 }
 
+// addResourceLists sums two ResourceLists on a per-key basis, preserving every
+// resource name (including limits.*/requests.* quota keys) rather than routing
+// through util.Resource, which only tracks a fixed set of known fields.
 func addResourceLists(list1, list2 corev1.ResourceList) corev1.ResourceList {
-	resUtil := util.NewResource(list1)
-	resUtil.Add(list2)
-	result := resUtil.ResourceList()
-	if result == nil {
-		return corev1.ResourceList{}
+	result := corev1.ResourceList{}
+	for name, quantity := range list1 {
+		result[name] = quantity.DeepCopy()
+	}
+	for name, quantity := range list2 {
+		if existing, ok := result[name]; ok {
+			existing.Add(quantity)
+			result[name] = existing
+		} else {
+			result[name] = quantity.DeepCopy()
+		}
 	}
 	return result
 }

--- a/pkg/webhook/resourcebinding/validating_test.go
+++ b/pkg/webhook/resourcebinding/validating_test.go
@@ -1206,3 +1206,68 @@ func TestAreResourceListsEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestAddResourceLists(t *testing.T) {
+	tests := []struct {
+		name   string
+		list1  corev1.ResourceList
+		list2  corev1.ResourceList
+		expect corev1.ResourceList
+	}{
+		{
+			name:   "both nil should return empty",
+			list1:  nil,
+			list2:  nil,
+			expect: corev1.ResourceList{},
+		},
+		{
+			name: "known resource names are summed",
+			list1: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("100m"),
+			},
+			list2: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("50m"),
+			},
+			expect: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("150m"),
+			},
+		},
+		{
+			name: "limits and requests resource names are preserved and summed",
+			list1: corev1.ResourceList{
+				corev1.ResourceName("limits.cpu"):      resource.MustParse("200m"),
+				corev1.ResourceName("requests.memory"): resource.MustParse("64Mi"),
+			},
+			list2: corev1.ResourceList{
+				corev1.ResourceName("limits.cpu"):      resource.MustParse("400m"),
+				corev1.ResourceName("requests.memory"): resource.MustParse("128Mi"),
+			},
+			expect: corev1.ResourceList{
+				corev1.ResourceName("limits.cpu"):      resource.MustParse("600m"),
+				corev1.ResourceName("requests.memory"): resource.MustParse("192Mi"),
+			},
+		},
+		{
+			name: "keys only present in one list are kept as-is",
+			list1: corev1.ResourceList{
+				corev1.ResourceName("limits.cpu"): resource.MustParse("200m"),
+			},
+			list2: corev1.ResourceList{
+				corev1.ResourceName("requests.cpu"): resource.MustParse("100m"),
+			},
+			expect: corev1.ResourceList{
+				corev1.ResourceName("limits.cpu"):   resource.MustParse("200m"),
+				corev1.ResourceName("requests.cpu"): resource.MustParse("100m"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addResourceLists(tt.list1, tt.list2)
+			if !areResourceListsEqual(got, tt.expect) {
+				t.Errorf("addResourceLists() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

With `FederatedQuotaEnforcement=true`, the `karmada-webhook` ResourceBinding validating admission silently fails to enforce `FederatedResourceQuota.spec.overall` entries that use the `limits.*`/`requests.*` resource-name convention (e.g. `limits.cpu`, `limits.memory`, `requests.cpu`, `requests.memory`). These names are explicitly accepted by Karmada's own FRQ validation (`pkg/util/lifted/corehelpers.go`'s `standardQuotaResources`), so users reasonably expect them to be enforced, but a workload exceeding such a quota is admitted anyway. Plain resource names (`cpu`, `memory`) already enforce correctly.

Root cause: `addResourceLists()` in `pkg/webhook/resourcebinding/validating.go` accumulated the FRQ's current usage and the incoming delta by routing both `corev1.ResourceList` maps through `util.NewResource(...).Add(...).ResourceList()`. `util.Resource` is a fixed-field struct (`MilliCPU`, `Memory`, `EphemeralStorage`, `AllowedPodNumber`, `ScalarResources`) built for scheduler-style aggregation; any resource name that isn't `cpu`/`memory`/`pods`/`ephemeral-storage`/an extended "scalar" resource (name containing `/`) falls through its `Add()` switch and is silently dropped. Because `limits.*`/`requests.*` names match none of those cases, the accumulated result for those keys was always an empty map, so `isAllowed()` had nothing to compare against the FRQ's `spec.overall` and always allowed the request.

**Approach**:

Rewrite `addResourceLists` to accumulate the two `corev1.ResourceList`s generically: copy every key from `list1`, then for each key in `list2` either add to the existing (deep-copied) quantity or insert it, using `resource.Quantity.Add` directly on the map. This preserves every resource name — including `limits.*`/`requests.*` — instead of only the fixed set `util.Resource` understands. Enforcement for `cpu`/`memory`/`pods`/extended resources is unchanged; this only restores enforcement for the previously-dropped quota key families.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This is a webhook-only, in-memory aggregation fix — no API or CRD change. Added `TestAddResourceLists` in `pkg/webhook/resourcebinding/validating_test.go` covering nil inputs, plain resource names, `limits.*`/`requests.*` names (verifying they are preserved and correctly summed), and keys present in only one input list.

Validation performed locally (no live cluster available in this environment, so the full kubectl-based repro from the issue was not re-run; the fix is validated at the unit level against the exact code path the issue identifies):
- `go build ./...` — succeeds.
- `go test --race ./pkg/webhook/...` — all 17 webhook packages pass.
- `golangci-lint run ./pkg/webhook/resourcebinding/...` — 0 issues.
- Confirmed the new `TestAddResourceLists` test **fails on the pre-fix code** (via `git stash` on just `validating.go`) with `addResourceLists() = map[], want map[limits.cpu:600m ...]` — reproducing the exact "empty result" defect described in the issue — and **passes** with the fix applied.

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-webhook`: Fixed the issue that FederatedResourceQuota enforcement silently ignored `limits.*`/`requests.*` resource names in `spec.overall`, allowing quota to be exceeded for those keys.
```

Fixes #7864