### PR TITLE
Fix parseSingle panic on comma-separated group/versions

### DIFF
--- a/pkg/util/apigroup.go
+++ b/pkg/util/apigroup.go
@@ -137,6 +137,9 @@ func (r *SkippedResourceConfig) parseSingle(token string) error {
 		for k := range strings.SplitSeq(token, ",") {
 			if strings.Contains(k, "/") {
 				s := strings.Split(k, "/")
+				if len(s) != 3 {
+					return fmt.Errorf("invalid token: %s", token)
+				}
 				g = s[0]
 				v = s[1]
 				kinds = append(kinds, s[2])

--- a/pkg/util/apigroup_test.go
+++ b/pkg/util/apigroup_test.go
@@ -356,3 +356,27 @@ func TestParseSingle(t *testing.T) {
 		})
 	}
 }
+
+func TestParseSingleInvalidToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{
+			name:  "comma separated group versions",
+			token: "apps/v1,batch/v1",
+		},
+		{
+			name:  "group version followed by comma separated group version",
+			token: "networking.k8s.io/v1,apps/v1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSkippedResourceConfig()
+			if err := r.parseSingle(tt.token); err == nil {
+				t.Errorf("parseSingle(%q) expects an error, but got nil", tt.token)
+			}
+		})
+	}
+}

--- a/pkg/util/apigroup_test.go
+++ b/pkg/util/apigroup_test.go
@@ -360,22 +360,22 @@ func TestParseSingle(t *testing.T) {
 func TestParseSingleInvalidToken(t *testing.T) {
 	tests := []struct {
 		name  string
-		token string
+		input string
 	}{
 		{
 			name:  "comma separated group versions",
-			token: "apps/v1,batch/v1",
+			input: "apps/v1,batch/v1",
 		},
 		{
 			name:  "group version followed by comma separated group version",
-			token: "networking.k8s.io/v1,apps/v1",
+			input: "networking.k8s.io/v1,apps/v1",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewSkippedResourceConfig()
-			if err := r.parseSingle(tt.token); err == nil {
-				t.Errorf("parseSingle(%q) expects an error, but got nil", tt.token)
+			if err := r.parseSingle(tt.input); err == nil {
+				t.Errorf("parseSingle(%q) expects an error, but got nil", tt.input)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

`parseSingle()` in `pkg/util/apigroup.go` switches on the number of `/` in the *whole* token, but `case 2` splits each comma-separated segment and unconditionally indexes `s[2]`:

```go
case 2:
    for k := range strings.SplitSeq(token, ",") {
        if strings.Contains(k, "/") {
            s := strings.Split(k, "/")
            g = s[0]
            v = s[1]
            kinds = append(kinds, s[2])   // panics when len(s) == 2
```

A token like `apps/v1,batch/v1` — using commas instead of semicolons, a natural mistake given the comma-separated `--skipped-propagating-namespaces` sibling flag — contains exactly two slashes, so it enters `case 2`, and its segment `apps/v1` splits into only two parts, panicking with `index out of range` instead of returning an error.

`SkippedResourceConfig.Parse` is called from the controller-manager options validation (`cmd/controller-manager/app/options/validation.go`) which is supposed to report the bad value as a `field.Invalid` "Invalid API string" error; instead the process crashes at startup with a panic stack.

This PR validates the segment length before indexing, mirroring the existing `invalid token` check in `case 1`. Regression tests cover two invalid inputs that previously panicked.

**Which issue(s) this PR fixes:**

No existing issue covers this; self-found while auditing the package.

**Special notes for your reviewers:**

**Does this PR introduce a user-facing change?**

```release-note
karmada-controller-manager and karmada-agent now report an invalid `--skipped-propagating-apis` value (comma-separated group/versions, e.g. `apps/v1,batch/v1`) as a flag validation error instead of crashing with a panic at startup.
```
