### PR TITLE
Fix obtainImageValue panic on out-of-range or non-map path segments

### DIFF
--- a/pkg/util/overridemanager/imageoverride.go
+++ b/pkg/util/overridemanager/imageoverride.go
@@ -141,7 +141,14 @@ func obtainImageValue(rawObj *unstructured.Unstructured, predicatePath string) (
 			if err != nil {
 				return "", fmt.Errorf("path(%s) of rawObj's is not number", pathSegments[index+1])
 			}
-			currentObj = tmpSlice[sliceIndex].(map[string]any)
+			if sliceIndex < 0 || sliceIndex >= int64(len(tmpSlice)) {
+				return "", fmt.Errorf("index(%s) of path(%s) is out of range", pathSegments[index+1], predicatePath)
+			}
+			sliceItem, ok := tmpSlice[sliceIndex].(map[string]any)
+			if !ok {
+				return "", fmt.Errorf("path(%s) of rawObj's type is not map[string]interface{}", pathSegments[index+1])
+			}
+			currentObj = sliceItem
 			index++
 		default:
 			return "", fmt.Errorf("path(%s) of rawObj's type is not map[string]interface{} and []interface{}", pathSegments[index])

--- a/pkg/util/overridemanager/imageoverride_test.go
+++ b/pkg/util/overridemanager/imageoverride_test.go
@@ -590,6 +590,38 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "imageOverrider with predicate, path index out of range",
+			args: args{
+				rawObj: generateDeploymentYaml(),
+				imageOverrider: &policyv1alpha1.ImageOverrider{
+					Predicate: &policyv1alpha1.ImagePredicate{
+						Path: "/spec/template/spec/containers/5/image",
+					},
+					Component: "Repository",
+					Operator:  policyv1alpha1.OverriderOpReplace,
+					Value:     "nginx",
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "imageOverrider with predicate, negative path index",
+			args: args{
+				rawObj: generateDeploymentYaml(),
+				imageOverrider: &policyv1alpha1.ImageOverrider{
+					Predicate: &policyv1alpha1.ImagePredicate{
+						Path: "/spec/template/spec/containers/-1/image",
+					},
+					Component: "Repository",
+					Operator:  policyv1alpha1.OverriderOpReplace,
+					Value:     "nginx",
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

`obtainImageValue()` in `pkg/util/overridemanager/imageoverride.go` walks the ImageOverrider predicate path on the target resource without bounds-checking array indexes and with an unchecked type assertion on slice elements:

```go
currentObj = tmpSlice[sliceIndex].(map[string]any)
```

An `ImageOverrider` whose predicate path points past the end of the resource's array (e.g. `/spec/template/spec/containers/5/image` for a single-container Deployment), uses a negative index, or traverses a scalar array element therefore panics at override time. The validating webhook only verifies the path is a well-formed JSON pointer (`pkg/util/validation/validation.go`), it cannot know the target resource's array length, so such an OverridePolicy/ClusterOverridePolicy is admitted. The panic happens inside the detector when it builds Works, i.e. in the karmada-controller-manager process, and repeats on every requeue after restart — a persistent crash loop for the affected resource.

This PR bounds-checks the parsed index, asserts the slice element type safely, and returns an error instead. The error propagates via `applyImageOverriders` -> `ApplyOverridePolicies` as a normal reconcile error instead of crashing the process.

Regression tests cover the out-of-range index and the negative index cases; on master they panic with `index out of range` at `imageoverride.go:144`, and with this PR they get an error.

**Which issue(s) this PR fixes:**

No existing issue covers this; self-found while auditing the overridemanager package.

**Special notes for your reviewers:**

**Does this PR introduce a user-facing change?**

```release-note
OverridePolicy/ClusterOverridePolicy imageOverrider with a predicate path that is out of range for the target resource (or traverses a non-object array element) now fails the override application with an error instead of panicking the karmada-controller-manager.
```
