### PR TITLE
Fix the co-existence validation gap of fieldOverrider in emptyOverrides

### DIFF
--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -437,6 +437,9 @@ func emptyOverrides(overriders policyv1alpha1.Overriders) bool {
 	if len(overriders.AnnotationsOverrider) != 0 {
 		return false
 	}
+	if len(overriders.FieldOverrider) != 0 {
+		return false
+	}
 	return true
 }
 

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -104,6 +104,26 @@ func TestValidateOverrideSpec(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "overrideRules and fieldOverrider can't co-exist",
+			overrideSpec: policyv1alpha1.OverrideSpec{
+				OverrideRules: []policyv1alpha1.RuleWithCluster{
+					{
+						TargetCluster: &policyv1alpha1.ClusterAffinity{
+							ClusterNames: []string{"cluster-name"},
+						},
+					},
+				},
+				Overriders: policyv1alpha1.Overriders{
+					FieldOverrider: []policyv1alpha1.FieldOverrider{
+						{
+							FieldPath: "/data/config.yaml",
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
 			name: "overrideRules, targetCluster and overriders can't co-exist",
 			overrideSpec: policyv1alpha1.OverrideSpec{
 				OverrideRules: []policyv1alpha1.RuleWithCluster{
@@ -437,6 +457,17 @@ func TestEmptyOverrides(t *testing.T) {
 			name:       "empty overrides",
 			overriders: policyv1alpha1.Overriders{},
 			want:       true,
+		},
+		{
+			name: "non-empty overrides with only fieldOverrider",
+			overriders: policyv1alpha1.Overriders{
+				FieldOverrider: []policyv1alpha1.FieldOverrider{
+					{
+						FieldPath: "/data/config.yaml",
+					},
+				},
+			},
+			want: false,
 		},
 		{
 			name: "non-empty overrides",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

`emptyOverrides()` in `pkg/util/validation/validation.go` checks six of the seven overrider types but misses `FieldOverrider`. As a result, `ValidateOverrideSpec` skips the "overrideRules and overriders can't co-exist" check when the top-level `spec.overriders` contains only `fieldOverrider` entries, and the webhook wrongly admits such an OverridePolicy/ClusterOverridePolicy, e.g.:

```yaml
apiVersion: policy.karmada.io/v1alpha1
kind: OverridePolicy
metadata:
  name: foo
spec:
  resourceSelectors:
    - apiVersion: v1
      kind: ConfigMap
      name: foo
  overrideRules:
    - targetCluster:
        clusterNames: [member1]
      overriders:
        plaintext:
          - path: /metadata/labels/foo
            operator: add
            value: bar
  overriders:
    fieldOverrider:
      - fieldPath: /data/config.yaml
        yaml:
          - op: add
            path: /key
            value: value
```

At runtime the override manager only looks at `spec.overrideRules` when it is non-empty (see the comment in `pkg/util/overridemanager/overridemanager.go`: the two forms can not co-exist, "guaranteed by webhook"), so the user's `fieldOverrider` rules are silently ignored instead of being rejected up front.

This PR adds the missing `FieldOverrider` check to `emptyOverrides()` and covers it with regression tests for both `ValidateOverrideSpec` (co-existence must be rejected) and `emptyOverrides()` (fieldOverrider-only overriders must not be reported as empty).

**Which issue(s) this PR fixes:**

No existing issue covers this; self-found while auditing the validation code.

**Special notes for your reviewers:**

**Does this PR introduce a user-facing change?**

```release-note
OverridePolicy/ClusterOverridePolicy with both `overrideRules` and top-level `overriders` (containing `fieldOverrider`) set are now rejected by the validating webhook as invalid, instead of being admitted and having the top-level overriders silently ignored.
```
