### PR TITLE
Deprecate the 'recreate' label of the create_resource_to_cluster metric

### DIFF
--- a/pkg/metrics/resource.go
+++ b/pkg/metrics/resource.go
@@ -73,7 +73,7 @@ var (
 
 	createResourceWhenSyncWork = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: createResourceToCluster,
-		Help: "Number of creation operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'), 'recreate' indicates whether the operation is recreated (true/false). Labels 'apiversion', 'kind', and 'member_cluster' specify the resource type, API version, and target cluster respectively.",
+		Help: "Number of creation operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'), 'recreate' indicates whether the operation is recreated (true/false); the 'recreate' label is deprecated since v1.19, always reports 'false' now that resource recreation is handled through the execution controller's normal reconciliation path, and will be removed in a future release. Labels 'apiversion', 'kind', and 'member_cluster' specify the resource type, API version, and target cluster respectively.",
 	}, []string{"result", "apiversion", "kind", memberClusterLabel, "recreate"})
 
 	updateResourceWhenSyncWork = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/pkg/metrics/resource_test.go
+++ b/pkg/metrics/resource_test.go
@@ -36,7 +36,7 @@ func TestCountCreateResourceToCluster(t *testing.T) {
 	CountCreateResourceToCluster(fmt.Errorf("boom"), apiVersion, kind, cluster, false)
 
 	want := `
-# HELP create_resource_to_cluster Number of creation operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'), 'recreate' indicates whether the operation is recreated (true/false). Labels 'apiversion', 'kind', and 'member_cluster' specify the resource type, API version, and target cluster respectively.
+# HELP create_resource_to_cluster Number of creation operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'), 'recreate' indicates whether the operation is recreated (true/false); the 'recreate' label is deprecated since v1.19, always reports 'false' now that resource recreation is handled through the execution controller's normal reconciliation path, and will be removed in a future release. Labels 'apiversion', 'kind', and 'member_cluster' specify the resource type, API version, and target cluster respectively.
 # TYPE create_resource_to_cluster counter
 create_resource_to_cluster{apiversion="v1",kind="Pod",member_cluster="member-1",recreate="false",result="error"} 1
 create_resource_to_cluster{apiversion="v1",kind="Pod",member_cluster="member-1",recreate="true",result="success"} 1


### PR DESCRIPTION
**What type of PR is this?**

/kind deprecation

**What this PR does / why we need it**:

After #7552, resource recreation is handled through the execution controller's normal reconciliation path, so the 'recreate' label always reports 'false'. Mark it as deprecated in the metric help text before removing it in a future release.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: The `recreate` label of the `create_resource_to_cluster` metric has been deprecated and will be removed in a future release. 
```

