### PR TITLE
docs: update CNCF status to graduated

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ with key features such as centralized multi-cloud management, high availability,
 
 ![cncf_logo](docs/images/cncf-logo.png)
 
-Karmada is an incubation project of the [Cloud Native Computing Foundation](https://cncf.io/) (CNCF).
+Karmada is a graduated project of the [Cloud Native Computing Foundation](https://cncf.io/) (CNCF).
 
 ## Why Karmada:
 - __K8s Native API Compatible__


### PR DESCRIPTION
## Summary
- Update README to state that Karmada is a CNCF graduated project, matching the September 3, 2026 graduation.

## Test plan
- [x] Confirm README wording matches https://www.cncf.io/projects/karmada/