### PR TITLE
stop maintaining version 1.16 and maintain version 1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,16 @@ updates:
 
   - package-ecosystem: docker
     directory: /cluster/images/
+    target-branch: "release-1.19"
+    schedule:
+      # Check for updates every Monday at 00:00 UTC
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"
+
+  - package-ecosystem: docker
+    directory: /cluster/images/
     target-branch: "release-1.18"
     schedule:
       # Check for updates every Monday at 00:00 UTC
@@ -37,16 +47,6 @@ updates:
   - package-ecosystem: docker
     directory: /cluster/images/
     target-branch: "release-1.17"
-    schedule:
-      # Check for updates every Monday at 00:00 UTC
-      interval: "weekly"
-      day: "monday"
-      time: "00:00"
-      timezone: "UTC"
-
-  - package-ecosystem: docker
-    directory: /cluster/images/
-    target-branch: "release-1.16"
     schedule:
       # Check for updates every Monday at 00:00 UTC
       interval: "weekly"

--- a/.github/workflows/ci-image-scanning-on-schedule.yml
+++ b/.github/workflows/ci-image-scanning-on-schedule.yml
@@ -27,7 +27,7 @@ jobs:
           - karmada-search
           - karmada-operator
           - karmada-metrics-adapter
-        karmada-version: [ release-1.18, release-1.17, release-1.16 ]
+        karmada-version: [ release-1.19, release-1.18, release-1.17 ]
     steps:
       - name: checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci-schedule-compatibility.yaml
+++ b/.github/workflows/ci-schedule-compatibility.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         kubeapiserver-version: [ v1.27.3, v1.28.0, v1.29.0, v1.30.0, v1.31.0, v1.32.0, v1.33.0, v1.34.0, v1.35.0, v1.36.1 ]
-        karmada-version: [ master, release-1.18, release-1.17, release-1.16 ]
+        karmada-version: [ master, release-1.19, release-1.18, release-1.17 ]
     env:
       KARMADA_APISERVER_VERSION: ${{ matrix.kubeapiserver-version }}
     steps:

--- a/README.md
+++ b/README.md
@@ -191,12 +191,12 @@ please refer to the [Kubernetes Compatibility](https://karmada.io/docs/administr
 
 The following table shows the compatibility test results against the latest 10 Kubernetes versions:
 
-|                       | Kubernetes 1.36 | Kubernetes 1.35 | Kubernetes 1.34 | Kubernetes 1.33 | Kubernetes 1.32 | Kubernetes 1.31 | Kubernetes 1.30 | Kubernetes 1.29 | Kubernetes 1.28 | Kubernetes 1.27 | Kubernetes 1.26 | Kubernetes 1.25 |
-|-----------------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-| Karmada v1.16         |                 |                 | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |
-| Karmada v1.17         |                 | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |                 |
-| Karmada v1.18         |                 | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |                 |
-| Karmada HEAD (master) | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |                 |                 |
+|                       | Kubernetes 1.36 | Kubernetes 1.35 | Kubernetes 1.34 | Kubernetes 1.33 | Kubernetes 1.32 | Kubernetes 1.31 | Kubernetes 1.30 | Kubernetes 1.29 | Kubernetes 1.28 | Kubernetes 1.27 | Kubernetes 1.26 |
+|-----------------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+| Karmada v1.17         |                 | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |
+| Karmada v1.18         |                 | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |
+| Karmada v1.19         | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |                 |
+| Karmada HEAD (master) | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |                 |
 
 Key:
 * `✓` Karmada and the Kubernetes version are exactly compatible.

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ nginx   2/2     2            2           20s
 Karmada is compatible with a wide range of Kubernetes versions. For detailed compatibility instructions, 
 please refer to the [Kubernetes Compatibility](https://karmada.io/docs/administrator/compatibility/). 
 
-The following table shows the compatibility test results against the latest 10 Kubernetes versions:
+The following table shows compatibility test results for each Karmada version against 10 Kubernetes versions:
 
 |                       | Kubernetes 1.36 | Kubernetes 1.35 | Kubernetes 1.34 | Kubernetes 1.33 | Kubernetes 1.32 | Kubernetes 1.31 | Kubernetes 1.30 | Kubernetes 1.29 | Kubernetes 1.28 | Kubernetes 1.27 | Kubernetes 1.26 |
 |-----------------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Stop maintaining version 1.16 and maintain version 1.19.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7869

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

- Tests: YAML, version-matrix, and README table assertions passed; `actionlint v1.7.12` passed for both scheduled workflows. The scheduled compatibility and image-scanning matrices were not run locally.
- AI assistance: Codex helped inspect prior release updates and prepare validation; I reviewed the diff and results.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```
