### PR TITLE
fix: preserve Kruise HPA selectors

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/customizations.yaml
@@ -54,6 +54,7 @@ spec:
           local readyReplicas = 0
           local availableReplicas = 0
           local unavailableReplicas = 0
+          local labelSelector = ''
 
           -- Use a map to merge conditions by type
           local conditionsMap = {}
@@ -69,6 +70,9 @@ spec:
               readyReplicas = readyReplicas + (itemStatus.readyReplicas or 0)
               availableReplicas = availableReplicas + (itemStatus.availableReplicas or 0)
               unavailableReplicas = unavailableReplicas + (itemStatus.unavailableReplicas or 0)
+              if itemStatus.labelSelector ~= nil and itemStatus.labelSelector ~= '' then
+                labelSelector = itemStatus.labelSelector
+              end
 
               -- Merge conditions from all clusters using a map
               if itemStatus.conditions ~= nil then
@@ -105,6 +109,7 @@ spec:
           desiredObj.status.readyReplicas = readyReplicas
           desiredObj.status.availableReplicas = availableReplicas
           desiredObj.status.unavailableReplicas = unavailableReplicas
+          desiredObj.status.labelSelector = labelSelector
 
           if #conditions > 0 then
             desiredObj.status.conditions = conditions
@@ -125,6 +130,7 @@ spec:
           status.readyReplicas = observedObj.status.readyReplicas
           status.availableReplicas = observedObj.status.availableReplicas
           status.unavailableReplicas = observedObj.status.unavailableReplicas
+          status.labelSelector = observedObj.status.labelSelector
           status.observedGeneration = observedObj.status.observedGeneration
           status.conditions = observedObj.status.conditions
 

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/aggregatestatus-test.yaml
@@ -58,6 +58,7 @@ statusItems:
       readyReplicas: 2
       updatedReplicas: 2
       availableReplicas: 2
+      labelSelector: app=sample
       collisionCount: 0
       observedGeneration: 1
       generation: 1
@@ -73,6 +74,7 @@ statusItems:
       readyReplicas: 1
       updatedReplicas: 1
       availableReplicas: 1
+      labelSelector: app=sample
       collisionCount: 0
       observedGeneration: 1
       generation: 1
@@ -126,6 +128,7 @@ output:
       updatedReplicas: 3
       availableReplicas: 3
       unavailableReplicas: 0
+      labelSelector: app=sample
       observedGeneration: 1
 ---
 name: "UnitedDeployment with mixed observed generations"
@@ -171,6 +174,7 @@ output:
       updatedReplicas: 3
       availableReplicas: 3
       unavailableReplicas: 0
+      labelSelector: ''
       observedGeneration: 1
 ---
 name: "UnitedDeployment with no status items"

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/interpretstatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/interpretstatus-test.yaml
@@ -53,6 +53,7 @@ observedObj:
     updatedReplicas: 3
     availableReplicas: 3
     collisionCount: 0
+    labelSelector: app=sample
     observedGeneration: 1
     conditions:
       - type: Available
@@ -72,6 +73,7 @@ output:
     updatedReplicas: 3
     readyReplicas: 3
     availableReplicas: 3
+    labelSelector: app=sample
     observedGeneration: 1
     conditions:
       - type: Available

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/customizations.yaml
@@ -89,6 +89,9 @@ spec:
             if statusItems[i].status ~= nil and statusItems[i].status.currentRevision ~= nil and statusItems[i].status.currentRevision ~= '' then
               currentRevision = statusItems[i].status.currentRevision
             end
+            if statusItems[i].status ~= nil and statusItems[i].status.labelSelector ~= nil and statusItems[i].status.labelSelector ~= '' then
+              labelSelector = statusItems[i].status.labelSelector
+            end
           
             -- Check if the member's status is updated to the latest generation
             local resourceTemplateGeneration = 0
@@ -123,6 +126,7 @@ spec:
           desiredObj.status.updatedReadyReplicas = updatedReadyReplicas
           desiredObj.status.updateRevision = updateRevision
           desiredObj.status.currentRevision = currentRevision
+          desiredObj.status.labelSelector = labelSelector
           return desiredObj
         end
     statusReflection:
@@ -141,6 +145,7 @@ spec:
           status.currentRevision = observedObj.status.currentRevision
           status.updatedReadyReplicas = observedObj.status.updatedReadyReplicas
           status.observedGeneration = observedObj.status.observedGeneration
+          status.labelSelector = observedObj.status.labelSelector
           
           -- handle resource generation report
           if observedObj.metadata == nil then

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/aggregatestatus-test.yaml
@@ -65,6 +65,7 @@ statusItems:
       availableReplicas: 2
       currentReplicas: 2
       currentRevision: sample-5675547df7
+      labelSelector: app=sample
       generation: 1
       resourceTemplateGeneration: 1
       observedGeneration: 1
@@ -80,6 +81,7 @@ statusItems:
       availableReplicas: 2
       currentReplicas: 2
       currentRevision: sample-5675547df7
+      labelSelector: app=sample
       generation: 1
       observedGeneration: 1
       resourceTemplateGeneration: 1
@@ -146,6 +148,7 @@ output:
       updatedReadyReplicas: 4
       updateRevision: sample-5675547df7
       currentRevision: sample-5675547df7
+      labelSelector: app=sample
       observedGeneration: 1
 ---
 name: "StatefulSet with partially ready replicas"
@@ -198,6 +201,7 @@ output:
       updatedReadyReplicas: 3
       currentRevision: ""
       updateRevision: ""
+      labelSelector: ""
       observedGeneration: 2
 ---
 name: "StatefulSet with mixed observed generations"
@@ -244,6 +248,7 @@ output:
       updatedReadyReplicas: 0
       currentRevision: ""
       updateRevision: ""
+      labelSelector: ""
       observedGeneration: 2
 ---
 name: "StatefulSet with no status items"
@@ -320,3 +325,4 @@ output:
       updatedReadyReplicas: 0
       updateRevision: ""
       currentRevision: ""
+      labelSelector: ""

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/interpretstatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/interpretstatus-test.yaml
@@ -76,6 +76,7 @@ output:
     updatedReadyReplicas: 2
     updateRevision: sample-5675547df7
     currentRevision: sample-5675547df7
+    labelSelector: app=sample
     observedGeneration: 1
     generation: 1
     resourceTemplateGeneration: 1


### PR DESCRIPTION
Reflect and aggregate label selectors for Kruise StatefulSet and UnitedDeployment so their scale subresources work with HPA.